### PR TITLE
Fix some links on the community page.

### DIFF
--- a/site/config.yaml
+++ b/site/config.yaml
@@ -6,6 +6,7 @@ params:
   twitter_url: "https://twitter.com/projectpinniped"
   github_url: "https://github.com/vmware-tanzu/pinniped"
   slack_url: "https://kubernetes.slack.com/messages/pinniped"
+  community_url: "https://go.pinniped.dev/community"
 pygmentsCodefences: true
 pygmentsStyle: "pygments"
 markup:

--- a/site/content/community/_index.html
+++ b/site/content/community/_index.html
@@ -1,5 +1,5 @@
 ---
-title: ""
+title: "Pinniped Community"
 layout: section
 ---
 
@@ -13,28 +13,28 @@ layout: section
     <div class="grid three">
         <div class="col">
             <div class="icon">
-                <img src="/img/github-image.svg" />
+                <a href="{{< param "github_url" >}}"><img src="/img/github-image.svg" /></a>
             </div>
             <div class="content">
-                <h3><a href="{{ .Site.Params.github_url }}">Check out Github</a></h3>
+                <h3><a href="{{< param "github_url" >}}">Check out Github</a></h3>
                 <p>Head over to our git repo and check out the discussions and issues sections.</p>
             </div>
         </div>
         <div class="col">
             <div class="icon">
-                <img src="/img/slack.svg" />
+                <a href="{{< param "slack_url" >}}"><img src="/img/slack.svg" /></a>
             </div>
             <div class="content">
-                <h3><a href="{{ .Site.Params.slack_url }}">Chat with us on our Slack channel</a></h3>
+                <h3><a href="{{< param "slack_url" >}}">Chat with us on our Slack channel</a></h3>
                 <p>Chat with us on our Kubernetes Slack channel #pinniped</p>
             </div>
         </div>
         <div class="col">
             <div class="icon">
-                <img src="/img/calendar.svg" />
+                <a href="{{< param "community_url" >}}"><img src="/img/calendar.svg" /></a>
             </div>
             <div class="content">
-                <h3><a href="#">Join the Meetings</a></h3>
+                <h3><a href="{{< param "community_url" >}}">Join the Meetings</a></h3>
                 <p>Join the Pinniped Community Meetings every 1st and 3rd Thursday</p>
             </div>
         </div>

--- a/site/redirects/go.pinniped.dev/netlify.toml
+++ b/site/redirects/go.pinniped.dev/netlify.toml
@@ -18,7 +18,7 @@
 
 [[redirects]]
   from = "/community/slack"
-  to = "https://kubernetes.slack.com/archives/C01BW364RJA"
+  to = "https://kubernetes.slack.com/messages/pinniped"
   status = 302
   force = true
 


### PR DESCRIPTION
Fixes a few links on the new community page of the website, gives it a title, and updates our `go.pinniped.dev/community/slack` redirect to a nicer URL.

**Release note**:

```release-note
NONE
```
