### PR TITLE
Switch to debian base images.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,11 @@
 # Copyright 2020 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.15.0-alpine as build-env
+FROM golang:1.15.0 as build-env
 
 # It is important that these ARG's are defined after the FROM statement
 ARG ACCESS_TOKEN_USR="nothing"
 ARG ACCESS_TOKEN_PWD="nothing"
-
-# git is required to fetch go dependencies
-RUN apk add --no-cache ca-certificates git bash
 
 # Create a netrc file using the credentials specified using --build-arg
 RUN printf "machine github.com\n\
@@ -18,19 +15,15 @@ RUN printf "machine github.com\n\
     machine api.github.com\n\
     login ${ACCESS_TOKEN_USR}\n\
     password ${ACCESS_TOKEN_PWD}\n"\
-    >> /root/.netrc
-RUN chmod 600 /root/.netrc
-
-RUN mkdir /work
-RUN mkdir /work/out
+    >> /root/.netrc && chmod 600 /root/.netrc && mkdir /work && mkdir /work/out
 WORKDIR /work
 # Get dependencies first so they can be cached as a layer
-COPY go.mod go.sum ./
-COPY pkg/client/go.mod pkg/client/go.sum ./pkg/client/
-COPY kubernetes/1.19/api/go.mod kubernetes/1.19/api/go.sum ./kubernetes/1.19/api/
-COPY kubernetes/1.19/client-go/go.mod kubernetes/1.19/client-go/go.sum ./kubernetes/1.19/client-go/
-
+COPY go.* ./
+COPY pkg/client/go.* ./pkg/client/
+COPY kubernetes/1.19/api/go.* ./kubernetes/1.19/api/
+COPY kubernetes/1.19/client-go/go.* ./kubernetes/1.19/client-go/
 RUN go mod download
+
 # Copy only the production source code to avoid cache misses when editing other files
 COPY kubernetes ./kubernetes
 COPY cmd ./cmd
@@ -38,16 +31,19 @@ COPY internal ./internal
 COPY pkg ./pkg
 COPY tools ./tools
 COPY hack ./hack
+
 # Build the executable binary (CGO_ENABLED=0 means static linking)
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$(hack/get-ldflags.sh)" -o out ./cmd/placeholder-name-server/...
 
-FROM alpine:latest
-# Install CA certs and some tools for debugging
-RUN apk --update --no-cache add ca-certificates bash curl
-WORKDIR /root/
+
+# Use a runtime image based on Debian slim
+FROM debian:10.5-slim
+
 # Copy the binary from the build-env stage
-COPY --from=build-env /work/out/placeholder-name-server placeholder-name-server
+COPY --from=build-env /work/out/placeholder-name-server /usr/local/bin/placeholder-name-server
+
 # Document the port
 EXPOSE 443
-# Set the command
-CMD ["./placeholder-name-server"]
+
+# Set the entrypoint
+ENTRYPOINT ["/usr/local/bin/placeholder-name-server"]

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -59,8 +59,6 @@ spec:
           image: #@ data.values.image_repo + ":" + data.values.image_tag
           #@ end
           imagePullPolicy: IfNotPresent
-          command:
-            - ./placeholder-name-server
           args:
             - --config=/etc/config/placeholder-name.yaml
             - --downward-api-path=/etc/podinfo


### PR DESCRIPTION
This takes our image size from approximately 67 MB to 127 MB, which shouldn't impact pull times too much in most cases.