### PR TITLE
Fix a bug in placeholder-name CLI (wrong API version).

### DIFF
--- a/cmd/placeholder-name/main.go
+++ b/cmd/placeholder-name/main.go
@@ -13,7 +13,7 @@ import (
 	"os"
 	"time"
 
-	"k8s.io/client-go/pkg/apis/clientauthentication"
+	clientauthenticationv1beta1 "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
 
 	"github.com/suzerain-io/placeholder-name/internal/constable"
 	"github.com/suzerain-io/placeholder-name/pkg/client"
@@ -28,7 +28,7 @@ func main() {
 }
 
 type envGetter func(string) (string, bool)
-type tokenExchanger func(ctx context.Context, token, caBundle, apiEndpoint string) (*clientauthentication.ExecCredential, error)
+type tokenExchanger func(ctx context.Context, token, caBundle, apiEndpoint string) (*clientauthenticationv1beta1.ExecCredential, error)
 
 const ErrMissingEnvVar = constable.Error("failed to login: environment variable not set")
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/pkg/apis/clientauthentication"
+	clientauthenticationv1beta1 "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
@@ -22,7 +22,7 @@ import (
 // ErrLoginFailed is returned by ExchangeToken when the server rejects the login request.
 const ErrLoginFailed = constable.Error("login failed")
 
-func ExchangeToken(ctx context.Context, token, caBundle, apiEndpoint string) (*clientauthentication.ExecCredential, error) {
+func ExchangeToken(ctx context.Context, token, caBundle, apiEndpoint string) (*clientauthenticationv1beta1.ExecCredential, error) {
 	clientset, err := getClient(apiEndpoint, caBundle)
 	if err != nil {
 		return nil, fmt.Errorf("could not get API client: %w", err)
@@ -43,12 +43,12 @@ func ExchangeToken(ctx context.Context, token, caBundle, apiEndpoint string) (*c
 		return nil, fmt.Errorf("%w: %s", ErrLoginFailed, resp.Status.Message)
 	}
 
-	return &clientauthentication.ExecCredential{
+	return &clientauthenticationv1beta1.ExecCredential{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ExecCredential",
 			APIVersion: "client.authentication.k8s.io/v1beta1",
 		},
-		Status: &clientauthentication.ExecCredentialStatus{
+		Status: &clientauthenticationv1beta1.ExecCredentialStatus{
 			ExpirationTimestamp:   resp.Status.Credential.ExpirationTimestamp,
 			ClientCertificateData: resp.Status.Credential.ClientCertificateData,
 			ClientKeyData:         resp.Status.Credential.ClientKeyData,

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/pkg/apis/clientauthentication"
+	clientauthenticationv1beta1 "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
 
 	placeholderv1alpha1 "github.com/suzerain-io/placeholder-name-api/pkg/apis/placeholder/v1alpha1"
 )
@@ -112,12 +112,12 @@ func TestExchangeToken(t *testing.T) {
 
 		got, err := ExchangeToken(ctx, "", caBundle, endpoint)
 		require.NoError(t, err)
-		require.Equal(t, &clientauthentication.ExecCredential{
+		require.Equal(t, &clientauthenticationv1beta1.ExecCredential{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ExecCredential",
 				APIVersion: "client.authentication.k8s.io/v1beta1",
 			},
-			Status: &clientauthentication.ExecCredentialStatus{
+			Status: &clientauthenticationv1beta1.ExecCredentialStatus{
 				ClientCertificateData: "test-certificate",
 				ClientKeyData:         "test-key",
 			},


### PR DESCRIPTION
This is kind of a subtle bug, but we were using the unversioned Kubernetes type package here, where we should have been using the v1beta1 version. They have the same fields, but they serialize to JSON differently.

This bug was introduced in #30.