### PR TITLE
Revert "Pin images to exact hashes (Dependabot can handle this, it seems)."

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2020 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.15.0@sha256:f92b2f06e4dbda381b142d63b009cf5117bb3c487617d4695808fce05a808ebe as build-env
+FROM golang:1.15.0 as build-env
 
 # It is important that these ARG's are defined after the FROM statement
 ARG ACCESS_TOKEN_USR="nothing"
@@ -37,7 +37,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$(hack/get-ldflags.
 
 
 # Use a runtime image based on Debian slim
-FROM debian:10.5-slim@sha256:b2cade793f3558c90d018ed386cd61bf5e4ec06bf8ed6761bed3dd7e2c425ecc
+FROM debian:10.5-slim
 
 # Copy the binary from the build-env stage
 COPY --from=build-env /work/out/placeholder-name-server /usr/local/bin/placeholder-name-server


### PR DESCRIPTION
Reverts suzerain-io/placeholder-name#59. This turns out to be "weird" for reasons I don't totally understand. Dependabot triggered some updates (https://github.com/suzerain-io/placeholder-name/pull/60 and https://github.com/suzerain-io/placeholder-name/pull/61) which shouldn't happen as far as I can understand. For example, on the Go version I think it's ignoring the `1.15.0` tag and pulling the `latest` tag which is okay now but not okay in the future.