### PR TITLE
Add Netlify configs for extra redirect domains.

### DIFF
--- a/site/redirects/get.pinniped.dev/netlify.toml
+++ b/site/redirects/get.pinniped.dev/netlify.toml
@@ -1,0 +1,12 @@
+
+[[redirects]]
+  from = "/latest/*"
+  to = "https://github.com/vmware-tanzu/pinniped/releases/download/v0.2.0/:splat"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/*"
+  to = "https://github.com/vmware-tanzu/pinniped/releases/download/:splat"
+  status = 302
+  force = true

--- a/site/redirects/go.pinniped.dev/index.html
+++ b/site/redirects/go.pinniped.dev/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>go.pinniped.dev/</title>
+<meta name="go-import" content="go.pinniped.dev git https://github.com/vmware-tanzu/pinniped">
+<meta name="go-source" content="go.pinniped.dev https://github.com/vmware-tanzu/pinniped https://github.com/vmware-tanzu/pinniped/tree/main{/dir} https://github.com/vmware-tanzu/pinniped/blob/main{/dir}/{file}#L{line}">
+<style>
+* { font-family: sans-serif; }
+body { margin-top: 0; }
+.content { display: inline-block; }
+code { display: block; font-family: monospace; font-size: 1em; background-color: #d5d5d5; padding: 1em; margin-bottom: 16px; }
+ul { margin-top: 16px; margin-bottom: 16px; }
+</style>
+</head>
+<body>
+<div class="content">
+<h2>go.pinniped.dev/</h2>
+<code>go get go.pinniped.dev/</code>
+<code>import "go.pinniped.dev/"</code>
+Home: <a href="https://godoc.org/go.pinniped.dev/">https://godoc.org/go.pinniped.dev/</a><br/>
+Source: <a href="https://github.com/vmware-tanzu/pinniped">https://github.com/vmware-tanzu/pinniped</a><br/>
+</div>
+</body>
+</html>

--- a/site/redirects/go.pinniped.dev/netlify.toml
+++ b/site/redirects/go.pinniped.dev/netlify.toml
@@ -1,0 +1,35 @@
+[[redirects]]
+  from = "/community"
+  to = "https://github.com/vmware-tanzu/pinniped/blob/main/CONTRIBUTING.md#meeting-with-the-maintainers"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/community/zoom"
+  to = "https://vmware.zoom.us/j/94638309756?pwd=V3NvRXJIdDg5QVc0TUdFM2dYRzgrUT09"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/community/agenda"
+  to = "https://docs.google.com/document/d/1qYA35wZV-6bxcH5375vOnIGkNBo7e4OROgsV4Sj8WjQ/edit?usp=sharing"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/community/slack"
+  to = "https://kubernetes.slack.com/archives/C01BW364RJA"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/community/group"
+  to = "https://groups.google.com/forum/#!forum/project-pinniped"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200
+  force = true


### PR DESCRIPTION
These are extra Netlify sites that we use primarily to serve redirects/ancillary content:

- `go.pinniped.dev` is used to serve our Go [vanity import](https://sagikazarmark.hu/blog/vanity-import-paths-in-go/) paths as well as some redirects under `/community/` for things like our Slack and community meeting pages.

- `get.pinniped.dev` is used to serve our release artifacts so they're easier to use with `kubectl apply -f [...]`. 

**Release note**:

```release-note
NONE
```
