### PR TITLE
Implement basic liveness and readiness probes

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -93,7 +93,7 @@ spec:
               path: /healthz
               port: 443
               scheme: HTTPS
-            initialDelaySeconds: 20
+            initialDelaySeconds: 2
             timeoutSeconds: 15
             periodSeconds: 10
             failureThreshold: 5
@@ -102,7 +102,7 @@ spec:
               path: /healthz
               port: 443
               scheme: HTTPS
-            initialDelaySeconds: 20
+            initialDelaySeconds: 2
             timeoutSeconds: 3
             periodSeconds: 10
             failureThreshold: 3


### PR DESCRIPTION
- Call the auto-generated /healthz endpoint of our aggregated API server
- Use http for liveness even though tcp seems like it might be
  more appropriate, because tcp probes cause TLS handshake errors
  to appear in our logs every few seconds
- Use conservative timeouts and retries on the liveness probe to avoid
  having our container get restarted when it is temporarily slow due
  to running in an environment under resource pressure
- Use less conservative timeouts and retries for the readiness probe
  to remove an unhealthy pod from the service less conservatively than
  restarting the container
- Tuning the settings for retries and timeouts seem to be a mysterious
  art, so these are just a first draft