### PR TITLE
Fix a timeout in TestCLILoginOIDC that was accidentally shortened.

### DIFF
--- a/test/integration/cli_test.go
+++ b/test/integration/cli_test.go
@@ -146,7 +146,7 @@ func getLoginProvider(t *testing.T) *loginProviderPatterns {
 func TestCLILoginOIDC(t *testing.T) {
 	env := library.IntegrationEnv(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
 	// Find the login CSS selectors for the test issuer, or fail fast.


### PR DESCRIPTION
Increases the timeout for the `TestCLILoginOIDC` back to a nice long value suitable for our (sometimes) slow CI runners.

This regression was accidentally committed as part of #165 (in 0adbb5234e16b5bc4108fd61fddc3d372cb9925f).

**Release note**:

```release-note
NONE
```
