### PR TITLE
Remove old generated directories from dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,16 +13,6 @@ updates:
       interval: "daily"
 
   - package-ecosystem: "gomod"
-    directory: "/kubernetes/1.19/client-go/"
-    schedule:
-      interval: "daily"
-
-  - package-ecosystem: "gomod"
-    directory: "/kubernetes/1.19/api/"
-    schedule:
-      interval: "daily"
-
-  - package-ecosystem: "gomod"
     directory: "/pkg/client"
     schedule:
       interval: "daily"


### PR DESCRIPTION
These never worked quite right, so let's disable them for now: https://github.com/suzerain-io/pinniped/pull/51

We can probably come up with some better solution now with the new codegen scripts, but I'll leave that for later.