### PR TITLE
Work around k8s 1.16 limitations of priorityClassName.

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -90,7 +90,9 @@ spec:
           hostPath:
             path: /etc/kubernetes/pki
             type: DirectoryOrCreate
-      priorityClassName: system-cluster-critical
+      #! "system-cluster-critical" cannot be used outside the kube-system namespace until Kubernetes >= 1.17,
+      #! so we skip setting this for now (see https://github.com/kubernetes/kubernetes/issues/60596).
+      #! priorityClassName: system-cluster-critical
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:


### PR DESCRIPTION
This works around an issue that prevented #27 from being successfully deployed into our acceptance environment, which is currently running on Kubernetes 1.16. We didn't catch this in our Kind-based integration environment because it's running a newer version.

We're hitting this upstream issue, which was resolved in 1.17: https://github.com/kubernetes/kubernetes/issues/60596