### PR TITLE
Clean up CredentialRequest `types.go`.

### DIFF
--- a/apis/pinniped/v1alpha1/types.go.tmpl
+++ b/apis/pinniped/v1alpha1/types.go.tmpl
@@ -13,19 +13,23 @@ const (
 	TokenCredentialType = CredentialType("token")
 )
 
+// CredentialRequestTokenCredential holds a bearer token issued by an upstream identity provider.
 type CredentialRequestTokenCredential struct {
 	// Value of the bearer token supplied with the credential request.
-	Value string `json:"value,omitempty" protobuf:"bytes,1,opt,name=value"`
+	Value string `json:"value,omitempty"`
 }
 
+// CredentialRequestSpec is the specification of a CredentialRequest, expected on requests to the Pinniped API
 type CredentialRequestSpec struct {
 	// Type of credential.
-	Type CredentialType `json:"type,omitempty" protobuf:"bytes,1,opt,name=type"`
+	Type CredentialType `json:"type,omitempty"`
 
 	// Token credential (when Type == TokenCredentialType).
-	Token *CredentialRequestTokenCredential `json:"token,omitempty" protobuf:"bytes,2,opt,name=token"`
+	Token *CredentialRequestTokenCredential `json:"token,omitempty"`
 }
 
+// CredentialRequestCredential is the cluster-specific credential returned on a successful CredentialRequest. It
+// contains either a valid bearer token or a valid TLS certificate and corresponding private key for the cluster.
 type CredentialRequestCredential struct {
 	// ExpirationTimestamp indicates a time when the provided credentials expire.
 	ExpirationTimestamp metav1.Time `json:"expirationTimestamp,omitempty"`
@@ -40,6 +44,7 @@ type CredentialRequestCredential struct {
 	ClientKeyData string `json:"clientKeyData,omitempty"`
 }
 
+// CredentialRequestStatus is the status of a CredentialRequest, returned on responses to the Pinniped API.
 type CredentialRequestStatus struct {
 	// A Credential will be returned for a successful credential request.
 	// +optional
@@ -50,25 +55,25 @@ type CredentialRequestStatus struct {
 	Message *string `json:"message,omitempty"`
 }
 
+// CredentialRequest submits an IDP-specific credential to Pinniped in exchange for a cluster-specific credential.
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
 type CredentialRequest struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   CredentialRequestSpec   `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
-	Status CredentialRequestStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
+	Spec   CredentialRequestSpec   `json:"spec,omitempty"`
+	Status CredentialRequestStatus `json:"status,omitempty"`
 }
 
-// +genclient:nonNamespaced
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // CredentialRequestList is a list of CredentialRequest objects.
+// +genclient:nonNamespaced
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type CredentialRequestList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	metav1.ListMeta `json:"metadata,omitempty"`
 
-	Items []CredentialRequest `json:"items" protobuf:"bytes,2,rep,name=items"`
+	Items []CredentialRequest `json:"items"`
 }

--- a/generated/1.17/README.adoc
+++ b/generated/1.17/README.adoc
@@ -210,7 +210,7 @@ Package v1alpha1 is the v1alpha1 version of the Pinniped aggregated API.
 [id="{anchor_prefix}-github-com-suzerain-io-pinniped-generated-1-17-apis-pinniped-v1alpha1-credentialrequest"]
 ==== CredentialRequest 
 
-
+CredentialRequest submits an IDP-specific credential to Pinniped in exchange for a cluster-specific credential.
 
 .Appears In:
 ****
@@ -230,7 +230,7 @@ Package v1alpha1 is the v1alpha1 version of the Pinniped aggregated API.
 [id="{anchor_prefix}-github-com-suzerain-io-pinniped-generated-1-17-apis-pinniped-v1alpha1-credentialrequestcredential"]
 ==== CredentialRequestCredential 
 
-
+CredentialRequestCredential is the cluster-specific credential returned on a successful CredentialRequest. It contains either a valid bearer token or a valid TLS certificate and corresponding private key for the cluster.
 
 .Appears In:
 ****
@@ -252,7 +252,7 @@ Package v1alpha1 is the v1alpha1 version of the Pinniped aggregated API.
 [id="{anchor_prefix}-github-com-suzerain-io-pinniped-generated-1-17-apis-pinniped-v1alpha1-credentialrequestspec"]
 ==== CredentialRequestSpec 
 
-
+CredentialRequestSpec is the specification of a CredentialRequest, expected on requests to the Pinniped API
 
 .Appears In:
 ****
@@ -270,7 +270,7 @@ Package v1alpha1 is the v1alpha1 version of the Pinniped aggregated API.
 [id="{anchor_prefix}-github-com-suzerain-io-pinniped-generated-1-17-apis-pinniped-v1alpha1-credentialrequeststatus"]
 ==== CredentialRequestStatus 
 
-
+CredentialRequestStatus is the status of a CredentialRequest, returned on responses to the Pinniped API.
 
 .Appears In:
 ****
@@ -288,7 +288,7 @@ Package v1alpha1 is the v1alpha1 version of the Pinniped aggregated API.
 [id="{anchor_prefix}-github-com-suzerain-io-pinniped-generated-1-17-apis-pinniped-v1alpha1-credentialrequesttokencredential"]
 ==== CredentialRequestTokenCredential 
 
-
+CredentialRequestTokenCredential holds a bearer token issued by an upstream identity provider.
 
 .Appears In:
 ****

--- a/generated/1.17/apis/pinniped/v1alpha1/types.go
+++ b/generated/1.17/apis/pinniped/v1alpha1/types.go
@@ -13,19 +13,23 @@ const (
 	TokenCredentialType = CredentialType("token")
 )
 
+// CredentialRequestTokenCredential holds a bearer token issued by an upstream identity provider.
 type CredentialRequestTokenCredential struct {
 	// Value of the bearer token supplied with the credential request.
-	Value string `json:"value,omitempty" protobuf:"bytes,1,opt,name=value"`
+	Value string `json:"value,omitempty"`
 }
 
+// CredentialRequestSpec is the specification of a CredentialRequest, expected on requests to the Pinniped API
 type CredentialRequestSpec struct {
 	// Type of credential.
-	Type CredentialType `json:"type,omitempty" protobuf:"bytes,1,opt,name=type"`
+	Type CredentialType `json:"type,omitempty"`
 
 	// Token credential (when Type == TokenCredentialType).
-	Token *CredentialRequestTokenCredential `json:"token,omitempty" protobuf:"bytes,2,opt,name=token"`
+	Token *CredentialRequestTokenCredential `json:"token,omitempty"`
 }
 
+// CredentialRequestCredential is the cluster-specific credential returned on a successful CredentialRequest. It
+// contains either a valid bearer token or a valid TLS certificate and corresponding private key for the cluster.
 type CredentialRequestCredential struct {
 	// ExpirationTimestamp indicates a time when the provided credentials expire.
 	ExpirationTimestamp metav1.Time `json:"expirationTimestamp,omitempty"`
@@ -40,6 +44,7 @@ type CredentialRequestCredential struct {
 	ClientKeyData string `json:"clientKeyData,omitempty"`
 }
 
+// CredentialRequestStatus is the status of a CredentialRequest, returned on responses to the Pinniped API.
 type CredentialRequestStatus struct {
 	// A Credential will be returned for a successful credential request.
 	// +optional
@@ -50,25 +55,25 @@ type CredentialRequestStatus struct {
 	Message *string `json:"message,omitempty"`
 }
 
+// CredentialRequest submits an IDP-specific credential to Pinniped in exchange for a cluster-specific credential.
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
 type CredentialRequest struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   CredentialRequestSpec   `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
-	Status CredentialRequestStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
+	Spec   CredentialRequestSpec   `json:"spec,omitempty"`
+	Status CredentialRequestStatus `json:"status,omitempty"`
 }
 
-// +genclient:nonNamespaced
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // CredentialRequestList is a list of CredentialRequest objects.
+// +genclient:nonNamespaced
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type CredentialRequestList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	metav1.ListMeta `json:"metadata,omitempty"`
 
-	Items []CredentialRequest `json:"items" protobuf:"bytes,2,rep,name=items"`
+	Items []CredentialRequest `json:"items"`
 }

--- a/generated/1.17/client/openapi/zz_generated.openapi.go
+++ b/generated/1.17/client/openapi/zz_generated.openapi.go
@@ -531,7 +531,8 @@ func schema_117_apis_pinniped_v1alpha1_CredentialRequest(ref common.ReferenceCal
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "CredentialRequest submits an IDP-specific credential to Pinniped in exchange for a cluster-specific credential.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
@@ -574,7 +575,8 @@ func schema_117_apis_pinniped_v1alpha1_CredentialRequestCredential(ref common.Re
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "CredentialRequestCredential is the cluster-specific credential returned on a successful CredentialRequest. It contains either a valid bearer token or a valid TLS certificate and corresponding private key for the cluster.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"expirationTimestamp": {
 						SchemaProps: spec.SchemaProps{
@@ -662,7 +664,8 @@ func schema_117_apis_pinniped_v1alpha1_CredentialRequestSpec(ref common.Referenc
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "CredentialRequestSpec is the specification of a CredentialRequest, expected on requests to the Pinniped API",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
@@ -689,7 +692,8 @@ func schema_117_apis_pinniped_v1alpha1_CredentialRequestStatus(ref common.Refere
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "CredentialRequestStatus is the status of a CredentialRequest, returned on responses to the Pinniped API.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"credential": {
 						SchemaProps: spec.SchemaProps{
@@ -716,7 +720,8 @@ func schema_117_apis_pinniped_v1alpha1_CredentialRequestTokenCredential(ref comm
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "CredentialRequestTokenCredential holds a bearer token issued by an upstream identity provider.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"value": {
 						SchemaProps: spec.SchemaProps{

--- a/generated/1.18/README.adoc
+++ b/generated/1.18/README.adoc
@@ -210,7 +210,7 @@ Package v1alpha1 is the v1alpha1 version of the Pinniped aggregated API.
 [id="{anchor_prefix}-github-com-suzerain-io-pinniped-generated-1-18-apis-pinniped-v1alpha1-credentialrequest"]
 ==== CredentialRequest 
 
-
+CredentialRequest submits an IDP-specific credential to Pinniped in exchange for a cluster-specific credential.
 
 .Appears In:
 ****
@@ -230,7 +230,7 @@ Package v1alpha1 is the v1alpha1 version of the Pinniped aggregated API.
 [id="{anchor_prefix}-github-com-suzerain-io-pinniped-generated-1-18-apis-pinniped-v1alpha1-credentialrequestcredential"]
 ==== CredentialRequestCredential 
 
-
+CredentialRequestCredential is the cluster-specific credential returned on a successful CredentialRequest. It contains either a valid bearer token or a valid TLS certificate and corresponding private key for the cluster.
 
 .Appears In:
 ****
@@ -252,7 +252,7 @@ Package v1alpha1 is the v1alpha1 version of the Pinniped aggregated API.
 [id="{anchor_prefix}-github-com-suzerain-io-pinniped-generated-1-18-apis-pinniped-v1alpha1-credentialrequestspec"]
 ==== CredentialRequestSpec 
 
-
+CredentialRequestSpec is the specification of a CredentialRequest, expected on requests to the Pinniped API
 
 .Appears In:
 ****
@@ -270,7 +270,7 @@ Package v1alpha1 is the v1alpha1 version of the Pinniped aggregated API.
 [id="{anchor_prefix}-github-com-suzerain-io-pinniped-generated-1-18-apis-pinniped-v1alpha1-credentialrequeststatus"]
 ==== CredentialRequestStatus 
 
-
+CredentialRequestStatus is the status of a CredentialRequest, returned on responses to the Pinniped API.
 
 .Appears In:
 ****
@@ -288,7 +288,7 @@ Package v1alpha1 is the v1alpha1 version of the Pinniped aggregated API.
 [id="{anchor_prefix}-github-com-suzerain-io-pinniped-generated-1-18-apis-pinniped-v1alpha1-credentialrequesttokencredential"]
 ==== CredentialRequestTokenCredential 
 
-
+CredentialRequestTokenCredential holds a bearer token issued by an upstream identity provider.
 
 .Appears In:
 ****

--- a/generated/1.18/apis/pinniped/v1alpha1/types.go
+++ b/generated/1.18/apis/pinniped/v1alpha1/types.go
@@ -13,19 +13,23 @@ const (
 	TokenCredentialType = CredentialType("token")
 )
 
+// CredentialRequestTokenCredential holds a bearer token issued by an upstream identity provider.
 type CredentialRequestTokenCredential struct {
 	// Value of the bearer token supplied with the credential request.
-	Value string `json:"value,omitempty" protobuf:"bytes,1,opt,name=value"`
+	Value string `json:"value,omitempty"`
 }
 
+// CredentialRequestSpec is the specification of a CredentialRequest, expected on requests to the Pinniped API
 type CredentialRequestSpec struct {
 	// Type of credential.
-	Type CredentialType `json:"type,omitempty" protobuf:"bytes,1,opt,name=type"`
+	Type CredentialType `json:"type,omitempty"`
 
 	// Token credential (when Type == TokenCredentialType).
-	Token *CredentialRequestTokenCredential `json:"token,omitempty" protobuf:"bytes,2,opt,name=token"`
+	Token *CredentialRequestTokenCredential `json:"token,omitempty"`
 }
 
+// CredentialRequestCredential is the cluster-specific credential returned on a successful CredentialRequest. It
+// contains either a valid bearer token or a valid TLS certificate and corresponding private key for the cluster.
 type CredentialRequestCredential struct {
 	// ExpirationTimestamp indicates a time when the provided credentials expire.
 	ExpirationTimestamp metav1.Time `json:"expirationTimestamp,omitempty"`
@@ -40,6 +44,7 @@ type CredentialRequestCredential struct {
 	ClientKeyData string `json:"clientKeyData,omitempty"`
 }
 
+// CredentialRequestStatus is the status of a CredentialRequest, returned on responses to the Pinniped API.
 type CredentialRequestStatus struct {
 	// A Credential will be returned for a successful credential request.
 	// +optional
@@ -50,25 +55,25 @@ type CredentialRequestStatus struct {
 	Message *string `json:"message,omitempty"`
 }
 
+// CredentialRequest submits an IDP-specific credential to Pinniped in exchange for a cluster-specific credential.
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
 type CredentialRequest struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   CredentialRequestSpec   `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
-	Status CredentialRequestStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
+	Spec   CredentialRequestSpec   `json:"spec,omitempty"`
+	Status CredentialRequestStatus `json:"status,omitempty"`
 }
 
-// +genclient:nonNamespaced
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // CredentialRequestList is a list of CredentialRequest objects.
+// +genclient:nonNamespaced
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type CredentialRequestList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	metav1.ListMeta `json:"metadata,omitempty"`
 
-	Items []CredentialRequest `json:"items" protobuf:"bytes,2,rep,name=items"`
+	Items []CredentialRequest `json:"items"`
 }

--- a/generated/1.18/client/openapi/zz_generated.openapi.go
+++ b/generated/1.18/client/openapi/zz_generated.openapi.go
@@ -531,7 +531,8 @@ func schema_118_apis_pinniped_v1alpha1_CredentialRequest(ref common.ReferenceCal
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "CredentialRequest submits an IDP-specific credential to Pinniped in exchange for a cluster-specific credential.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
@@ -574,7 +575,8 @@ func schema_118_apis_pinniped_v1alpha1_CredentialRequestCredential(ref common.Re
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "CredentialRequestCredential is the cluster-specific credential returned on a successful CredentialRequest. It contains either a valid bearer token or a valid TLS certificate and corresponding private key for the cluster.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"expirationTimestamp": {
 						SchemaProps: spec.SchemaProps{
@@ -662,7 +664,8 @@ func schema_118_apis_pinniped_v1alpha1_CredentialRequestSpec(ref common.Referenc
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "CredentialRequestSpec is the specification of a CredentialRequest, expected on requests to the Pinniped API",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
@@ -689,7 +692,8 @@ func schema_118_apis_pinniped_v1alpha1_CredentialRequestStatus(ref common.Refere
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "CredentialRequestStatus is the status of a CredentialRequest, returned on responses to the Pinniped API.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"credential": {
 						SchemaProps: spec.SchemaProps{
@@ -716,7 +720,8 @@ func schema_118_apis_pinniped_v1alpha1_CredentialRequestTokenCredential(ref comm
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "CredentialRequestTokenCredential holds a bearer token issued by an upstream identity provider.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"value": {
 						SchemaProps: spec.SchemaProps{

--- a/generated/1.19/README.adoc
+++ b/generated/1.19/README.adoc
@@ -210,7 +210,7 @@ Package v1alpha1 is the v1alpha1 version of the Pinniped aggregated API.
 [id="{anchor_prefix}-github-com-suzerain-io-pinniped-generated-1-19-apis-pinniped-v1alpha1-credentialrequest"]
 ==== CredentialRequest 
 
-
+CredentialRequest submits an IDP-specific credential to Pinniped in exchange for a cluster-specific credential.
 
 .Appears In:
 ****
@@ -230,7 +230,7 @@ Package v1alpha1 is the v1alpha1 version of the Pinniped aggregated API.
 [id="{anchor_prefix}-github-com-suzerain-io-pinniped-generated-1-19-apis-pinniped-v1alpha1-credentialrequestcredential"]
 ==== CredentialRequestCredential 
 
-
+CredentialRequestCredential is the cluster-specific credential returned on a successful CredentialRequest. It contains either a valid bearer token or a valid TLS certificate and corresponding private key for the cluster.
 
 .Appears In:
 ****
@@ -252,7 +252,7 @@ Package v1alpha1 is the v1alpha1 version of the Pinniped aggregated API.
 [id="{anchor_prefix}-github-com-suzerain-io-pinniped-generated-1-19-apis-pinniped-v1alpha1-credentialrequestspec"]
 ==== CredentialRequestSpec 
 
-
+CredentialRequestSpec is the specification of a CredentialRequest, expected on requests to the Pinniped API
 
 .Appears In:
 ****
@@ -270,7 +270,7 @@ Package v1alpha1 is the v1alpha1 version of the Pinniped aggregated API.
 [id="{anchor_prefix}-github-com-suzerain-io-pinniped-generated-1-19-apis-pinniped-v1alpha1-credentialrequeststatus"]
 ==== CredentialRequestStatus 
 
-
+CredentialRequestStatus is the status of a CredentialRequest, returned on responses to the Pinniped API.
 
 .Appears In:
 ****
@@ -288,7 +288,7 @@ Package v1alpha1 is the v1alpha1 version of the Pinniped aggregated API.
 [id="{anchor_prefix}-github-com-suzerain-io-pinniped-generated-1-19-apis-pinniped-v1alpha1-credentialrequesttokencredential"]
 ==== CredentialRequestTokenCredential 
 
-
+CredentialRequestTokenCredential holds a bearer token issued by an upstream identity provider.
 
 .Appears In:
 ****

--- a/generated/1.19/apis/pinniped/v1alpha1/types.go
+++ b/generated/1.19/apis/pinniped/v1alpha1/types.go
@@ -13,19 +13,23 @@ const (
 	TokenCredentialType = CredentialType("token")
 )
 
+// CredentialRequestTokenCredential holds a bearer token issued by an upstream identity provider.
 type CredentialRequestTokenCredential struct {
 	// Value of the bearer token supplied with the credential request.
-	Value string `json:"value,omitempty" protobuf:"bytes,1,opt,name=value"`
+	Value string `json:"value,omitempty"`
 }
 
+// CredentialRequestSpec is the specification of a CredentialRequest, expected on requests to the Pinniped API
 type CredentialRequestSpec struct {
 	// Type of credential.
-	Type CredentialType `json:"type,omitempty" protobuf:"bytes,1,opt,name=type"`
+	Type CredentialType `json:"type,omitempty"`
 
 	// Token credential (when Type == TokenCredentialType).
-	Token *CredentialRequestTokenCredential `json:"token,omitempty" protobuf:"bytes,2,opt,name=token"`
+	Token *CredentialRequestTokenCredential `json:"token,omitempty"`
 }
 
+// CredentialRequestCredential is the cluster-specific credential returned on a successful CredentialRequest. It
+// contains either a valid bearer token or a valid TLS certificate and corresponding private key for the cluster.
 type CredentialRequestCredential struct {
 	// ExpirationTimestamp indicates a time when the provided credentials expire.
 	ExpirationTimestamp metav1.Time `json:"expirationTimestamp,omitempty"`
@@ -40,6 +44,7 @@ type CredentialRequestCredential struct {
 	ClientKeyData string `json:"clientKeyData,omitempty"`
 }
 
+// CredentialRequestStatus is the status of a CredentialRequest, returned on responses to the Pinniped API.
 type CredentialRequestStatus struct {
 	// A Credential will be returned for a successful credential request.
 	// +optional
@@ -50,25 +55,25 @@ type CredentialRequestStatus struct {
 	Message *string `json:"message,omitempty"`
 }
 
+// CredentialRequest submits an IDP-specific credential to Pinniped in exchange for a cluster-specific credential.
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
 type CredentialRequest struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   CredentialRequestSpec   `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
-	Status CredentialRequestStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
+	Spec   CredentialRequestSpec   `json:"spec,omitempty"`
+	Status CredentialRequestStatus `json:"status,omitempty"`
 }
 
-// +genclient:nonNamespaced
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // CredentialRequestList is a list of CredentialRequest objects.
+// +genclient:nonNamespaced
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type CredentialRequestList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	metav1.ListMeta `json:"metadata,omitempty"`
 
-	Items []CredentialRequest `json:"items" protobuf:"bytes,2,rep,name=items"`
+	Items []CredentialRequest `json:"items"`
 }

--- a/generated/1.19/client/openapi/zz_generated.openapi.go
+++ b/generated/1.19/client/openapi/zz_generated.openapi.go
@@ -532,7 +532,8 @@ func schema_119_apis_pinniped_v1alpha1_CredentialRequest(ref common.ReferenceCal
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "CredentialRequest submits an IDP-specific credential to Pinniped in exchange for a cluster-specific credential.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
@@ -575,7 +576,8 @@ func schema_119_apis_pinniped_v1alpha1_CredentialRequestCredential(ref common.Re
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "CredentialRequestCredential is the cluster-specific credential returned on a successful CredentialRequest. It contains either a valid bearer token or a valid TLS certificate and corresponding private key for the cluster.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"expirationTimestamp": {
 						SchemaProps: spec.SchemaProps{
@@ -663,7 +665,8 @@ func schema_119_apis_pinniped_v1alpha1_CredentialRequestSpec(ref common.Referenc
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "CredentialRequestSpec is the specification of a CredentialRequest, expected on requests to the Pinniped API",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
@@ -690,7 +693,8 @@ func schema_119_apis_pinniped_v1alpha1_CredentialRequestStatus(ref common.Refere
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "CredentialRequestStatus is the status of a CredentialRequest, returned on responses to the Pinniped API.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"credential": {
 						SchemaProps: spec.SchemaProps{
@@ -717,7 +721,8 @@ func schema_119_apis_pinniped_v1alpha1_CredentialRequestTokenCredential(ref comm
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "CredentialRequestTokenCredential holds a bearer token issued by an upstream identity provider.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"value": {
 						SchemaProps: spec.SchemaProps{


### PR DESCRIPTION
Mostly cleaned up and added doc strings, but also removed unneeded protobuf tags.
