### PR TITLE
Make sure we have an explicit DNS SAN on our API serving certificate.

### DIFF
--- a/internal/controller/apicerts/certs_manager.go
+++ b/internal/controller/apicerts/certs_manager.go
@@ -91,9 +91,10 @@ func (c *certsManagerController) Sync(ctx controller.Context) error {
 	const serviceName = "placeholder-name-api"
 
 	// Using the CA from above, create a TLS server cert for the aggregated API server to use.
+	serviceEndpoint := serviceName + "." + c.namespace + ".svc"
 	aggregatedAPIServerTLSCert, err := aggregatedAPIServerCA.Issue(
-		pkix.Name{CommonName: serviceName + "." + c.namespace + ".svc"},
-		[]string{},
+		pkix.Name{CommonName: serviceEndpoint},
+		[]string{serviceEndpoint},
 		24*365*time.Hour,
 	)
 	if err != nil {

--- a/internal/controller/apicerts/certs_manager_test.go
+++ b/internal/controller/apicerts/certs_manager_test.go
@@ -229,12 +229,14 @@ func TestManagerControllerSync(t *testing.T) {
 					r.NotNil(block)
 					parsedCert, err := x509.ParseCertificate(block.Bytes)
 					r.NoError(err)
+					serviceEndpoint := "placeholder-name-api." + installedInNamespace + ".svc"
 					opts := x509.VerifyOptions{
-						DNSName: "placeholder-name-api." + installedInNamespace + ".svc",
+						DNSName: serviceEndpoint,
 						Roots:   roots,
 					}
 					_, err = parsedCert.Verify(opts)
 					r.NoError(err)
+					r.Contains(parsedCert.DNSNames, serviceEndpoint, "expected an explicit DNS SAN, not just Common Name")
 
 					// Check the created cert's validity bounds
 					r.WithinDuration(time.Now(), parsedCert.NotBefore, time.Minute*2)


### PR DESCRIPTION
This should help us when Kubernetes upgrades to Go 1.15 and gets this deprecation: https://golang.org/doc/go1.15#commonname