### PR TITLE
WIP: Switch to a local development workflow based on Tilt.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 
 # goland
 .idea
+
+# Intermediate files used by Tilt
+/hack/lib/tilt/build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: '^generated/'
+exclude: '^(generated|hack/lib/tilt/tilt_modules)/'
 repos:
 - repo: git://github.com/pre-commit/pre-commit-hooks
   rev: v3.2.0

--- a/cmd/pinniped-server/main.go
+++ b/cmd/pinniped-server/main.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"os"
+	"time"
 
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/pkg/version"
@@ -21,7 +22,12 @@ func main() {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	klog.Infof("Running %s at %#v", rest.DefaultKubernetesUserAgent(), version.Get())
+	// Dump out the time since compile (mostly useful for benchmarking our local development cycle latency).
+	var timeSinceCompile time.Duration
+	if buildDate, err := time.Parse(time.RFC3339, version.Get().BuildDate); err == nil {
+		timeSinceCompile = time.Since(buildDate)
+	}
+	klog.Infof("Running %s at %#v (%s since build)", rest.DefaultKubernetesUserAgent(), version.Get(), timeSinceCompile)
 
 	ctx := genericapiserver.SetupSignalContext()
 

--- a/hack/lib/tilt/Dockerfile
+++ b/hack/lib/tilt/Dockerfile
@@ -1,0 +1,14 @@
+# Copyright 2020 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Use a runtime image based on Debian slim
+FROM debian:10.5-slim
+
+# Copy the binary from the build-env stage
+COPY build/pinniped-server /usr/local/bin/pinniped-server
+
+# Document the port
+EXPOSE 443
+
+# Set the entrypoint
+ENTRYPOINT ["/usr/local/bin/pinniped-server"]

--- a/hack/lib/tilt/Tiltfile
+++ b/hack/lib/tilt/Tiltfile
@@ -1,0 +1,62 @@
+load('ext://restart_process', 'docker_build_with_restart')
+disable_snapshots()
+analytics_settings(False)
+update_settings(max_parallel_updates=8)
+
+# TODO: avoid needing these in this file.
+webhookURL = 'https://tanzuuserauthentication.stable.tmc-dev.cloud.vmware.com/v1alpha/clusters/c:01EHBFF2AHDZXZNP1MDPKHSCDR/auth/token'
+webhookCABundle = 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZhekNDQTFPZ0F3SUJBZ0lSQUlJUXo3RFNRT05aUkdQZ3UyT0Npd0F3RFFZSktvWklodmNOQVFFTEJRQXcKVHpFTE1Ba0dBMVVFQmhNQ1ZWTXhLVEFuQmdOVkJBb1RJRWx1ZEdWeWJtVjBJRk5sWTNWeWFYUjVJRkpsYzJWaApjbU5vSUVkeWIzVndNUlV3RXdZRFZRUURFd3hKVTFKSElGSnZiM1FnV0RFd0hoY05NVFV3TmpBME1URXdORE00CldoY05NelV3TmpBME1URXdORE00V2pCUE1Rc3dDUVlEVlFRR0V3SlZVekVwTUNjR0ExVUVDaE1nU1c1MFpYSnUKWlhRZ1UyVmpkWEpwZEhrZ1VtVnpaV0Z5WTJnZ1IzSnZkWEF4RlRBVEJnTlZCQU1UREVsVFVrY2dVbTl2ZENCWQpNVENDQWlJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dJUEFEQ0NBZ29DZ2dJQkFLM29KSFAwRkRmem01NHJWeWdjCmg3N2N0OTg0a0l4dVBPWlhvSGozZGNLaS92VnFidllBVHlqYjNtaUdiRVNUdHJGai9SUVNhNzhmMHVveG15RisKMFRNOHVrajEzWG5mczdqL0V2RWhta3ZCaW9aeGFVcG1abXlQZmp4d3Y2MHBJZ2J6NU1EbWdLN2lTNCszbVg2VQpBNS9UUjVkOG1VZ2pVK2c0cms4S2I0TXUwVWxYaklCMHR0b3YwRGlOZXdOd0lSdDE4akE4K28rdTNkcGpxK3NXClQ4S09FVXQrend2by83VjNMdlN5ZTByZ1RCSWxESENOQXltZzRWTWs3QlBaN2htL0VMTktqRCtKbzJGUjNxeUgKQjVUMFkzSHNMdUp2VzVpQjRZbGNOSGxzZHU4N2tHSjU1dHVrbWk4bXhkQVE0UTdlMlJDT0Z2dTM5NmozeCtVQwpCNWlQTmdpVjUrSTNsZzAyZFo3N0RuS3hIWnU4QS9sSkJkaUIzUVcwS3RaQjZhd0JkcFVLRDlqZjFiMFNIelV2CktCZHMwcGpCcUFsa2QyNUhON3JPckZsZWFKMS9jdGFKeFFaQktUNVpQdDBtOVNUSkVhZGFvMHhBSDBhaG1iV24KT2xGdWhqdWVmWEtuRWdWNFdlMCtVWGdWQ3dPUGpkQXZCYkkrZTBvY1MzTUZFdnpHNnVCUUUzeERrM1N6eW5UbgpqaDhCQ05BdzFGdHhOclFIdXNFd01GeEl0NEk3bUtaOVlJcWlveW1DekxxOWd3UWJvb01EUWFIV0JmRWJ3cmJ3CnFIeUdPMGFvU0NxSTNIYWFkcjhmYXFVOUdZL3JPUE5rM3NnckRRb28vL2ZiNGhWQzFDTFFKMTNoZWY0WTUzQ0kKclU3bTJZczZ4dDBuVVc3L3ZHVDFNME5QQWdNQkFBR2pRakJBTUE0R0ExVWREd0VCL3dRRUF3SUJCakFQQmdOVgpIUk1CQWY4RUJUQURBUUgvTUIwR0ExVWREZ1FXQkJSNXRGbm1lN2JsNUFGemdBaUl5QnBZOXVtYmJqQU5CZ2txCmhraUc5dzBCQVFzRkFBT0NBZ0VBVlI5WXFieXlxRkRRRExIWUdta2dKeWtJckdGMVhJcHUrSUxsYVMvVjlsWkwKdWJoekVGblRJWmQrNTB4eCs3TFNZSzA1cUF2cUZ5RldoZkZRRGxucnp1Qlo2YnJKRmUrR25ZK0VnUGJrNlpHUQozQmViWWh0RjhHYVYwbnh2d3VvNzd4L1B5OWF1Si9HcHNNaXUvWDErbXZvaUJPdi8yWC9xa1NzaXNSY09qL0tLCk5GdFkyUHdCeVZTNXVDYk1pb2d6aVV3dGhEeUMzKzZXVndXNkxMdjN4TGZIVGp1Q3ZqSElJbk56a3RIQ2dLUTUKT1JBekk0Sk1QSitHc2xXWUhiNHBob3dpbTU3aWF6dFhPb0p3VGR3Sng0bkxDZ2ROYk9oZGpzbnZ6cXZIdTdVcgpUa1hXU3RBbXpPVnl5Z2hxcFpYakZhSDNwTzNKTEYrbCsvK3NLQUl1dnRkN3UrTnhlNUFXMHdkZVJsTjhOd2RDCmpOUEVscHpWbWJVcTRKVWFnRWl1VERrSHpzeEhwRktWSzdxNCs2M1NNMU45NVIxTmJkV2hzY2RDYitaQUp6VmMKb3lpM0I0M25qVE9RNXlPZisxQ2NlV3hHMWJRVnM1WnVmcHNNbGpxNFVpMC8xbHZoK3dqQ2hQNGtxS09KMnF4cQo0Umdxc2FoRFlWdlRIOXc3alhieUxlaU5kZDhYTTJ3OVUvdDd5MEZmLzl5aTBHRTQ0WmE0ckYyTE45ZDExVFBBCm1SR3VuVUhCY25XRXZnSkJRbDluSkVpVTBac252Z2MvdWJoUGdYUlI0WHEzN1owajRyN2cxU2dFRXp3eEE1N2QKZW15UHhnY1l4bi9lUjQ0L0tKNEVCcytsVkRSM3ZleUptK2tYUTk5YjIxLytqaDVYb3MxQW5YNWlJdHJlR0NjPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCi0tLS0tQkVHSU4gQ0VSVElGSUNBVEUtLS0tLQpNSUlEU2pDQ0FqS2dBd0lCQWdJUVJLK3dnTmFqSjdxSk1EbUdMdmhBYXpBTkJna3Foa2lHOXcwQkFRVUZBREEvCk1TUXdJZ1lEVlFRS0V4dEVhV2RwZEdGc0lGTnBaMjVoZEhWeVpTQlVjblZ6ZENCRGJ5NHhGekFWQmdOVkJBTVQKRGtSVFZDQlNiMjkwSUVOQklGZ3pNQjRYRFRBd01Ea3pNREl4TVRJeE9Wb1hEVEl4TURrek1ERTBNREV4TlZvdwpQekVrTUNJR0ExVUVDaE1iUkdsbmFYUmhiQ0JUYVdkdVlYUjFjbVVnVkhKMWMzUWdRMjh1TVJjd0ZRWURWUVFECkV3NUVVMVFnVW05dmRDQkRRU0JZTXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUIKQU4rdjZaZFFDSU5YdE14aVpmYVFndXpIMHl4ck1NcGI3Tm5EZmNkQXdSZ1VpK0RvTTNaSkt1TS9JVW1UckU0TwpyejVJeTJYdS9OTWhEMlhTS3RreWo0emw5M2V3RW51MWxjQ0pvNm02N1hNdWVnd0dNb09pZm9vVU1NMFJvT0VxCk9MbDVDakg5VUwyQVpkKzNVV09EeU9LSVllcExZWUhzVW11NW91SkxHaWlmU0tPZUROb0pqajRYTGg3ZElOOWIKeGlxS3F5NjljSzNGQ3hvbGtIUnl4WHRxcXpUV01Jbi81V2dUZTFRTHlOYXU3RnFja2g0OVpMT014dCsveVVGdwo3Qlp5MVNic09GVTVROUQ4L1JoY1FQR1g2OVdhbTQwZHV0b2x1Y2JZMzhFVkFqcXIybTd4UGk3MVhBaWNQTmFECmFlUVFteGtxdGlsWDQrVTltNS93QWwwQ0F3RUFBYU5DTUVBd0R3WURWUjBUQVFIL0JBVXdBd0VCL3pBT0JnTlYKSFE4QkFmOEVCQU1DQVFZd0hRWURWUjBPQkJZRUZNU25zYVI3TEhINjIrRkxrSFgveEJWZ2hZa1FNQTBHQ1NxRwpTSWIzRFFFQkJRVUFBNElCQVFDakdpeWJGd0JjcVI3dUtHWTNPcitEeHo5THd3bWdsU0JkNDlsWlJOSStEVDY5CmlrdWdkQi9PRUlLY2RCb2RmcGdhM2NzVFM3TWdST1NSNmN6OGZhWGJhdVgrNXYzZ1R0MjNBRHExY0Vtdjh1WHIKQXZIUkFvc1p5NVE2WGtqRUdCNVlHVjhlQWxyd0RQR3hyYW5jV1lhTGJ1bVI5WWJLK3JsbU02cFpXODdpcHhaegpSOHNyekptd04walA0MVpMOWM4UERISXloOGJ3Ukx0VGNtMUQ5U1pJbWxKbnQxaXIvbWQyY1hqYkRhSldGQk01CkpER0ZvcWdDV2pCSDRkMVFCN3dDQ1pBQTYyUmpZSnNXdklqSkV1YlNmWkdMK1QweWpXVzA2WHl4VjNicXhiWW8KT2I4VlpSekk5bmVXYWdxTmR3dllrUXNFamdmYktiWUs3cDJDTlRVUQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0t'
+
+k8s_yaml(local([
+    'ytt',
+    '--file', '../../../deploy',
+    '--data-value', 'namespace=integration',
+    '--data-value', 'webhook_url='+webhookURL,
+    '--data-value', 'webhook_ca_bundle='+webhookCABundle,
+    '--data-value', 'image_repo=image',
+    '--data-value', 'image_tag=tilt-dev',
+    '--data-value-yaml', 'replicas=1',
+]))
+
+# TODO: re-use the existing BuildTime variable from our regular build
+local_resource(
+  'compile',
+  'cd ../../../ && '+
+    'CGO_ENABLED=0 GOOS=linux GOARCH=amd64 '+
+    'go build -v '+
+    '-ldflags "$(hack/get-ldflags.sh)" '+
+    '-o ./hack/lib/tilt/build/pinniped-server '+
+    './cmd/pinniped-server',
+  deps=['../../../cmd', '../../../internal', '../../../pkg', '../../../generated'],
+)
+
+docker_build_with_restart('image', '.',
+    entrypoint=['/usr/local/bin/pinniped-server'],
+    live_update=[
+        sync('./build', '/usr/local/bin'),
+    ],
+)
+
+k8s_resource(
+    workload='pinniped',
+    new_name='deploy',
+    objects=[
+       'integration:namespace',
+       'credentialissuerconfigs.crd.pinniped.dev:customresourcedefinition',
+       'pinniped-service-account:serviceaccount',
+       'pinniped-aggregated-api-server-role:role',
+       'pinniped-kube-system-pod-exec-role:role',
+       'pinniped-cluster-info-lister-watcher-role:role',
+       'pinniped-aggregated-api-server-cluster-role:clusterrole',
+       'pinniped-credentialrequests-cluster-role:clusterrole',
+       'pinniped-aggregated-api-server-role-binding:rolebinding',
+       'pinniped-kube-system-pod-exec-role-binding:rolebinding',
+       'pinniped-extension-apiserver-authentication-reader-role-binding:rolebinding',
+       'pinniped-cluster-info-lister-watcher-role-binding:rolebinding',
+       'pinniped-aggregated-api-server-cluster-role-binding:clusterrolebinding',
+       'pinniped-credentialrequests-cluster-role-binding:clusterrolebinding',
+       'pinniped-service-account-cluster-role-binding:clusterrolebinding',
+       'pinniped-config:configmap',
+       'v1alpha1.pinniped.dev:apiservice',
+    ],
+)

--- a/hack/lib/tilt/tilt_modules/docker_build_sub/Tiltfile
+++ b/hack/lib/tilt/tilt_modules/docker_build_sub/Tiltfile
@@ -1,0 +1,44 @@
+def docker_build_sub(ref, context, extra_cmds, child_context=None, base_suffix='-tilt_docker_build_sub_base', live_update=[], **kwargs):
+  """
+  Substitutes in a docker image with extra Dockerfile commands.
+
+  This allows you to easily customize your docker build for your dev environment without changing your prod Dockerfile.
+
+  This works by:
+  1. Renaming the original image to, e.g. "myimage-base"
+  2. Creating a new image named, e.g. "myimage" that starts with "FROM myimage-base"
+  3. Adding whatever extra stuff you want
+
+  Examples:
+  ```
+  # load the extension
+  load("ext://docker_build_sub", "docker_build_sub")
+
+  # ensure you have vim installed when running in dev, so you can
+  # shell into the box and look at files
+  docker_build_sub('myimage', '.', extra_cmds=["apt-get install vim"])
+
+  # use live_update to sync files from outside your docker context
+  docker_build_sub('foo', 'foo', child_context='bar',
+    extra_cmds=['ADD . /bar'],
+    live_update=[
+      sync('foo', '/foo'),
+      sync('bar', '/bar'),
+    ]
+  )
+  ```
+
+  This function supports all the normal `docker_build` arguments. See [docker_build API docs](https://docs.tilt.dev/api.html#api.docker_build) for arguments not mentioned here..
+
+  Args:
+    context (str): The directory in which to build the parent (original) image. If child_context is not set, also the directory in which to build the new child image.
+    extra_cmds (List[str]): Any extra Dockerfile commands you want to run when building the image.
+    child_context (str): The directory in which to build the new child image. If unset (None), defaults to the parent image's context.
+    base_suffix (str): The suffix to append to the parent (original) image's name so that the new child image can take the original name. This is mostly ignorable, and just here in case the default generates a conflict for you.
+  """
+  if not child_context:
+    child_context = context
+  base_ref = '%s-base' % ref
+  docker_build(base_ref, context, **kwargs)
+  df = '\n'.join(['FROM %s' % base_ref] + extra_cmds)
+  docker_build(ref, child_context, dockerfile_contents=df, live_update=live_update, **kwargs)

--- a/hack/lib/tilt/tilt_modules/extensions.json
+++ b/hack/lib/tilt/tilt_modules/extensions.json
@@ -1,0 +1,16 @@
+{
+  "Extensions": [
+    {
+      "Name": "restart_process",
+      "GitCommitHash": "b8df6f5f3368ced855da56e002027a3bd1a61bdf",
+      "ExtensionRegistry": "https://github.com/tilt-dev/tilt-extensions",
+      "TimeFetched": "2020-09-03T23:04:40.167635-05:00"
+    },
+    {
+      "Name": "docker_build_sub",
+      "GitCommitHash": "b8df6f5f3368ced855da56e002027a3bd1a61bdf",
+      "ExtensionRegistry": "https://github.com/tilt-dev/tilt-extensions",
+      "TimeFetched": "2020-09-04T18:01:24.795509-05:00"
+    }
+  ]
+}

--- a/hack/lib/tilt/tilt_modules/restart_process/Tiltfile
+++ b/hack/lib/tilt/tilt_modules/restart_process/Tiltfile
@@ -1,0 +1,78 @@
+RESTART_FILE = '/.restart-proc'
+TYPE_RESTART_CONTAINER_STEP = 'live_update_restart_container_step'
+
+KWARGS_BLACKLIST = [
+    # since we'll be passing `dockerfile_contents` when building the
+    # child image, remove any kwargs that might conflict
+    'dockerfile', 'dockerfile_contents',
+
+    # 'target' isn't relevant to our child build--if we pass this arg,
+    # Docker will just fail to find the specified stage and error out
+    'target',
+]
+
+def docker_build_with_restart(ref, context, entrypoint, live_update,
+                              base_suffix='-tilt_docker_build_with_restart_base', restart_file=RESTART_FILE, **kwargs):
+    """Wrap a docker_build call and its associated live_update steps so that the last step
+    of any live update is to rerun the given entrypoint.
+
+
+     Args:
+      ref: name for this image (e.g. 'myproj/backend' or 'myregistry/myproj/backend'); as the parameter of the same name in docker_build
+      context: path to use as the Docker build context; as the parameter of the same name in docker_build
+      entrypoint: the command to be (re-)executed when the container starts or when a live_update is run
+      live_update: set of steps for updating a running container; as the parameter of the same name in docker_build
+      base_suffix: suffix for naming the base image, applied as {ref}{base_suffix}
+      restart_file: file that Tilt will update during a live_update to signal the entrypoint to rerun
+      **kwargs: will be passed to the underlying `docker_build` call
+    """
+
+    # first, validate the given live_update steps
+    if len(live_update) == 0:
+        fail("`docker_build_with_restart` requires at least one live_update step")
+    for step in live_update:
+        if type(step) == TYPE_RESTART_CONTAINER_STEP:
+            fail("`docker_build_with_restart` is not compatible with live_update step: "+
+                 "`restart_container()` (this extension is meant to REPLACE restart_container() )")
+
+    # rename the original image to make it a base image and declare a docker_build for it
+    base_ref = '{}{}'.format(ref, base_suffix)
+    docker_build(base_ref, context, **kwargs)
+
+    # declare a new docker build that adds a static binary of tilt-restart-wrapper
+    # (which makes use of `entr` to watch files and restart processes) to the user's image
+    df = '''
+    FROM tiltdev/restart-helper:2020-07-16 as restart-helper
+
+    FROM {}
+    USER root
+    RUN ["touch", "{}"]
+    COPY --from=restart-helper /tilt-restart-wrapper /
+    COPY --from=restart-helper /entr /
+  '''.format(base_ref, restart_file)
+
+    # Clean kwargs for building the child image (which builds on user's specified
+    # image and copies in Tilt's restart wrapper). In practice, this means removing
+    # kwargs that were relevant to building the user's specified image but are NOT
+    # relevant to building the child image / may conflict with args we specifically
+    # pass for the child image.
+    cleaned_kwargs = {k: v for k, v in kwargs.items() if k not in KWARGS_BLACKLIST}
+
+    # Change the entrypoint to use `tilt-restart-wrapper`.
+    # `tilt-restart-wrapper` makes use of `entr` (https://github.com/eradman/entr/) to
+    # re-execute $entrypoint whenever $restart_file changes
+    if type(entrypoint) == type(""):
+        entrypoint_with_entr = ["/tilt-restart-wrapper", "--watch_file={}".format(restart_file), "sh", "-c", entrypoint]
+    elif type(entrypoint) == type([]):
+        entrypoint_with_entr = ["/tilt-restart-wrapper", "--watch_file={}".format(restart_file)] + entrypoint
+    else:
+        fail("`entrypoint` must be a string or list of strings: got {}".format(type(entrypoint)))
+
+    # last live_update step should always be to modify $restart_file, which
+    # triggers the process wrapper to rerun $entrypoint
+    # NB: write `date` instead of just `touch`ing because `entr` doesn't respond
+    # to timestamp changes, only writes (see https://github.com/eradman/entr/issues/32)
+    live_update = live_update + [run('date > {}'.format(restart_file))]
+
+    docker_build(ref, context, entrypoint=entrypoint_with_entr, dockerfile_contents=df,
+                 live_update=live_update, **cleaned_kwargs)


### PR DESCRIPTION
https://docs.tilt.dev/

I did a bit of experimentation and got some basic setup working in a couple of hours. It dropped my local "cycle time" from ~2.5 minutes to ~5 seconds (!).

From the moment I saved a `.go` file, Tilt had compiled, packaged, deployed, and the new code was up and running ~5 seconds later.

I think the improvements come mainly from:
1. Building outside of Docker, which avoids the virtualization I/O tax.
1. Building with a warm Go build cache (related to item 1).
1. Hot-reloading the built binary instead of building a new image and copying it into Kind.

There's a bit of work left to push this over the finish line, so I'm setting it aside for the moment.