### PR TITLE
Refactor certificate generation for integration test Dex.

### DIFF
--- a/hack/lib/tilt/Tiltfile
+++ b/hack/lib/tilt/Tiltfile
@@ -19,35 +19,25 @@ local_resource(
 )
 
 #####################################################################################################
-# Dex
+# Test IDP (Dex + cert generation + squid proxy)
 #
 
-# Render the Dex installation manifest using ytt.
+# Render the IDP installation manifest using ytt.
 k8s_yaml(local(['ytt','--file', '../../../test/deploy/dex']))
 # Tell tilt to watch all of those files for changes.
 watch_file('../../../test/deploy/dex')
 
-# Collect all the deployed certificate issuer resources under a "cert-issuer" resource tab.
-k8s_resource(
-    workload='cert-issuer',
-    objects=[
-        # these are the objects that would otherwise appear in the "uncategorized" tab in the tilt UI
-        'cert-issuer:serviceaccount',
-        'cert-issuer:role',
-        'cert-issuer:rolebinding',
-    ],
-)
+k8s_resource(objects=['dex:namespace'], new_name='dex-ns')
+k8s_resource(workload='cert-issuer', resource_deps=['dex-ns'], objects=[
+    'cert-issuer:serviceaccount',
+    'cert-issuer:role',
+    'cert-issuer:rolebinding',
+])
+k8s_resource(workload='proxy', resource_deps=['dex-ns'])
+k8s_resource(workload='dex', resource_deps=['dex-ns', 'cert-issuer'], objects=[
+    'dex-config:configmap',
+])
 
-# Collect all the deployed Dex resources under a "dex" resource tab.
-k8s_resource(
-    workload='dex', # this is the deployment name
-    objects=[
-        # these are the objects that would otherwise appear in the "uncategorized" tab in the tilt UI
-        'dex:namespace',
-        'dex-config:configmap',
-   ],
-   resource_deps=['cert-issuer'],
-)
 
 #####################################################################################################
 # Local-user-authenticator app
@@ -198,6 +188,6 @@ k8s_resource(
 local_resource(
   'test-env',
   'TILT_MODE=yes ../../prepare-for-integration-tests.sh',
-  resource_deps=['local-user-auth', 'concierge', 'supervisor', 'dex', 'cert-issuer'],
+  resource_deps=['local-user-auth', 'concierge', 'supervisor', 'dex', 'proxy'],
   deps=['../../prepare-for-integration-tests.sh'],
 )

--- a/hack/lib/tilt/Tiltfile
+++ b/hack/lib/tilt/Tiltfile
@@ -27,6 +27,17 @@ k8s_yaml(local(['ytt','--file', '../../../test/deploy/dex']))
 # Tell tilt to watch all of those files for changes.
 watch_file('../../../test/deploy/dex')
 
+# Collect all the deployed certificate issuer resources under a "cert-issuer" resource tab.
+k8s_resource(
+    workload='cert-issuer',
+    objects=[
+        # these are the objects that would otherwise appear in the "uncategorized" tab in the tilt UI
+        'cert-issuer:serviceaccount',
+        'cert-issuer:role',
+        'cert-issuer:rolebinding',
+    ],
+)
+
 # Collect all the deployed Dex resources under a "dex" resource tab.
 k8s_resource(
     workload='dex', # this is the deployment name
@@ -35,6 +46,7 @@ k8s_resource(
         'dex:namespace',
         'dex-config:configmap',
    ],
+   resource_deps=['cert-issuer'],
 )
 
 #####################################################################################################
@@ -186,6 +198,6 @@ k8s_resource(
 local_resource(
   'test-env',
   'TILT_MODE=yes ../../prepare-for-integration-tests.sh',
-  resource_deps=['local-user-auth', 'concierge', 'supervisor'],
+  resource_deps=['local-user-auth', 'concierge', 'supervisor', 'dex', 'cert-issuer'],
   deps=['../../prepare-for-integration-tests.sh'],
 )

--- a/hack/prepare-for-integration-tests.sh
+++ b/hack/prepare-for-integration-tests.sh
@@ -268,7 +268,7 @@ fi
 #
 # Download the test CA bundle that was generated in the Dex pod.
 #
-test_ca_bundle_pem="$(kubectl exec -n dex deployment/dex -- cat /var/certs/ca.pem)"
+test_ca_bundle_pem="$(kubectl get secrets -n dex certs -o go-template='{{index .data "ca.pem" | base64decode}}')"
 
 #
 # Create the environment file

--- a/test/deploy/dex/cert-issuer.yaml
+++ b/test/deploy/dex/cert-issuer.yaml
@@ -1,0 +1,101 @@
+#! Copyright 2020 the Pinniped contributors. All Rights Reserved.
+#! SPDX-License-Identifier: Apache-2.0
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cert-issuer
+  namespace: dex
+  labels:
+    app: cert-issuer
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cert-issuer
+  namespace: dex
+  labels:
+    app: cert-issuer
+rules:
+  - apiGroups: [""]
+    resources: [secrets]
+    verbs: [create, get, patch, update, watch, delete]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cert-issuer
+  namespace: dex
+  labels:
+    app: cert-issuer
+subjects:
+  - kind: ServiceAccount
+    name: cert-issuer
+    namespace: dex
+roleRef:
+  kind: Role
+  name: cert-issuer
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cert-issuer
+  namespace: dex
+  labels:
+    app: cert-issuer
+spec:
+  template:
+    spec:
+      serviceAccountName: cert-issuer
+      initContainers:
+      - name: generate-certs
+        image: cfssl/cfssl:1.5.0
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/bash"]
+        args:
+        - -c
+        - |
+          cd /var/certs
+          cfssl print-defaults config > /tmp/cfssl-default.json
+          echo '{"CN": "Pinniped Test","hosts": [],"key": {"algo": "ecdsa","size": 256},"names": [{}]}' > /tmp/csr.json
+
+          echo "generating CA key..."
+          cfssl genkey \
+            -config /tmp/cfssl-default.json \
+            -initca /tmp/csr.json \
+            | cfssljson -bare ca
+
+          echo "generating Dex server certificate..."
+          cfssl gencert \
+            -ca ca.pem -ca-key ca-key.pem \
+            -config /tmp/cfssl-default.json \
+            -profile www \
+            -cn "dex.dex.svc.cluster.local" \
+            -hostname "dex.dex.svc.cluster.local" \
+            /tmp/csr.json \
+            | cfssljson -bare dex
+
+          chmod -R 777 /var/certs
+
+          echo "generated certificates:"
+          ls -l /var/certs
+        volumeMounts:
+        - name: certs
+          mountPath: /var/certs
+      containers:
+      - name: save-certs
+        image: bitnami/kubectl
+        command: ["/bin/bash"]
+        args:
+        - -c
+        - |
+          kubectl get secrets -n dex certs -o jsonpath='created: {.metadata.creationTimestamp}' || \
+            kubectl create secret generic certs --from-file=/var/certs
+        volumeMounts:
+        - name: certs
+          mountPath: /var/certs
+      volumes:
+      - name: certs
+        emptyDir: {}
+      restartPolicy: Never

--- a/test/deploy/dex/dex.yaml
+++ b/test/deploy/dex/dex.yaml
@@ -69,36 +69,6 @@ spec:
       annotations:
         dexConfigHash: #@ sha256.sum(yaml.encode(dexConfig()))
     spec:
-      initContainers:
-      - name: generate-certs
-        image: cfssl/cfssl:1.5.0
-        imagePullPolicy: IfNotPresent
-        command: ["/bin/bash"]
-        args:
-        - -c
-        - |
-          cd /var/certs
-          cfssl print-defaults config > /tmp/cfssl-default.json
-          echo '{"CN": "Pinniped Test","hosts": [],"key": {"algo": "ecdsa","size": 256},"names": [{}]}' > csr.json
-
-          echo "generating CA key..."
-          cfssl genkey \
-            -config /tmp/cfssl-default.json \
-            -initca csr.json \
-            | cfssljson -bare ca
-
-          echo "generating Dex server certificate..."
-          cfssl gencert \
-            -ca ca.pem -ca-key ca-key.pem \
-            -config /tmp/cfssl-default.json \
-            -profile www \
-            -cn "dex.dex.svc.cluster.local" \
-            -hostname "dex.dex.svc.cluster.local" \
-            csr.json \
-            | cfssljson -bare dex
-        volumeMounts:
-          - name: certs
-            mountPath: /var/certs
       containers:
       - name: dex
         image: quay.io/dexidp/dex:v2.10.0
@@ -121,7 +91,8 @@ spec:
         configMap:
           name: dex-config
       - name: certs
-        emptyDir: {}
+        secret:
+          secretName: certs
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Before, we did this in an init container, which meant if the Dex pod restarted we would have fresh certs, but our Tilt/bash setup didn't account for this.

Now, the certs are generated by a Job which runs once and saves the generated files into a Secret. This should be a bit more stable.

This is a test environment change only.

**Release note**:

```release-note
NONE
```
