### PR TITLE
Clean up some lint errors that we missed before.

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -124,7 +124,7 @@ func ExchangeToken(ctx context.Context, token, caBundle, apiEndpoint string) (*C
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusCreated {
-		return nil, fmt.Errorf("could not login: server returned status %d", resp.StatusCode)
+		return nil, fmt.Errorf("%w: server returned status %d", ErrLoginFailed, resp.StatusCode)
 	}
 
 	var respBody struct {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -72,6 +72,7 @@ func TestExchangeToken(t *testing.T) {
 		// Start a test server that doesn't do anything.
 		caBundle, endpoint := startTestServer(t, func(w http.ResponseWriter, r *http.Request) {})
 
+		//nolint:staticcheck // ignore "do not pass a nil Context" linter error since that's what we're testing here.
 		got, err := ExchangeToken(nil, "", caBundle, endpoint)
 		require.EqualError(t, err, `could not build request: net/http: nil Context`)
 		require.Nil(t, got)
@@ -86,7 +87,7 @@ func TestExchangeToken(t *testing.T) {
 		})
 
 		got, err := ExchangeToken(ctx, "", caBundle, endpoint)
-		require.EqualError(t, err, `could not login: server returned status 500`)
+		require.EqualError(t, err, `login failed: server returned status 500`)
 		require.Nil(t, got)
 	})
 

--- a/test/integration/client_test.go
+++ b/test/integration/client_test.go
@@ -17,14 +17,17 @@ import (
 	"github.com/suzerain-io/placeholder-name/test/library"
 )
 
-var (
-	// Test certificate and private key that should get an authentication error. Generated with
-	// https://github.com/cloudflare/cfssl, like this:
-	// $ brew install cfssl
-	// $ cfssl print-defaults csr | cfssl genkey -initca - | cfssljson -bare ca
-	// $ cfssl print-defaults csr | cfssl gencert -ca ca.pem -ca-key ca-key.pem -hostname=testuser - | cfssljson -bare client
-	// $ cat client.pem client-key.pem
+/*
+Test certificate and private key that should get an authentication error. Generated with cfssl [1], like this:
 
+	$ brew install cfssl
+	$ cfssl print-defaults csr | cfssl genkey -initca - | cfssljson -bare ca
+	$ cfssl print-defaults csr | cfssl gencert -ca ca.pem -ca-key ca-key.pem -hostname=testuser - | cfssljson -bare client
+	$ cat client.pem client-key.pem
+
+[1]: https://github.com/cloudflare/cfssl
+*/
+var (
 	testCert = strings.TrimSpace(`
 -----BEGIN CERTIFICATE-----
 MIICBDCCAaugAwIBAgIUeidKWlZQuoKfBGydObI1hMwzt9cwCgYIKoZIzj0EAwIw
@@ -40,7 +43,6 @@ c2VyMAoGCCqGSM49BAMCA0cAMEQCIEwPZhPpYhYHndfTEsWOxnxzJkmhAcYIMCeJ
 d9kyq/fPAiBNCJw1MCLT8LjNlyUZCfwI2zuI3e0w6vuau89oj2zvVA==
 -----END CERTIFICATE-----
 	`)
-
 	testKey = strings.TrimSpace(`
 -----BEGIN EC PRIVATE KEY-----
 MHcCAQEEIAqkBGGKTH5GzLx8XZLAHEFW2E8jT+jpy0p6w6MMR7DkoAoGCCqGSM49


### PR DESCRIPTION
This is part of my effort to break down the larger monorepo PR into some smaller bites.

I think we missed these linter errors previously because of the module boundary issue (which is exacerbated by the monorepo change).