### PR TITLE
PoC: support Kubernetes 1.19.x by running a temporary pod instead of using exec.

### DIFF
--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -75,7 +75,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: [pods]
-    verbs: [get, list]
+    verbs: [get, list, create]
   - apiGroups: [""]
     resources: [pods/exec]
     verbs: [create]


### PR DESCRIPTION
This isn't intended to be merged directly, but I was able to confirm that this approach works with Kubernetes 1.19 on Kind.

One sketch for a more production ready version of this would be:
- Add a new controller which has the task of creating exactly one `pinniped-pause` pod in a configuration similar to below.
- This pod can run a "sleep forever" image (maybe the Kubernetes `pause` image?).
- The exec code can take a parameter which allows it to target the `pinniped-signer` pod instead of `kube-controller-manager`.
- The `pinniped-pause` pod-creating controller can be enabled only in the case where the original exec-based behavior has failed once, perhaps?