### PR TITLE
Promote the `pinniped login` command out of alpha.

### DIFF
--- a/cmd/pinniped/cmd/login.go
+++ b/cmd/pinniped/cmd/login.go
@@ -17,5 +17,5 @@ var loginCmd = &cobra.Command{
 
 //nolint: gochecknoinits
 func init() {
-	alphaCmd.AddCommand(loginCmd)
+	rootCmd.AddCommand(loginCmd)
 }

--- a/test/integration/cli_test.go
+++ b/test/integration/cli_test.go
@@ -395,7 +395,7 @@ func spawnTestGoroutine(t *testing.T, f func() error) {
 
 func oidcLoginCommand(ctx context.Context, t *testing.T, pinnipedExe string, sessionCachePath string) *exec.Cmd {
 	env := library.IntegrationEnv(t)
-	return exec.CommandContext(ctx, pinnipedExe, "alpha", "login", "oidc",
+	return exec.CommandContext(ctx, pinnipedExe, "login", "oidc",
 		"--issuer", env.OIDCUpstream.Issuer,
 		"--client-id", env.OIDCUpstream.ClientID,
 		"--listen-port", strconv.Itoa(env.OIDCUpstream.LocalhostPort),


### PR DESCRIPTION
This change promote the `pinniped login` command out of alpha. This was hidden behind a `pinniped alpha` hidden subcommand, but we're comfortable enough with the CLI flag interface now to promote it.

The new subcommand for OIDC login is:
```cmd
$ pinniped login oidc --issuer [...] --client-id [...]
```

**Release note**:

```release-note
Promotes the `pinniped login oidc` command out of hidden alpha.
```
