### PR TITLE
Enable cache mutation detector in unit tests

### DIFF
--- a/hack/module.sh
+++ b/hack/module.sh
@@ -42,13 +42,21 @@ function with_modules() {
   local cmd_function="${1}"
   cmd="$(${cmd_function})"
 
+  # start the cache mutation detector by default so that cache mutators will be found
+  local kube_cache_mutation_detector="${KUBE_CACHE_MUTATION_DETECTOR:-true}"
+
+  # panic the server on watch decode errors since they are considered coder mistakes
+  local kube_panic_watch_decode_error="${KUBE_PANIC_WATCH_DECODE_ERROR:-true}"
+
+  env_vars="KUBE_CACHE_MUTATION_DETECTOR=${kube_cache_mutation_detector} KUBE_PANIC_WATCH_DECODE_ERROR=${kube_panic_watch_decode_error}"
+
   pushd "${ROOT}" >/dev/null
   for mod_file in $(find . -maxdepth 4 -not -path "./generated/*" -name go.mod | sort); do
     mod_dir="$(dirname "${mod_file}")"
     (
       echo "=> "
-      echo "   cd ${mod_dir} && ${cmd}"
-      cd "${mod_dir}" && ${cmd}
+      echo "   cd ${mod_dir} && ${env_vars} ${cmd}"
+      cd "${mod_dir}" && env ${env_vars} ${cmd}
     )
   done
   popd >/dev/null

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -1,0 +1,29 @@
+// Copyright 2020 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestCacheMutationDetectorEnabled(t *testing.T) {
+	// this is a bit of simplistic test to check if we have a real cache mutation detector.
+	// if we actually start mutating an informer cache in this test, the test will almost
+	// always fail because the go race detector will see the mutation.
+	// the cache mutation detector will certainly make certain races more common and thus
+	// easily detected by the race detector, but its real use is against a compiled binary
+	// such as pinniped-server running in a pod - that binary has no race detector at runtime.
+
+	c := cache.NewCacheMutationDetector("test pinniped")
+
+	type isRealCacheMutationDetector interface {
+		CompareObjects() // this is brittle, but this function name has never changed...
+	}
+
+	_, ok := c.(isRealCacheMutationDetector)
+	require.Truef(t, ok, "%T is not a real cache mutation detector", c)
+}

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -20,10 +20,8 @@ func TestCacheMutationDetectorEnabled(t *testing.T) {
 
 	c := cache.NewCacheMutationDetector("test pinniped")
 
-	type isRealCacheMutationDetector interface {
+	type realCacheMutationDetector interface {
 		CompareObjects() // this is brittle, but this function name has never changed...
 	}
-
-	_, ok := c.(isRealCacheMutationDetector)
-	require.Truef(t, ok, "%T is not a real cache mutation detector", c)
+	require.Implementsf(t, (*realCacheMutationDetector)(nil), c, "%T is not a real cache mutation detector", c)
 }


### PR DESCRIPTION
Signed-off-by: Monis Khan <mok@vmware.com>

**Summary of the changes included in this PR**

Enable cache mutation detector in unit tests.  This will cause code that mutates data stored in an informer cache to panic (even when the race detector is not enabled).

**Issue(s) addressed by this PR**

N/A

**Things to consider while reviewing this PR**

This needs a follow-up PR to enable these env vars in the integration test scripts and the `pinniped-server` deployment (the running server will greatly benefit from that because it cannot run the race detector).

**Suggested release note for the first release which contains this PR**

N/A