### PR TITLE
internal/controller/issuerconfig: use Kubernetes DeepEqual

### DIFF
--- a/internal/controller/issuerconfig/create_or_update_credential_issuer_config.go
+++ b/internal/controller/issuerconfig/create_or_update_credential_issuer_config.go
@@ -6,8 +6,8 @@ package issuerconfig
 import (
 	"context"
 	"fmt"
-	"reflect"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
@@ -73,7 +73,7 @@ func createOrUpdateCredentialIssuerConfig(
 		credentialIssuerConfig := existingCredentialIssuerConfig.DeepCopy()
 		applyUpdatesToCredentialIssuerConfigFunc(credentialIssuerConfig)
 
-		if reflect.DeepEqual(existingCredentialIssuerConfig.Status, credentialIssuerConfig.Status) {
+		if equality.Semantic.DeepEqual(existingCredentialIssuerConfig, credentialIssuerConfig) {
 			// Nothing interesting would change as a result of this update, so skip it
 			return nil
 		}

--- a/internal/controller/issuerconfig/create_or_update_credential_issuer_config_test.go
+++ b/internal/controller/issuerconfig/create_or_update_credential_issuer_config_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
@@ -145,6 +146,11 @@ func TestCreateOrUpdateCredentialIssuerConfig(t *testing.T) {
 				err := CreateOrUpdateCredentialIssuerConfig(ctx, installationNamespace, pinnipedAPIClient,
 					func(configToUpdate *v1alpha1.CredentialIssuerConfig) {
 						configToUpdate.Status.KubeConfigInfo.CertificateAuthorityData = "initial-ca-value"
+
+						t := configToUpdate.Status.Strategies[0].LastUpdateTime
+						loc, err := time.LoadLocation("Asia/Shanghai")
+						r.NoError(err)
+						configToUpdate.Status.Strategies[0].LastUpdateTime = metav1.NewTime(t.In(loc))
 					},
 				)
 				r.NoError(err)


### PR DESCRIPTION
Hey Ryan - I think I led us astray a couple of weeks ago when I recommended that we use `reflect.DeepEqual` when comparing two Kubernetes objects. Apparently there is a better way to do this: https://github.com/kubernetes/apimachinery/issues/75#issuecomment-550150929. Kinda interesting. Let me know if you have any qualms. Otherwise I'll merge.