### PR TITLE
Add pod anti-affinity to make our HA deployment more HA

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -130,6 +130,17 @@ spec:
       #! "system-cluster-critical" cannot be used outside the kube-system namespace until Kubernetes >= 1.17,
       #! so we skip setting this for now (see https://github.com/kubernetes/kubernetes/issues/60596).
       #!priorityClassName: system-cluster-critical
+      #! This will help make sure our multiple pods run on different nodes, making
+      #! our deployment "more" "HA".
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 50
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: #@ data.values.app_name
+                topologyKey: kubernetes.io/hostname
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Signed-off-by: Andrew Keesler <akeesler@vmware.com>

@cfryanr @mattmoyer - what do y'all think of this?

We could also add a YTT knob for deployers to choose their own `topologyKey` (potentially this could be an array of `topologyKey` so they could specify multiple anti-affinity constraints, e.g., I don't want 2 pods to run on the same rack, or the same AZ, or the same proprietary grouping of nodes).

This doc was helpful for me: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/. It scared me a little bit with this note: `Note: Inter-pod affinity and anti-affinity require substantial amount of processing which can slow down scheduling in large clusters significantly. We do not recommend using them in clusters larger than several hundred nodes.`