### PR TITLE
Increase client cert TTL from 5m to 1h.

### DIFF
--- a/pkg/registry/loginrequest/rest.go
+++ b/pkg/registry/loginrequest/rest.go
@@ -23,6 +23,9 @@ import (
 	placeholderapi "github.com/suzerain-io/placeholder-name-api/pkg/apis/placeholder"
 )
 
+// clientCertificateTTL is the TTL for short-lived client certificates returned by this API.
+const clientCertificateTTL = 1 * time.Hour
+
 var (
 	_ rest.Creater                 = &REST{}
 	_ rest.NamespaceScopedStrategy = &REST{}
@@ -128,7 +131,7 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 			OrganizationalUnit: authResponse.User.GetGroups(),
 		},
 		[]string{},
-		5*time.Minute,
+		clientCertificateTTL,
 	)
 	if err != nil {
 		klog.Warningf("failed to issue short lived client certificate: %v", err)

--- a/pkg/registry/loginrequest/rest_test.go
+++ b/pkg/registry/loginrequest/rest_test.go
@@ -144,7 +144,7 @@ func TestCreateSucceedsWhenGivenATokenAndTheWebhookAuthenticatesTheToken(t *test
 			CommonName:         "test-user",
 			OrganizationalUnit: []string{"test-group-1", "test-group-2"}},
 		[]string{},
-		5*time.Minute,
+		1*time.Hour,
 	).Return([]byte("test-cert"), []byte("test-key"), nil)
 
 	storage := NewREST(&webhook, issuer)


### PR DESCRIPTION
This will make manual testing easier and seems like a reasonable tradeoff. We'll iterate more in the future.

