### PR TITLE
Add some verbose logging to TestCLILoginOIDC.

### DIFF
--- a/test/integration/cli_test.go
+++ b/test/integration/cli_test.go
@@ -208,7 +208,7 @@ func TestCLILoginOIDC(t *testing.T) {
 			}
 		}()
 
-		reader := bufio.NewReader(stderr)
+		reader := bufio.NewReader(library.NewLoggerReader(t, "stderr", stderr))
 		line, err := reader.ReadString('\n')
 		if err != nil {
 			return fmt.Errorf("could not read login URL line from stderr: %w", err)
@@ -233,7 +233,7 @@ func TestCLILoginOIDC(t *testing.T) {
 				err = fmt.Errorf("stdout stream closed with error: %w", closeErr)
 			}
 		}()
-		reader := bufio.NewReader(stdout)
+		reader := bufio.NewReader(library.NewLoggerReader(t, "stdout", stdout))
 		var out clientauthenticationv1beta1.ExecCredential
 		if err := json.NewDecoder(reader).Decode(&out); err != nil {
 			return fmt.Errorf("could not read ExecCredential from stdout: %w", err)

--- a/test/library/iotest.go
+++ b/test/library/iotest.go
@@ -1,0 +1,43 @@
+// Copyright 2020 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package library
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"testing"
+)
+
+// NewLoggerReader wraps an io.Reader to log its input and output. It also performs some heuristic token masking.
+func NewLoggerReader(t *testing.T, name string, reader io.Reader) io.Reader {
+	t.Helper()
+	return &testlogReader{t: t, name: name, r: reader}
+}
+
+type testlogReader struct {
+	t    *testing.T
+	name string
+	r    io.Reader
+}
+
+func (l *testlogReader) Read(p []byte) (n int, err error) {
+	l.t.Helper()
+	n, err = l.r.Read(p)
+	if err != nil {
+		l.t.Logf("%s > %q: %v", l.name, maskTokens(p[0:n]), err)
+	} else {
+		l.t.Logf("%s > %q", l.name, maskTokens(p[0:n]))
+	}
+	return
+}
+
+//nolint: gochecknoglobals
+var tokenLike = regexp.MustCompile(`(?mi)[a-zA-Z0-9._-]{30,}|[a-zA-Z0-9]{20,}`)
+
+func maskTokens(in []byte) string {
+	return tokenLike.ReplaceAllStringFunc(string(in), func(t string) string {
+		return fmt.Sprintf("[...%d bytes...]", len(t))
+	})
+}


### PR DESCRIPTION
Adds some additional debug logging to the `TestCLILoginOIDC` test, which has been failing in certain environments in a way that is hard to diagnose.

Example output:
```
=== RUN TestCLILoginOIDC
cli_test.go:156: opening browser driver
cli_test.go:172: building CLI binary
cli_test.go:179: starting CLI subprocess
cli_test.go:246: waiting for CLI to output login URL
bufio.go:101: stderr > "Please log in: http://127.0.0.1:12346/dex/auth?access_type=offline&client_id=pinniped-cli&code_challenge=[...43 bytes...]&code_challenge_method=S256&nonce=[...32 bytes...]&redirect_uri=http%3A%2F%2F127.0.0.1%3A48095%2Fcallback&response_type=code&scope=email+offline_access+openid+profile&state=[...32 bytes...]\n"
cli_test.go:253: navigating to login page
cli_test.go:257: waiting for redirect to Dex login page
cli_test.go:264: logging into Dex
cli_test.go:270: waiting for redirect to localhost callback
cli_test.go:276: verifying success page
cli_test.go:283: waiting for CLI to output ExecCredential JSON
bufio.go:227: stdout > "{\"kind\":\"ExecCredential\",\"apiVersion\":\"client.authentication.k8s.io/v1beta1\",\"spec\":{},\"status\":{\"expirationTimestamp\":\"2020-10-23T15:48:40Z\",\"token\":\"[...834 bytes...]\"}}\n"
buffer.go:204: stdout > "": EOF
buffer.go:204: stderr > "": EOF
cli_test.go:292: validating ExecCredential
cli_test.go:314: starting second CLI subprocess to test session caching
cli_test.go:327: validating second ExecCredential
cli_test.go:194: CLI subprocess exited with code 0
--- PASS: TestCLILoginOIDC (6.73s)
```

**Release note**:

```release-note
NONE
```
