### PR TITLE
Add our TokenCredentialRequest to the "pinniped" API category as well.

### DIFF
--- a/internal/registry/credentialrequest/rest.go
+++ b/internal/registry/credentialrequest/rest.go
@@ -24,13 +24,6 @@ import (
 // clientCertificateTTL is the TTL for short-lived client certificates returned by this API.
 const clientCertificateTTL = 1 * time.Hour
 
-type Storage interface {
-	rest.Creater
-	rest.NamespaceScopedStrategy
-	rest.Scoper
-	rest.Storage
-}
-
 type CertIssuer interface {
 	IssuePEM(subject pkix.Name, dnsNames []string, ttl time.Duration) ([]byte, []byte, error)
 }
@@ -51,12 +44,25 @@ type REST struct {
 	issuer        CertIssuer
 }
 
+// Assert that our *REST implements all the optional interfaces that we expect it to implement.
+var _ interface {
+	rest.Creater
+	rest.NamespaceScopedStrategy
+	rest.Scoper
+	rest.Storage
+	rest.CategoriesProvider
+} = (*REST)(nil)
+
 func (*REST) New() runtime.Object {
 	return &loginapi.TokenCredentialRequest{}
 }
 
 func (*REST) NamespaceScoped() bool {
 	return true
+}
+
+func (*REST) Categories() []string {
+	return []string{"pinniped"}
 }
 
 func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {

--- a/internal/registry/credentialrequest/rest_test.go
+++ b/internal/registry/credentialrequest/rest_test.go
@@ -31,6 +31,7 @@ func TestNew(t *testing.T) {
 	r := NewREST(nil, nil)
 	require.NotNil(t, r)
 	require.True(t, r.NamespaceScoped())
+	require.Equal(t, []string{"pinniped"}, r.Categories())
 	require.IsType(t, &loginapi.TokenCredentialRequest{}, r.New())
 }
 

--- a/test/integration/kube_api_discovery_test.go
+++ b/test/integration/kube_api_discovery_test.go
@@ -17,8 +17,7 @@ import (
 func TestGetAPIResourceList(t *testing.T) {
 	library.SkipUnlessIntegration(t)
 
-	client := library.NewConciergeClientset(t)
-
+	client := library.NewClientset(t)
 	groups, resources, err := client.Discovery().ServerGroupsAndResources()
 	require.NoError(t, err)
 
@@ -47,6 +46,7 @@ func TestGetAPIResourceList(t *testing.T) {
 						Kind:       "TokenCredentialRequest",
 						Verbs:      []string{"create"},
 						Namespaced: true,
+						Categories: []string{"pinniped"},
 					},
 				},
 			},
@@ -188,14 +188,11 @@ func TestGetAPIResourceList(t *testing.T) {
 				continue
 			}
 			for _, a := range r.APIResources {
-				assert.NotContainsf(t, a.Categories, "all", "expected resource %q not to be in the 'all' category", a.Name)
 				if strings.HasSuffix(a.Name, "/status") {
 					continue
 				}
-				if a.Kind == "TokenCredentialRequest" {
-					continue
-				}
 				assert.Containsf(t, a.Categories, "pinniped", "expected resource %q to be in the 'pinniped' category", a.Name)
+				assert.NotContainsf(t, a.Categories, "all", "expected resource %q not to be in the 'all' category", a.Name)
 			}
 		}
 	})


### PR DESCRIPTION
This is a followup to #205 to make the `TokenCredentialRequest` API follow the same rules as our CRD-based APIs. I also fixed an interface-assertion test that was intended to be there before but wasn't hooked up.

**Release note**:

```release-note
NONE
```
