### PR TITLE
Fix demo.md and updated default namespace for pinniped-concierge.

### DIFF
--- a/cmd/pinniped/cmd/get_kubeconfig.go
+++ b/cmd/pinniped/cmd/get_kubeconfig.go
@@ -52,7 +52,7 @@ type getKubeConfigCommand struct {
 func newGetKubeConfigCommand() *getKubeConfigCommand {
 	return &getKubeConfigCommand{
 		flags: getKubeConfigFlags{
-			namespace: "pinniped",
+			namespace: "pinniped-concierge",
 		},
 		getPathToSelf: os.Executable,
 		kubeClientCreator: func(restConfig *rest.Config) (pinnipedclientset.Interface, error) {

--- a/cmd/pinniped/cmd/get_kubeconfig_test.go
+++ b/cmd/pinniped/cmd/get_kubeconfig_test.go
@@ -35,7 +35,7 @@ var (
 		  -h, --help                        help for get-kubeconfig
 			  --kubeconfig string           Path to the kubeconfig file
 			  --kubeconfig-context string   Kubeconfig context override
-			  --pinniped-namespace string   Namespace in which Pinniped was installed (default "pinniped")
+			  --pinniped-namespace string   Namespace in which Pinniped was installed (default "pinniped-concierge")
 			  --token string                Credential to include in the resulting kubeconfig output (Required)
 
 		`)
@@ -66,7 +66,7 @@ var (
 		  -h, --help                        help for get-kubeconfig
 			  --kubeconfig string           Path to the kubeconfig file
 			  --kubeconfig-context string   Kubeconfig context override
-			  --pinniped-namespace string   Namespace in which Pinniped was installed (default "pinniped")
+			  --pinniped-namespace string   Namespace in which Pinniped was installed (default "pinniped-concierge")
 			  --token string                Credential to include in the resulting kubeconfig output (Required)
 		`)
 )

--- a/doc/demo.md
+++ b/doc/demo.md
@@ -108,7 +108,7 @@ as the identity provider.
      | tee /tmp/local-user-authenticator-ca-base64-encoded
    ```
 
-1. Deploy Pinniped.
+1. Deploy the Pinniped concierge.
 
    ```bash
     kubectl apply -f https://github.com/vmware-tanzu/pinniped/releases/download/$pinniped_version/install-pinniped-concierge.yaml
@@ -121,7 +121,7 @@ as the identity provider.
 1. Create a `WebhookAuthenticator` object to configure Pinniped to authenticate using local-user-authenticator.
 
     ```bash
-    cat <<EOF | kubectl create --namespace pinniped -f -
+    cat <<EOF | kubectl create --namespace pinniped-concierge -f -
     apiVersion: authentication.concierge.pinniped.dev/v1alpha1
     kind: WebhookAuthenticator
     metadata:
@@ -143,7 +143,7 @@ as the identity provider.
    allow you to authenticate as the user that you created above.
 
    ```bash
-   pinniped get-kubeconfig --token "pinny-the-seal:password123" --authenticator-type webhook --authenticator-name local-user-authenticator > /tmp/pinniped-kubeconfig
+   pinniped get-kubeconfig --pinniped-namespace pinniped-concierge --token "pinny-the-seal:password123" --authenticator-type webhook --authenticator-name local-user-authenticator > /tmp/pinniped-kubeconfig
    ```
 
    If you are using MacOS, you may get an error dialog that says
@@ -162,7 +162,7 @@ as the identity provider.
    the `pinny-the-seal` user.
 
    ```bash
-   kubectl --kubeconfig /tmp/pinniped-kubeconfig get pods -n pinniped
+   kubectl --kubeconfig /tmp/pinniped-kubeconfig get pods -n pinniped-concierge
    ```
 
    Because this user has no RBAC permissions on this cluster, the previous command
@@ -179,7 +179,7 @@ as the identity provider.
 1. Use the generated kubeconfig to issue arbitrary `kubectl` commands as the `pinny-the-seal` user.
 
    ```bash
-   kubectl --kubeconfig /tmp/pinniped-kubeconfig get pods -n pinniped
+   kubectl --kubeconfig /tmp/pinniped-kubeconfig get pods -n pinniped-concierge
    ```
 
    The user has permission to list pods, so the command succeeds this time.


### PR DESCRIPTION
I tried the new release, following the demo.md today but found it doesn't work due to the namespace change in install-pinniped-concierge.yaml. So, I've:

 - Updated doc/demo.md with required namespace (based on the assumption that install-pinniped-concierge.yaml is correct to use the new pinniped-concierge namespace)
 - Updated the default namespace for pinniped-concierge to match (though this commit may not be wanted, you may instead want to update the install file - though that's been released - not sure).

 Note that I've run lint and unit tests, but not integration tests (ran out of time around my EOD).

 **Release note**:

 ```release-note
 The default namespace used by the `pinniped get-kubeconfig` command is switched to `pinniped-concierge`.

 ```

