### PR TITLE
Condense discovery integration tests

### DIFF
--- a/test/integration/loginrequest_test.go
+++ b/test/integration/loginrequest_test.go
@@ -7,7 +7,6 @@ package integration
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 	"testing"
 	"time"
@@ -66,50 +65,8 @@ func TestLoginRequest_ShouldFailWhenRequestDoesNotIncludeToken(t *testing.T) {
 	require.Equal(t, "spec.token.value", cause.Field)
 }
 
-func TestGetDiscovery(t *testing.T) {
-	client := library.NewPlaceholderNameClientset(t)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	result, err := client.Discovery().RESTClient().Get().Do(ctx).Raw()
-	require.NoError(t, err)
-
-	var parsedResult map[string]interface{}
-	err = json.Unmarshal(result, &parsedResult)
-	require.NoError(t, err)
-	require.Contains(t, parsedResult["paths"], "/apis/placeholder.suzerain-io.github.io")
-	require.Contains(t, parsedResult["paths"], "/apis/placeholder.suzerain-io.github.io/v1alpha1")
-}
-
 func TestGetAPIResourceList(t *testing.T) {
-	var expectedAPIResourceList = `{
-	  "kind": "APIResourceList",
-	  "apiVersion": "v1",
-	  "groupVersion": "placeholder.suzerain-io.github.io/v1alpha1",
-	  "resources": [
-		{
-		  "name": "loginrequests",
-		  "singularName": "",
-		  "namespaced": false,
-		  "kind": "LoginRequest",
-		  "verbs": [
-			"create"
-		  ]
-		}
-	  ]
-	}`
-
 	client := library.NewPlaceholderNameClientset(t)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	result, err := client.PlaceholderV1alpha1().RESTClient().Get().Do(ctx).Raw()
-	require.NoError(t, err)
-	require.JSONEq(t, expectedAPIResourceList, string(result))
-
-	// proposed:
 
 	groups, resources, err := client.Discovery().ServerGroupsAndResources()
 	require.NoError(t, err)


### PR DESCRIPTION
I think I had a conversation with @aramprice and @cfryanr about these integration test the other day. My takeaway from the conversation is that `TestGetDiscovery` and `TestGetAPIResourceList` could be condensed into using the stuff returned from `client.Discovery().ServerGroupsAndResources()`. Please correct me if I am wrong.

@mattmoyer @cfryanr - would you mind reviewing this?