### PR TITLE
Do codegen across all version in parallel.

### DIFF
--- a/hack/update.sh
+++ b/hack/update.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 # Generate code.
-xargs "$ROOT/hack/lib/update-codegen.sh" < "${ROOT}/hack/lib/kube-versions.txt"
+xargs -n 1 -P 8 "$ROOT/hack/lib/update-codegen.sh" < "${ROOT}/hack/lib/kube-versions.txt"
 
 # Copy each CRD yaml to the app which should cause it to be installed.
 cp "$ROOT"/generated/1.19/crds/*oidcproviderconfigs.yaml "$ROOT/deploy/supervisor"


### PR DESCRIPTION
This only matters for local development, since we don't use this script directly in CI. Makes the full codegen ste take ~90s on my laptop.

**Release note**:

```release-note
NONE
```
