### PR TITLE
Reduce client cert TTL back to 5 mins

### DIFF
--- a/internal/certauthority/certauthority.go
+++ b/internal/certauthority/certauthority.go
@@ -27,7 +27,7 @@ import (
 // This could certainly be made configurable by an installer of pinniped, but we
 // will see if we can save adding a configuration knob with a reasonable default
 // here.
-const certBackdate = 5 * time.Minute
+const certBackdate = 10 * time.Second
 
 type env struct {
 	// secure random number generators for various steps (usually crypto/rand.Reader, but broken out here for tests).

--- a/internal/certauthority/certauthority_test.go
+++ b/internal/certauthority/certauthority_test.go
@@ -94,7 +94,7 @@ func TestNew(t *testing.T) {
 	caCert, err := x509.ParseCertificate(got.caCertBytes)
 	require.NoError(t, err)
 	require.Equal(t, "Test CA", caCert.Subject.CommonName)
-	require.WithinDuration(t, now.Add(-5*time.Minute), caCert.NotBefore, 10*time.Second)
+	require.WithinDuration(t, now.Add(-10*time.Second), caCert.NotBefore, 10*time.Second)
 	require.WithinDuration(t, now.Add(time.Minute), caCert.NotAfter, 10*time.Second)
 }
 
@@ -149,7 +149,7 @@ func TestNewInternal(t *testing.T) {
 			},
 			wantCommonName: "Test CA",
 			wantNotAfter:   now.Add(time.Minute),
-			wantNotBefore:  now.Add(-5 * time.Minute),
+			wantNotBefore:  now.Add(-10 * time.Second),
 		},
 	}
 	for _, tt := range tests {

--- a/internal/registry/credentialrequest/rest.go
+++ b/internal/registry/credentialrequest/rest.go
@@ -22,7 +22,7 @@ import (
 )
 
 // clientCertificateTTL is the TTL for short-lived client certificates returned by this API.
-const clientCertificateTTL = 1 * time.Hour
+const clientCertificateTTL = 5 * time.Minute
 
 type Storage interface {
 	rest.Creater

--- a/internal/registry/credentialrequest/rest_test.go
+++ b/internal/registry/credentialrequest/rest_test.go
@@ -69,7 +69,7 @@ func TestCreate(t *testing.T) {
 					CommonName:   "test-user",
 					Organization: []string{"test-group-1", "test-group-2"}},
 				[]string{},
-				1*time.Hour,
+				5*time.Minute,
 			).Return([]byte("test-cert"), []byte("test-key"), nil)
 
 			storage := NewREST(requestAuthenticator, issuer)
@@ -81,7 +81,7 @@ func TestCreate(t *testing.T) {
 
 			expires := response.(*loginapi.TokenCredentialRequest).Status.Credential.ExpirationTimestamp
 			r.NotNil(expires)
-			r.InDelta(time.Now().Add(1*time.Hour).Unix(), expires.Unix(), 5)
+			r.InDelta(time.Now().Add(5*time.Minute).Unix(), expires.Unix(), 5)
 			response.(*loginapi.TokenCredentialRequest).Status.Credential.ExpirationTimestamp = metav1.Time{}
 
 			r.Equal(response, &loginapi.TokenCredentialRequest{

--- a/test/integration/client_test.go
+++ b/test/integration/client_test.go
@@ -78,7 +78,7 @@ func TestClient(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotNil(t, resp.Status.ExpirationTimestamp)
-	require.InDelta(t, time.Until(resp.Status.ExpirationTimestamp.Time), 1*time.Hour, float64(3*time.Minute))
+	require.InDelta(t, 5*time.Minute, time.Until(resp.Status.ExpirationTimestamp.Time), float64(time.Minute))
 
 	// Create a client using the certificate and key returned by the token exchange.
 	validClient := library.NewClientsetWithCertAndKey(t, resp.Status.ClientCertificateData, resp.Status.ClientKeyData)

--- a/test/integration/concierge_credentialrequest_test.go
+++ b/test/integration/concierge_credentialrequest_test.go
@@ -64,7 +64,7 @@ func TestSuccessfulCredentialRequest(t *testing.T) {
 	require.ElementsMatch(t, env.TestUser.ExpectedGroups, getOrganizations(t, response.Status.Credential.ClientCertificateData))
 	require.NotEmpty(t, response.Status.Credential.ClientKeyData)
 	require.NotNil(t, response.Status.Credential.ExpirationTimestamp)
-	require.InDelta(t, time.Until(response.Status.Credential.ExpirationTimestamp.Time), 1*time.Hour, float64(3*time.Minute))
+	require.InDelta(t, 5*time.Minute, time.Until(response.Status.Credential.ExpirationTimestamp.Time), float64(time.Minute))
 
 	// Create a client using the admin kubeconfig.
 	adminClient := library.NewClientset(t)


### PR DESCRIPTION
Signed-off-by: Monis Khan <mok@vmware.com>

```release-note
The token credential request API returns client certificates which are valid for only 5 minutes instead of an hour.  This is a safer duration since these certificates are not revocable.
```