### PR TITLE
Remove curly braces from doc commands

### DIFF
--- a/doc/demo.md
+++ b/doc/demo.md
@@ -68,7 +68,7 @@ for a more specific example of installing onto a local kind cluster, including t
 1. Deploy the `local-user-authenticator` app.
 
     ```bash
-    kubectl apply -f https://github.com/vmware-tanzu/pinniped/releases/download/${pinniped_version}/install-local-user-authenticator.yaml
+    kubectl apply -f https://github.com/vmware-tanzu/pinniped/releases/download/$pinniped_version/install-local-user-authenticator.yaml
     ```
 
    The `install-local-user-authenticator.yaml` file includes the default deployment options.
@@ -96,7 +96,7 @@ for a more specific example of installing onto a local kind cluster, including t
 1. Deploy Pinniped.
 
    ```bash
-    kubectl apply -f https://github.com/vmware-tanzu/pinniped/releases/download/${pinniped_version}/install-pinniped.yaml
+    kubectl apply -f https://github.com/vmware-tanzu/pinniped/releases/download/$pinniped_version/install-pinniped.yaml
    ```
 
    The `install-pinniped.yaml` file includes the default deployment options.


### PR DESCRIPTION
**Summary of the changes included in this PR**

Remove curly braces from doc commands, because when you copy/paste them to zsh they are automatically escaped and then they do not work correctly.

**Issue(s) addressed by this PR**

N/A

**Things to consider while reviewing this PR**

N/A

**Suggested release note for the first release which contains this PR**

N/A: doc change only