### PR TITLE
Put all of our APIs into a "pinniped" category, and never use "all".

### DIFF
--- a/apis/concierge/authentication/v1alpha1/types_webhook.go.tmpl
+++ b/apis/concierge/authentication/v1alpha1/types_webhook.go.tmpl
@@ -30,7 +30,7 @@ type WebhookAuthenticatorSpec struct {
 // WebhookAuthenticator describes the configuration of a webhook authenticator.
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:categories=all;authenticator;authenticators
+// +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators
 // +kubebuilder:printcolumn:name="Endpoint",type=string,JSONPath=`.spec.endpoint`
 type WebhookAuthenticator struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/concierge/config/v1alpha1/types_credentialissuer.go.tmpl
+++ b/apis/concierge/config/v1alpha1/types_credentialissuer.go.tmpl
@@ -68,7 +68,7 @@ type CredentialIssuerStrategy struct {
 // Describes the configuration status of a Pinniped credential issuer.
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
+// +kubebuilder:resource:categories=pinniped
 type CredentialIssuer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -79,7 +79,6 @@ type CredentialIssuer struct {
 
 // List of CredentialIssuer objects.
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
 type CredentialIssuerList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/apis/supervisor/config/v1alpha1/types_oidcprovider.go.tmpl
+++ b/apis/supervisor/config/v1alpha1/types_oidcprovider.go.tmpl
@@ -86,6 +86,7 @@ type OIDCProviderStatus struct {
 // OIDCProvider describes the configuration of an OIDC provider.
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:resource:categories=pinniped
 type OIDCProvider struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/deploy/concierge/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
+++ b/deploy/concierge/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
@@ -11,9 +11,9 @@ spec:
   group: authentication.concierge.pinniped.dev
   names:
     categories:
-    - all
-    - authenticator
-    - authenticators
+    - pinniped
+    - pinniped-authenticator
+    - pinniped-authenticators
     kind: WebhookAuthenticator
     listKind: WebhookAuthenticatorList
     plural: webhookauthenticators

--- a/deploy/concierge/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/deploy/concierge/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   group: config.concierge.pinniped.dev
   names:
+    categories:
+    - pinniped
     kind: CredentialIssuer
     listKind: CredentialIssuerList
     plural: credentialissuers
@@ -19,6 +21,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: Describes the configuration status of a Pinniped credential issuer.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/deploy/supervisor/config.supervisor.pinniped.dev_oidcproviders.yaml
+++ b/deploy/supervisor/config.supervisor.pinniped.dev_oidcproviders.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   group: config.supervisor.pinniped.dev
   names:
+    categories:
+    - pinniped
     kind: OIDCProvider
     listKind: OIDCProviderList
     plural: oidcproviders

--- a/generated/1.17/README.adoc
+++ b/generated/1.17/README.adoc
@@ -125,7 +125,7 @@ Package v1alpha1 is the v1alpha1 version of the Pinniped concierge configuration
 [id="{anchor_prefix}-go-pinniped-dev-generated-1-17-apis-concierge-config-v1alpha1-credentialissuer"]
 ==== CredentialIssuer 
 
-
+Describes the configuration status of a Pinniped credential issuer.
 
 .Appears In:
 ****

--- a/generated/1.17/apis/concierge/authentication/v1alpha1/types_webhook.go
+++ b/generated/1.17/apis/concierge/authentication/v1alpha1/types_webhook.go
@@ -30,7 +30,7 @@ type WebhookAuthenticatorSpec struct {
 // WebhookAuthenticator describes the configuration of a webhook authenticator.
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:categories=all;authenticator;authenticators
+// +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators
 // +kubebuilder:printcolumn:name="Endpoint",type=string,JSONPath=`.spec.endpoint`
 type WebhookAuthenticator struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/generated/1.17/apis/concierge/config/v1alpha1/types_credentialissuer.go
+++ b/generated/1.17/apis/concierge/config/v1alpha1/types_credentialissuer.go
@@ -68,7 +68,7 @@ type CredentialIssuerStrategy struct {
 // Describes the configuration status of a Pinniped credential issuer.
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
+// +kubebuilder:resource:categories=pinniped
 type CredentialIssuer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -79,7 +79,6 @@ type CredentialIssuer struct {
 
 // List of CredentialIssuer objects.
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
 type CredentialIssuerList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/generated/1.17/apis/supervisor/config/v1alpha1/types_oidcprovider.go
+++ b/generated/1.17/apis/supervisor/config/v1alpha1/types_oidcprovider.go
@@ -86,6 +86,7 @@ type OIDCProviderStatus struct {
 // OIDCProvider describes the configuration of an OIDC provider.
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:resource:categories=pinniped
 type OIDCProvider struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/generated/1.17/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
+++ b/generated/1.17/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
@@ -11,9 +11,9 @@ spec:
   group: authentication.concierge.pinniped.dev
   names:
     categories:
-    - all
-    - authenticator
-    - authenticators
+    - pinniped
+    - pinniped-authenticator
+    - pinniped-authenticators
     kind: WebhookAuthenticator
     listKind: WebhookAuthenticatorList
     plural: webhookauthenticators

--- a/generated/1.17/crds/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/generated/1.17/crds/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   group: config.concierge.pinniped.dev
   names:
+    categories:
+    - pinniped
     kind: CredentialIssuer
     listKind: CredentialIssuerList
     plural: credentialissuers
@@ -19,6 +21,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: Describes the configuration status of a Pinniped credential issuer.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/generated/1.17/crds/config.supervisor.pinniped.dev_oidcproviders.yaml
+++ b/generated/1.17/crds/config.supervisor.pinniped.dev_oidcproviders.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   group: config.supervisor.pinniped.dev
   names:
+    categories:
+    - pinniped
     kind: OIDCProvider
     listKind: OIDCProviderList
     plural: oidcproviders

--- a/generated/1.18/README.adoc
+++ b/generated/1.18/README.adoc
@@ -125,7 +125,7 @@ Package v1alpha1 is the v1alpha1 version of the Pinniped concierge configuration
 [id="{anchor_prefix}-go-pinniped-dev-generated-1-18-apis-concierge-config-v1alpha1-credentialissuer"]
 ==== CredentialIssuer 
 
-
+Describes the configuration status of a Pinniped credential issuer.
 
 .Appears In:
 ****

--- a/generated/1.18/apis/concierge/authentication/v1alpha1/types_webhook.go
+++ b/generated/1.18/apis/concierge/authentication/v1alpha1/types_webhook.go
@@ -30,7 +30,7 @@ type WebhookAuthenticatorSpec struct {
 // WebhookAuthenticator describes the configuration of a webhook authenticator.
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:categories=all;authenticator;authenticators
+// +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators
 // +kubebuilder:printcolumn:name="Endpoint",type=string,JSONPath=`.spec.endpoint`
 type WebhookAuthenticator struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/generated/1.18/apis/concierge/config/v1alpha1/types_credentialissuer.go
+++ b/generated/1.18/apis/concierge/config/v1alpha1/types_credentialissuer.go
@@ -68,7 +68,7 @@ type CredentialIssuerStrategy struct {
 // Describes the configuration status of a Pinniped credential issuer.
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
+// +kubebuilder:resource:categories=pinniped
 type CredentialIssuer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -79,7 +79,6 @@ type CredentialIssuer struct {
 
 // List of CredentialIssuer objects.
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
 type CredentialIssuerList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/generated/1.18/apis/supervisor/config/v1alpha1/types_oidcprovider.go
+++ b/generated/1.18/apis/supervisor/config/v1alpha1/types_oidcprovider.go
@@ -86,6 +86,7 @@ type OIDCProviderStatus struct {
 // OIDCProvider describes the configuration of an OIDC provider.
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:resource:categories=pinniped
 type OIDCProvider struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/generated/1.18/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
+++ b/generated/1.18/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
@@ -11,9 +11,9 @@ spec:
   group: authentication.concierge.pinniped.dev
   names:
     categories:
-    - all
-    - authenticator
-    - authenticators
+    - pinniped
+    - pinniped-authenticator
+    - pinniped-authenticators
     kind: WebhookAuthenticator
     listKind: WebhookAuthenticatorList
     plural: webhookauthenticators

--- a/generated/1.18/crds/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/generated/1.18/crds/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   group: config.concierge.pinniped.dev
   names:
+    categories:
+    - pinniped
     kind: CredentialIssuer
     listKind: CredentialIssuerList
     plural: credentialissuers
@@ -19,6 +21,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: Describes the configuration status of a Pinniped credential issuer.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/generated/1.18/crds/config.supervisor.pinniped.dev_oidcproviders.yaml
+++ b/generated/1.18/crds/config.supervisor.pinniped.dev_oidcproviders.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   group: config.supervisor.pinniped.dev
   names:
+    categories:
+    - pinniped
     kind: OIDCProvider
     listKind: OIDCProviderList
     plural: oidcproviders

--- a/generated/1.19/README.adoc
+++ b/generated/1.19/README.adoc
@@ -125,7 +125,7 @@ Package v1alpha1 is the v1alpha1 version of the Pinniped concierge configuration
 [id="{anchor_prefix}-go-pinniped-dev-generated-1-19-apis-concierge-config-v1alpha1-credentialissuer"]
 ==== CredentialIssuer 
 
-
+Describes the configuration status of a Pinniped credential issuer.
 
 .Appears In:
 ****

--- a/generated/1.19/apis/concierge/authentication/v1alpha1/types_webhook.go
+++ b/generated/1.19/apis/concierge/authentication/v1alpha1/types_webhook.go
@@ -30,7 +30,7 @@ type WebhookAuthenticatorSpec struct {
 // WebhookAuthenticator describes the configuration of a webhook authenticator.
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:categories=all;authenticator;authenticators
+// +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators
 // +kubebuilder:printcolumn:name="Endpoint",type=string,JSONPath=`.spec.endpoint`
 type WebhookAuthenticator struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/generated/1.19/apis/concierge/config/v1alpha1/types_credentialissuer.go
+++ b/generated/1.19/apis/concierge/config/v1alpha1/types_credentialissuer.go
@@ -68,7 +68,7 @@ type CredentialIssuerStrategy struct {
 // Describes the configuration status of a Pinniped credential issuer.
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
+// +kubebuilder:resource:categories=pinniped
 type CredentialIssuer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -79,7 +79,6 @@ type CredentialIssuer struct {
 
 // List of CredentialIssuer objects.
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
 type CredentialIssuerList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/generated/1.19/apis/supervisor/config/v1alpha1/types_oidcprovider.go
+++ b/generated/1.19/apis/supervisor/config/v1alpha1/types_oidcprovider.go
@@ -86,6 +86,7 @@ type OIDCProviderStatus struct {
 // OIDCProvider describes the configuration of an OIDC provider.
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:resource:categories=pinniped
 type OIDCProvider struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/generated/1.19/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
+++ b/generated/1.19/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
@@ -11,9 +11,9 @@ spec:
   group: authentication.concierge.pinniped.dev
   names:
     categories:
-    - all
-    - authenticator
-    - authenticators
+    - pinniped
+    - pinniped-authenticator
+    - pinniped-authenticators
     kind: WebhookAuthenticator
     listKind: WebhookAuthenticatorList
     plural: webhookauthenticators

--- a/generated/1.19/crds/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/generated/1.19/crds/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   group: config.concierge.pinniped.dev
   names:
+    categories:
+    - pinniped
     kind: CredentialIssuer
     listKind: CredentialIssuerList
     plural: credentialissuers
@@ -19,6 +21,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: Describes the configuration status of a Pinniped credential issuer.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/generated/1.19/crds/config.supervisor.pinniped.dev_oidcproviders.yaml
+++ b/generated/1.19/crds/config.supervisor.pinniped.dev_oidcproviders.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   group: config.supervisor.pinniped.dev
   names:
+    categories:
+    - pinniped
     kind: OIDCProvider
     listKind: OIDCProviderList
     plural: oidcproviders

--- a/test/integration/kube_api_discovery_test.go
+++ b/test/integration/kube_api_discovery_test.go
@@ -163,6 +163,18 @@ func TestGetAPIResourceList(t *testing.T) {
 		}
 	})
 
+	t.Run("Pinniped resources do not have short names", func(t *testing.T) {
+		t.Parallel()
+		for _, r := range resources {
+			if !strings.Contains(r.GroupVersion, "pinniped.dev") {
+				continue
+			}
+			for _, a := range r.APIResources {
+				assert.Empty(t, a.ShortNames, "expected resource %q not to have any short names", a.Name)
+			}
+		}
+	})
+
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.group.Name, func(t *testing.T) {

--- a/test/integration/kube_api_discovery_test.go
+++ b/test/integration/kube_api_discovery_test.go
@@ -4,8 +4,10 @@
 package integration
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -45,11 +47,6 @@ func TestGetAPIResourceList(t *testing.T) {
 						Kind:       "TokenCredentialRequest",
 						Verbs:      []string{"create"},
 						Namespaced: true,
-
-						// This is currently an empty string in the response; maybe it should not be
-						// empty? Seems like no harm in keeping it like this for now, but feel free
-						// to update in the future if there is a compelling reason to do so.
-						SingularName: "",
 					},
 				},
 			},
@@ -76,6 +73,7 @@ func TestGetAPIResourceList(t *testing.T) {
 						Namespaced:   true,
 						Kind:         "OIDCProvider",
 						Verbs:        []string{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
+						Categories:   []string{"pinniped"},
 					},
 				},
 			},
@@ -102,6 +100,7 @@ func TestGetAPIResourceList(t *testing.T) {
 						Namespaced:   true,
 						Kind:         "CredentialIssuer",
 						Verbs:        []string{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
+						Categories:   []string{"pinniped"},
 					},
 				},
 			},
@@ -128,16 +127,46 @@ func TestGetAPIResourceList(t *testing.T) {
 						Namespaced:   true,
 						Kind:         "WebhookAuthenticator",
 						Verbs:        []string{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
-						Categories:   []string{"all", "authenticator", "authenticators"},
+						Categories:   []string{"pinniped", "pinniped-authenticator", "pinniped-authenticators"},
 					},
 				},
 			},
 		},
 	}
 
+	t.Run("every Pinniped API has explicit test coverage", func(t *testing.T) {
+		t.Parallel()
+		testedGroups := map[string]bool{}
+		for _, tt := range tests {
+			testedGroups[tt.group.Name] = true
+		}
+		for _, g := range groups {
+			if !strings.Contains(g.Name, "pinniped.dev") {
+				continue
+			}
+			assert.Truef(t, testedGroups[g.Name], "expected group %q to have assertions defined", g.Name)
+		}
+	})
+
+	t.Run("every API categorized appropriately", func(t *testing.T) {
+		t.Parallel()
+		for _, r := range resources {
+			if !strings.Contains(r.GroupVersion, "pinniped.dev") {
+				continue
+			}
+			for _, a := range r.APIResources {
+				if a.Kind != "TokenCredentialRequest" {
+					assert.Containsf(t, a.Categories, "pinniped", "expected resource %q to be in the 'pinniped' category", a.Name)
+				}
+				assert.NotContainsf(t, a.Categories, "all", "expected resource %q not to be in the 'all' category", a.Name)
+			}
+		}
+	})
+
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.group.Name, func(t *testing.T) {
+			t.Parallel()
 			require.Contains(t, groups, &tt.group)
 
 			for groupVersion, expectedResources := range tt.resourceByVersion {


### PR DESCRIPTION
We want to have our APIs respond to `kubectl get pinniped`, and we shouldn't use `all` because we don't think most average users should have permission to see our API types, which means if we put our types there, they would get an error from `kubectl get all`.

I also added some tests to assert these properties on all `*.pinniped.dev` API resources.

**Release note**:

```release-note
Adjusted our Kubernetes API categories so `kubectl get pinniped` returns all Pinniped-related objects.
```
