### PR TITLE
Add CPU/memory limits to our deployments

### DIFF
--- a/deploy/concierge/deployment.yaml
+++ b/deploy/concierge/deployment.yaml
@@ -102,6 +102,8 @@ spec:
           resources:
             requests:
               memory: "128Mi"
+            limits:
+              memory: "128Mi"
           args:
             - --config=/etc/config/pinniped.yaml
             - --downward-api-path=/etc/podinfo

--- a/deploy/concierge/deployment.yaml
+++ b/deploy/concierge/deployment.yaml
@@ -101,8 +101,10 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
             requests:
+              cpu: "100m"
               memory: "128Mi"
             limits:
+              cpu: "100m"
               memory: "128Mi"
           args:
             - --config=/etc/config/pinniped.yaml

--- a/deploy/supervisor/deployment.yaml
+++ b/deploy/supervisor/deployment.yaml
@@ -80,8 +80,10 @@ spec:
             - /etc/config/pinniped.yaml
           resources:
             requests:
+              cpu: "100m"
               memory: "128Mi"
             limits:
+              cpu: "100m"
               memory: "128Mi"
           volumeMounts:
             - name: config-volume

--- a/deploy/supervisor/deployment.yaml
+++ b/deploy/supervisor/deployment.yaml
@@ -81,6 +81,8 @@ spec:
           resources:
             requests:
               memory: "128Mi"
+            limits:
+              memory: "128Mi"
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config


### PR DESCRIPTION
This is the beginning of a change to add cpu/memory limits to our pods.
We are doing this because some consumers require this, and it is generally
a good practice.

The limits == requests for "Guaranteed" QoS.

**Release note**:

```release-note
Add CPU and memory limits to the deployments because some clusters might require them to be present.
```
