### PR TITLE
Implement per-issuer OIDC JWKS endpoint

### DIFF
--- a/internal/controller/identityprovider/webhookcachecleaner/webhookcachecleaner.go
+++ b/internal/controller/identityprovider/webhookcachecleaner/webhookcachecleaner.go
@@ -31,7 +31,7 @@ func New(cache *idpcache.Cache, webhookIDPs idpinformers.WebhookIdentityProvider
 		},
 		controllerlib.WithInformer(
 			webhookIDPs,
-			pinnipedcontroller.NoOpFilter(),
+			pinnipedcontroller.MatchAnythingFilter(),
 			controllerlib.InformerOption{},
 		),
 	)
@@ -44,7 +44,7 @@ type controller struct {
 }
 
 // Sync implements controllerlib.Syncer.
-func (c *controller) Sync(ctx controllerlib.Context) error {
+func (c *controller) Sync(_ controllerlib.Context) error {
 	webhooks, err := c.webhookIDPs.Lister().List(labels.Everything())
 	if err != nil {
 		return fmt.Errorf("failed to list WebhookIdentityProviders: %w", err)

--- a/internal/controller/identityprovider/webhookcachefiller/webhookcachefiller.go
+++ b/internal/controller/identityprovider/webhookcachefiller/webhookcachefiller.go
@@ -40,7 +40,7 @@ func New(cache *idpcache.Cache, webhookIDPs idpinformers.WebhookIdentityProvider
 		},
 		controllerlib.WithInformer(
 			webhookIDPs,
-			pinnipedcontroller.NoOpFilter(),
+			pinnipedcontroller.MatchAnythingFilter(),
 			controllerlib.InformerOption{},
 		),
 	)

--- a/internal/controller/supervisorconfig/jwks_observer.go
+++ b/internal/controller/supervisorconfig/jwks_observer.go
@@ -1,0 +1,94 @@
+// Copyright 2020 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package supervisorconfig
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"gopkg.in/square/go-jose.v2"
+	"k8s.io/apimachinery/pkg/labels"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/klog/v2"
+
+	"go.pinniped.dev/generated/1.19/client/informers/externalversions/config/v1alpha1"
+	pinnipedcontroller "go.pinniped.dev/internal/controller"
+	"go.pinniped.dev/internal/controllerlib"
+)
+
+type jwksObserverController struct {
+	issuerToJWKSSetter         IssuerToJWKSMapSetter
+	oidcProviderConfigInformer v1alpha1.OIDCProviderConfigInformer
+	secretInformer             corev1informers.SecretInformer
+}
+
+type IssuerToJWKSMapSetter interface {
+	SetIssuerToJWKSMap(issuerToJWKSMap map[string]*jose.JSONWebKeySet)
+}
+
+// Returns a controller which watches all of the OIDCProviderConfigs and their corresponding Secrets
+// and fills an in-memory cache of the JWKS info for each currently configured issuer.
+// This controller assumes that the informers passed to it are already scoped down to the
+// appropriate namespace. It also assumes that the IssuerToJWKSMapSetter passed to it has an
+// underlying implementation which is thread-safe.
+func NewJWKSObserverController(
+	issuerToJWKSSetter IssuerToJWKSMapSetter,
+	secretInformer corev1informers.SecretInformer,
+	oidcProviderConfigInformer v1alpha1.OIDCProviderConfigInformer,
+	withInformer pinnipedcontroller.WithInformerOptionFunc,
+) controllerlib.Controller {
+	return controllerlib.New(
+		controllerlib.Config{
+			Name: "certs-observer-controller",
+			Syncer: &jwksObserverController{
+				issuerToJWKSSetter:         issuerToJWKSSetter,
+				oidcProviderConfigInformer: oidcProviderConfigInformer,
+				secretInformer:             secretInformer,
+			},
+		},
+		withInformer(
+			secretInformer,
+			pinnipedcontroller.MatchAnythingFilter(),
+			controllerlib.InformerOption{},
+		),
+		withInformer(
+			oidcProviderConfigInformer,
+			pinnipedcontroller.MatchAnythingFilter(),
+			controllerlib.InformerOption{},
+		),
+	)
+}
+
+func (c *jwksObserverController) Sync(ctx controllerlib.Context) error {
+	ns := ctx.Key.Namespace
+	allProviders, err := c.oidcProviderConfigInformer.Lister().OIDCProviderConfigs(ns).List(labels.Everything())
+	if err != nil {
+		return fmt.Errorf("failed to list OIDCProviderConfigs: %w", err)
+	}
+
+	// Rebuild the whole map on any change to any Secret or OIDCProvider, because either can have changes that
+	// can cause the map to need to be updated.
+	issuerToJWKSMap := map[string]*jose.JSONWebKeySet{}
+
+	for _, provider := range allProviders {
+		secretRef := provider.Status.JWKSSecret
+		jwksSecret, err := c.secretInformer.Lister().Secrets(ns).Get(secretRef.Name)
+		if err != nil {
+			klog.InfoS("jwksObserverController Sync could not find JWKS secret", "namespace", ns, "secretName", secretRef.Name)
+			continue
+		}
+		jwkFromSecret := jose.JSONWebKeySet{}
+		err = json.Unmarshal(jwksSecret.Data[jwksKey], &jwkFromSecret)
+		if err != nil {
+			klog.InfoS("jwksObserverController Sync found a JWKS secret with Data in an unexpected format", "namespace", ns, "secretName", secretRef.Name)
+			continue
+		}
+		issuerToJWKSMap[provider.Spec.Issuer] = &jwkFromSecret
+	}
+
+	klog.InfoS("jwksObserverController Sync updated the JWKS cache", "issuerCount", len(issuerToJWKSMap))
+	c.issuerToJWKSSetter.SetIssuerToJWKSMap(issuerToJWKSMap)
+
+	return nil
+}

--- a/internal/controller/supervisorconfig/jwks_observer_test.go
+++ b/internal/controller/supervisorconfig/jwks_observer_test.go
@@ -1,0 +1,302 @@
+// Copyright 2020 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package supervisorconfig
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/square/go-jose.v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeinformers "k8s.io/client-go/informers"
+	kubernetesfake "k8s.io/client-go/kubernetes/fake"
+
+	"go.pinniped.dev/generated/1.19/apis/config/v1alpha1"
+	pinnipedfake "go.pinniped.dev/generated/1.19/client/clientset/versioned/fake"
+	pinnipedinformers "go.pinniped.dev/generated/1.19/client/informers/externalversions"
+	"go.pinniped.dev/internal/controllerlib"
+	"go.pinniped.dev/internal/testutil"
+)
+
+func TestJWKSObserverControllerInformerFilters(t *testing.T) {
+	spec.Run(t, "informer filters", func(t *testing.T, when spec.G, it spec.S) {
+		var (
+			r                                *require.Assertions
+			observableWithInformerOption     *testutil.ObservableWithInformerOption
+			secretsInformerFilter            controllerlib.Filter
+			oidcProviderConfigInformerFilter controllerlib.Filter
+		)
+
+		it.Before(func() {
+			r = require.New(t)
+			observableWithInformerOption = testutil.NewObservableWithInformerOption()
+			secretsInformer := kubeinformers.NewSharedInformerFactory(nil, 0).Core().V1().Secrets()
+			oidcProviderConfigInformer := pinnipedinformers.NewSharedInformerFactory(nil, 0).Config().V1alpha1().OIDCProviderConfigs()
+			_ = NewJWKSObserverController(
+				nil,
+				secretsInformer,
+				oidcProviderConfigInformer,
+				observableWithInformerOption.WithInformer, // make it possible to observe the behavior of the Filters
+			)
+			secretsInformerFilter = observableWithInformerOption.GetFilterForInformer(secretsInformer)
+			oidcProviderConfigInformerFilter = observableWithInformerOption.GetFilterForInformer(oidcProviderConfigInformer)
+		})
+
+		when("watching Secret objects", func() {
+			var (
+				subject             controllerlib.Filter
+				secret, otherSecret *corev1.Secret
+			)
+
+			it.Before(func() {
+				subject = secretsInformerFilter
+				secret = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "any-name", Namespace: "any-namespace"}}
+				otherSecret = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "any-other-name", Namespace: "any-other-namespace"}}
+			})
+
+			when("any Secret changes", func() {
+				it("returns true to trigger the sync method", func() {
+					r.True(subject.Add(secret))
+					r.True(subject.Update(secret, otherSecret))
+					r.True(subject.Update(otherSecret, secret))
+					r.True(subject.Delete(secret))
+				})
+			})
+		})
+
+		when("watching OIDCProviderConfig objects", func() {
+			var (
+				subject                 controllerlib.Filter
+				provider, otherProvider *v1alpha1.OIDCProviderConfig
+			)
+
+			it.Before(func() {
+				subject = oidcProviderConfigInformerFilter
+				provider = &v1alpha1.OIDCProviderConfig{ObjectMeta: metav1.ObjectMeta{Name: "any-name", Namespace: "any-namespace"}}
+				otherProvider = &v1alpha1.OIDCProviderConfig{ObjectMeta: metav1.ObjectMeta{Name: "any-other-name", Namespace: "any-other-namespace"}}
+			})
+
+			when("any OIDCProviderConfig changes", func() {
+				it("returns true to trigger the sync method", func() {
+					r.True(subject.Add(provider))
+					r.True(subject.Update(provider, otherProvider))
+					r.True(subject.Update(otherProvider, provider))
+					r.True(subject.Delete(provider))
+				})
+			})
+		})
+	}, spec.Parallel(), spec.Report(report.Terminal{}))
+}
+
+type fakeIssuerToJWKSMapSetter struct {
+	setIssuerToJWKSMapWasCalled bool
+	issuerToJWKSMapReceived     map[string]*jose.JSONWebKeySet
+}
+
+func (f *fakeIssuerToJWKSMapSetter) SetIssuerToJWKSMap(issuerToJWKSMap map[string]*jose.JSONWebKeySet) {
+	f.setIssuerToJWKSMapWasCalled = true
+	f.issuerToJWKSMapReceived = issuerToJWKSMap
+}
+
+func TestJWKSObserverControllerSync(t *testing.T) {
+	spec.Run(t, "Sync", func(t *testing.T, when spec.G, it spec.S) {
+		const installedInNamespace = "some-namespace"
+
+		var (
+			r                      *require.Assertions
+			subject                controllerlib.Controller
+			pinnipedInformerClient *pinnipedfake.Clientset
+			kubeInformerClient     *kubernetesfake.Clientset
+			pinnipedInformers      pinnipedinformers.SharedInformerFactory
+			kubeInformers          kubeinformers.SharedInformerFactory
+			timeoutContext         context.Context
+			timeoutContextCancel   context.CancelFunc
+			syncContext            *controllerlib.Context
+			issuerToJWKSSetter     *fakeIssuerToJWKSMapSetter
+		)
+
+		// Defer starting the informers until the last possible moment so that the
+		// nested Before's can keep adding things to the informer caches.
+		var startInformersAndController = func() {
+			// Set this at the last second to allow for injection of server override.
+			subject = NewJWKSObserverController(
+				issuerToJWKSSetter,
+				kubeInformers.Core().V1().Secrets(),
+				pinnipedInformers.Config().V1alpha1().OIDCProviderConfigs(),
+				controllerlib.WithInformer,
+			)
+
+			// Set this at the last second to support calling subject.Name().
+			syncContext = &controllerlib.Context{
+				Context: timeoutContext,
+				Name:    subject.Name(),
+				Key: controllerlib.Key{
+					Namespace: installedInNamespace,
+					Name:      "any-name",
+				},
+			}
+
+			// Must start informers before calling TestRunSynchronously()
+			kubeInformers.Start(timeoutContext.Done())
+			pinnipedInformers.Start(timeoutContext.Done())
+			controllerlib.TestRunSynchronously(t, subject)
+		}
+
+		it.Before(func() {
+			r = require.New(t)
+
+			timeoutContext, timeoutContextCancel = context.WithTimeout(context.Background(), time.Second*3)
+
+			kubeInformerClient = kubernetesfake.NewSimpleClientset()
+			kubeInformers = kubeinformers.NewSharedInformerFactory(kubeInformerClient, 0)
+			pinnipedInformerClient = pinnipedfake.NewSimpleClientset()
+			pinnipedInformers = pinnipedinformers.NewSharedInformerFactory(pinnipedInformerClient, 0)
+			issuerToJWKSSetter = &fakeIssuerToJWKSMapSetter{}
+
+			unrelatedSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "some other unrelated secret",
+					Namespace: installedInNamespace,
+				},
+			}
+			r.NoError(kubeInformerClient.Tracker().Add(unrelatedSecret))
+		})
+
+		it.After(func() {
+			timeoutContextCancel()
+		})
+
+		when("there are no OIDCProviderConfigs and no JWKS Secrets yet", func() {
+			it("sets the issuerToJWKSSetter's map to be empty", func() {
+				startInformersAndController()
+				err := controllerlib.TestSync(t, subject, *syncContext)
+				r.NoError(err)
+
+				r.True(issuerToJWKSSetter.setIssuerToJWKSMapWasCalled)
+				r.Empty(issuerToJWKSSetter.issuerToJWKSMapReceived)
+			})
+		})
+
+		when("there are OIDCProviderConfigs where some have corresponding JWKS Secrets and some don't", func() {
+			var (
+				expectedJWK1, expectedJWK2 string
+			)
+
+			it.Before(func() {
+				oidcProviderConfigWithoutSecret1 := &v1alpha1.OIDCProviderConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "no-secret-oidcproviderconfig1",
+						Namespace: installedInNamespace,
+					},
+					Spec:   v1alpha1.OIDCProviderConfigSpec{Issuer: "https://no-secret-issuer1.com"},
+					Status: v1alpha1.OIDCProviderConfigStatus{}, // no JWKSSecret field
+				}
+				oidcProviderConfigWithoutSecret2 := &v1alpha1.OIDCProviderConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "no-secret-oidcproviderconfig2",
+						Namespace: installedInNamespace,
+					},
+					Spec: v1alpha1.OIDCProviderConfigSpec{Issuer: "https://no-secret-issuer2.com"},
+					// no Status field
+				}
+				oidcProviderConfigWithBadSecret := &v1alpha1.OIDCProviderConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "bad-secret-oidcproviderconfig",
+						Namespace: installedInNamespace,
+					},
+					Spec: v1alpha1.OIDCProviderConfigSpec{Issuer: "https://bad-secret-issuer.com"},
+					Status: v1alpha1.OIDCProviderConfigStatus{
+						JWKSSecret: corev1.LocalObjectReference{Name: "bad-jwks-secret-name"},
+					},
+				}
+				oidcProviderConfigWithGoodSecret1 := &v1alpha1.OIDCProviderConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "good-secret-oidcproviderconfig1",
+						Namespace: installedInNamespace,
+					},
+					Spec: v1alpha1.OIDCProviderConfigSpec{Issuer: "https://issuer-with-good-secret1.com"},
+					Status: v1alpha1.OIDCProviderConfigStatus{
+						JWKSSecret: corev1.LocalObjectReference{Name: "good-jwks-secret-name1"},
+					},
+				}
+				oidcProviderConfigWithGoodSecret2 := &v1alpha1.OIDCProviderConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "good-secret-oidcproviderconfig2",
+						Namespace: installedInNamespace,
+					},
+					Spec: v1alpha1.OIDCProviderConfigSpec{Issuer: "https://issuer-with-good-secret2.com"},
+					Status: v1alpha1.OIDCProviderConfigStatus{
+						JWKSSecret: corev1.LocalObjectReference{Name: "good-jwks-secret-name2"},
+					},
+				}
+				expectedJWK1 = string(readJWKJSON(t, "testdata/public-jwk.json"))
+				r.NotEmpty(expectedJWK1)
+				expectedJWK2 = string(readJWKJSON(t, "testdata/public-jwk2.json"))
+				r.NotEmpty(expectedJWK2)
+				goodJWKSSecret1 := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "good-jwks-secret-name1",
+						Namespace: installedInNamespace,
+					},
+					Data: map[string][]byte{
+						"activeJWK": []byte(expectedJWK1),
+						"jwks":      []byte(`{"keys": [` + expectedJWK1 + `]}`),
+					},
+				}
+				goodJWKSSecret2 := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "good-jwks-secret-name2",
+						Namespace: installedInNamespace,
+					},
+					Data: map[string][]byte{
+						"activeJWK": []byte(expectedJWK2),
+						"jwks":      []byte(`{"keys": [` + expectedJWK2 + `]}`),
+					},
+				}
+				badJWKSSecret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "bad-jwks-secret-name",
+						Namespace: installedInNamespace,
+					},
+					Data: map[string][]byte{"junk": nil},
+				}
+				r.NoError(pinnipedInformerClient.Tracker().Add(oidcProviderConfigWithoutSecret1))
+				r.NoError(pinnipedInformerClient.Tracker().Add(oidcProviderConfigWithoutSecret2))
+				r.NoError(pinnipedInformerClient.Tracker().Add(oidcProviderConfigWithBadSecret))
+				r.NoError(pinnipedInformerClient.Tracker().Add(oidcProviderConfigWithGoodSecret1))
+				r.NoError(pinnipedInformerClient.Tracker().Add(oidcProviderConfigWithGoodSecret2))
+				r.NoError(kubeInformerClient.Tracker().Add(goodJWKSSecret1))
+				r.NoError(kubeInformerClient.Tracker().Add(goodJWKSSecret2))
+				r.NoError(kubeInformerClient.Tracker().Add(badJWKSSecret))
+			})
+
+			requireJWKJSON := func(expectedJWKJSON string, actualJWKS *jose.JSONWebKeySet) {
+				r.NotNil(actualJWKS)
+				r.Len(actualJWKS.Keys, 1)
+				actualJWK := actualJWKS.Keys[0]
+				actualJWKJSON, err := json.Marshal(actualJWK)
+				r.NoError(err)
+				r.JSONEq(expectedJWKJSON, string(actualJWKJSON))
+			}
+
+			it("updates the issuerToJWKSSetter's map to include only the issuers that had valid JWKS", func() {
+				startInformersAndController()
+				r.NoError(controllerlib.TestSync(t, subject, *syncContext))
+
+				r.True(issuerToJWKSSetter.setIssuerToJWKSMapWasCalled)
+				r.Len(issuerToJWKSSetter.issuerToJWKSMapReceived, 2)
+
+				// the actual JWK should match the one from the test fixture that was put into the secret
+				requireJWKJSON(expectedJWK1, issuerToJWKSSetter.issuerToJWKSMapReceived["https://issuer-with-good-secret1.com"])
+				requireJWKJSON(expectedJWK2, issuerToJWKSSetter.issuerToJWKSMapReceived["https://issuer-with-good-secret2.com"])
+			})
+		})
+	}, spec.Parallel(), spec.Report(report.Terminal{}))
+}

--- a/internal/controller/supervisorconfig/jwks_writer_test.go
+++ b/internal/controller/supervisorconfig/jwks_writer_test.go
@@ -30,7 +30,7 @@ import (
 	"go.pinniped.dev/internal/testutil"
 )
 
-func TestJWKSControllerFilterSecret(t *testing.T) {
+func TestJWKSWriterControllerFilterSecret(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -150,7 +150,7 @@ func TestJWKSControllerFilterSecret(t *testing.T) {
 				0,
 			).Config().V1alpha1().OIDCProviderConfigs()
 			withInformer := testutil.NewObservableWithInformerOption()
-			_ = NewJWKSController(
+			_ = NewJWKSWriterController(
 				nil, // labels, not needed
 				nil, // kubeClient, not needed
 				nil, // pinnipedClient, not needed
@@ -170,7 +170,7 @@ func TestJWKSControllerFilterSecret(t *testing.T) {
 	}
 }
 
-func TestJWKSControllerFilterOPC(t *testing.T) {
+func TestJWKSWriterControllerFilterOPC(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -204,7 +204,7 @@ func TestJWKSControllerFilterOPC(t *testing.T) {
 				0,
 			).Config().V1alpha1().OIDCProviderConfigs()
 			withInformer := testutil.NewObservableWithInformerOption()
-			_ = NewJWKSController(
+			_ = NewJWKSWriterController(
 				nil, // labels, not needed
 				nil, // kubeClient, not needed
 				nil, // pinnipedClient, not needed
@@ -224,7 +224,7 @@ func TestJWKSControllerFilterOPC(t *testing.T) {
 	}
 }
 
-func TestJWKSControllerSync(t *testing.T) {
+func TestJWKSWriterControllerSync(t *testing.T) {
 	// We shouldn't run this test in parallel since it messes with a global function (generateKey).
 
 	const namespace = "tuna-namespace"
@@ -284,10 +284,10 @@ func TestJWKSControllerSync(t *testing.T) {
 		}
 		s.Data = make(map[string][]byte)
 		if activeJWKPath != "" {
-			s.Data["activeJWK"] = read(t, activeJWKPath)
+			s.Data["activeJWK"] = readJWKJSON(t, activeJWKPath)
 		}
 		if jwksPath != "" {
-			s.Data["jwks"] = read(t, jwksPath)
+			s.Data["jwks"] = readJWKJSON(t, jwksPath)
 		}
 		return &s
 	}
@@ -653,7 +653,7 @@ func TestJWKSControllerSync(t *testing.T) {
 				0,
 			)
 
-			c := NewJWKSController(
+			c := NewJWKSWriterController(
 				map[string]string{
 					"myLabelKey1": "myLabelValue1",
 					"myLabelKey2": "myLabelValue2",
@@ -692,7 +692,7 @@ func TestJWKSControllerSync(t *testing.T) {
 	}
 }
 
-func read(t *testing.T, path string) []byte {
+func readJWKJSON(t *testing.T, path string) []byte {
 	t.Helper()
 
 	data, err := ioutil.ReadFile(path)

--- a/internal/controller/supervisorconfig/oidcproviderconfig_watcher.go
+++ b/internal/controller/supervisorconfig/oidcproviderconfig_watcher.go
@@ -58,7 +58,7 @@ func NewOIDCProviderConfigWatcherController(
 		},
 		withInformer(
 			opcInformer,
-			pinnipedcontroller.NoOpFilter(),
+			pinnipedcontroller.MatchAnythingFilter(),
 			controllerlib.InformerOption{},
 		),
 	)

--- a/internal/controller/supervisorconfig/testdata/public-jwk2.json
+++ b/internal/controller/supervisorconfig/testdata/public-jwk2.json
@@ -1,0 +1,9 @@
+{
+  "use": "sig",
+  "kty": "EC",
+  "kid": "pinniped-supervisor-key2",
+  "crv": "P-256",
+  "alg": "ES256",
+  "x"   : "SVqB4JcUD6lsfvqMr-OKUNUphdNn64Eay60978ZlL74",
+  "y"   : "lf0u0pMj4lGAzZix5u4Cm5CMQIgMNpkwy163wtKYVKI"
+}

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -15,8 +15,8 @@ func NameAndNamespaceExactMatchFilterFactory(name, namespace string) controllerl
 	})
 }
 
-// NoOpFilter returns a controllerlib.Filter that allows all objects.
-func NoOpFilter() controllerlib.Filter {
+// MatchAnythingFilter returns a controllerlib.Filter that allows all objects.
+func MatchAnythingFilter() controllerlib.Filter {
 	return SimpleFilter(func(object metav1.Object) bool { return true })
 }
 

--- a/internal/oidc/discovery/discovery_handler.go
+++ b/internal/oidc/discovery/discovery_handler.go
@@ -39,13 +39,13 @@ type Metadata struct {
 	// ^^^ Optional ^^^
 }
 
-// New returns an http.Handler that serves an OIDC discovery endpoint.
-func New(issuerURL string) http.Handler {
+// NewHandler returns an http.Handler that serves an OIDC discovery endpoint.
+func NewHandler(issuerURL string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
 		if r.Method != http.MethodGet {
-			http.Error(w, `{"error": "Method not allowed (try GET)"}`, http.StatusMethodNotAllowed)
+			http.Error(w, `Method not allowed (try GET)`, http.StatusMethodNotAllowed)
 			return
 		}
 

--- a/internal/oidc/jwks/dynamic_jwks_provider.go
+++ b/internal/oidc/jwks/dynamic_jwks_provider.go
@@ -1,0 +1,38 @@
+// Copyright 2020 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package jwks
+
+import (
+	"sync"
+
+	"gopkg.in/square/go-jose.v2"
+)
+
+type DynamicJWKSProvider interface {
+	SetIssuerToJWKSMap(issuerToJWKSMap map[string]*jose.JSONWebKeySet)
+	GetJWKS(issuerName string) *jose.JSONWebKeySet
+}
+
+type dynamicJWKSProvider struct {
+	issuerToJWKSMap map[string]*jose.JSONWebKeySet
+	mutex           sync.RWMutex
+}
+
+func NewDynamicJWKSProvider() DynamicJWKSProvider {
+	return &dynamicJWKSProvider{
+		issuerToJWKSMap: map[string]*jose.JSONWebKeySet{},
+	}
+}
+
+func (p *dynamicJWKSProvider) SetIssuerToJWKSMap(issuerToJWKSMap map[string]*jose.JSONWebKeySet) {
+	p.mutex.Lock() // acquire a write lock
+	defer p.mutex.Unlock()
+	p.issuerToJWKSMap = issuerToJWKSMap
+}
+
+func (p *dynamicJWKSProvider) GetJWKS(issuerName string) *jose.JSONWebKeySet {
+	p.mutex.RLock() // acquire a read lock
+	defer p.mutex.RUnlock()
+	return p.issuerToJWKSMap[issuerName]
+}

--- a/internal/oidc/jwks/jwks_handler.go
+++ b/internal/oidc/jwks/jwks_handler.go
@@ -1,0 +1,33 @@
+// Copyright 2020 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package discovery provides a handler for the OIDC discovery endpoint.
+package jwks
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// NewHandler returns an http.Handler that serves an OIDC JWKS endpoint for a specific issuer.
+func NewHandler(issuerName string, provider DynamicJWKSProvider) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.Method != http.MethodGet {
+			http.Error(w, `Method not allowed (try GET)`, http.StatusMethodNotAllowed)
+			return
+		}
+
+		jwks := provider.GetJWKS(issuerName)
+
+		if jwks == nil {
+			http.Error(w, "JWKS not found for requested issuer", http.StatusNotFound)
+			return
+		}
+
+		if err := json.NewEncoder(w).Encode(&jwks); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	})
+}

--- a/internal/oidc/jwks/jwks_handler_test.go
+++ b/internal/oidc/jwks/jwks_handler_test.go
@@ -1,0 +1,112 @@
+// Copyright 2020 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package jwks
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/square/go-jose.v2"
+
+	"go.pinniped.dev/internal/here"
+)
+
+func TestJWKSEndpoint(t *testing.T) {
+	testJWKSJSONString := here.Doc(`
+		{
+		  "keys": [
+			{
+			  "use": "sig",
+			  "kty": "EC",
+			  "kid": "pinniped-supervisor-key",
+			  "crv": "P-256",
+			  "alg": "ES256",
+			  "x": "awmmj6CIMhSoJyfsqH7sekbTeY72GGPLEy16tPWVz2U",
+			  "y": "FcMh06uXLaq9b2MOixlLVidUkycO1u7IHOkrTi7N0aw"
+			}
+		  ]
+		}
+	`)
+
+	tests := []struct {
+		name string
+
+		issuer   string
+		provider DynamicJWKSProvider
+		method   string
+		path     string
+
+		wantStatus         int
+		wantContentType    string
+		wantBodyJSONString string
+		wantBodyString     string
+	}{
+		{
+			name:               "happy path",
+			issuer:             "https://some-issuer.com/some/path",
+			provider:           newDynamicJWKSProvider(t, "https://some-issuer.com/some/path", testJWKSJSONString),
+			method:             http.MethodGet,
+			path:               "/some/path",
+			wantStatus:         http.StatusOK,
+			wantContentType:    "application/json",
+			wantBodyJSONString: testJWKSJSONString,
+		},
+		{
+			name:            "bad method",
+			issuer:          "https://some-issuer.com",
+			provider:        newDynamicJWKSProvider(t, "https://some-issuer.com", testJWKSJSONString),
+			method:          http.MethodPost,
+			path:            "/some/path",
+			wantStatus:      http.StatusMethodNotAllowed,
+			wantContentType: "text/plain; charset=utf-8",
+			wantBodyString:  "Method not allowed (try GET)\n",
+		},
+		{
+			name:            "no JWKS found in provider's cache for this issuer",
+			issuer:          "https://some-issuer.com",
+			provider:        newDynamicJWKSProvider(t, "https://some-other-unrelated-issuer.com", testJWKSJSONString),
+			method:          http.MethodGet,
+			path:            "/some/path",
+			wantStatus:      http.StatusNotFound,
+			wantContentType: "text/plain; charset=utf-8",
+			wantBodyString:  "JWKS not found for requested issuer\n",
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			handler := NewHandler(test.issuer, test.provider)
+			req := httptest.NewRequest(test.method, test.path, nil)
+			rsp := httptest.NewRecorder()
+			handler.ServeHTTP(rsp, req)
+
+			require.Equal(t, test.wantStatus, rsp.Code)
+
+			require.Equal(t, test.wantContentType, rsp.Header().Get("Content-Type"))
+
+			if test.wantBodyJSONString != "" {
+				require.JSONEq(t, test.wantBodyJSONString, rsp.Body.String())
+			}
+
+			if test.wantBodyString != "" {
+				require.Equal(t, test.wantBodyString, rsp.Body.String())
+			}
+		})
+	}
+}
+
+func newDynamicJWKSProvider(t *testing.T, issuer string, jwksJSON string) DynamicJWKSProvider {
+	t.Helper()
+	jwksProvider := NewDynamicJWKSProvider()
+	var keySet jose.JSONWebKeySet
+	err := json.Unmarshal([]byte(jwksJSON), &keySet)
+	require.NoError(t, err)
+	jwksProvider.SetIssuerToJWKSMap(map[string]*jose.JSONWebKeySet{
+		issuer: &keySet,
+	})
+	return jwksProvider
+}


### PR DESCRIPTION
- Dynamically create and destroy JWKS endpoints for each OIDCProviderConfig
- Dynamically serve the most recent version of the JWKS associated with each OIDCProviderConfig

**Release note**:

```release-note
Support OIDC Discovery JWKS Endpoints for each issuer defined by an OIDCProviderConfig
```
