### PR TITLE
Use `omitempty` on UpstreamOIDCProvider `spec.authorizationConfig` field.

### DIFF
--- a/apis/supervisor/idp/v1alpha1/types_upstreamoidcprovider.go.tmpl
+++ b/apis/supervisor/idp/v1alpha1/types_upstreamoidcprovider.go.tmpl
@@ -41,7 +41,7 @@ type OIDCAuthorizationConfig struct {
 	// AdditionalScopes are the scopes in addition to "openid" that will be requested as part of the authorization
 	// request flow with an OIDC identity provider. By default only the "openid" scope will be requested.
 	// +optional
-	AdditionalScopes []string `json:"additionalScopes"`
+	AdditionalScopes []string `json:"additionalScopes,omitempty"`
 }
 
 // OIDCClaims provides a mapping from upstream claims into identities.
@@ -82,7 +82,7 @@ type UpstreamOIDCProviderSpec struct {
 	// AuthorizationConfig holds information about how to form the OAuth2 authorization request
 	// parameters to be used with this OIDC identity provider.
 	// +optional
-	AuthorizationConfig OIDCAuthorizationConfig `json:"authorizationConfig"`
+	AuthorizationConfig OIDCAuthorizationConfig `json:"authorizationConfig,omitempty"`
 
 	// Claims provides the names of token claims that will be used when inspecting an identity from
 	// this OIDC identity provider.

--- a/generated/1.17/apis/supervisor/idp/v1alpha1/types_upstreamoidcprovider.go
+++ b/generated/1.17/apis/supervisor/idp/v1alpha1/types_upstreamoidcprovider.go
@@ -41,7 +41,7 @@ type OIDCAuthorizationConfig struct {
 	// AdditionalScopes are the scopes in addition to "openid" that will be requested as part of the authorization
 	// request flow with an OIDC identity provider. By default only the "openid" scope will be requested.
 	// +optional
-	AdditionalScopes []string `json:"additionalScopes"`
+	AdditionalScopes []string `json:"additionalScopes,omitempty"`
 }
 
 // OIDCClaims provides a mapping from upstream claims into identities.
@@ -82,7 +82,7 @@ type UpstreamOIDCProviderSpec struct {
 	// AuthorizationConfig holds information about how to form the OAuth2 authorization request
 	// parameters to be used with this OIDC identity provider.
 	// +optional
-	AuthorizationConfig OIDCAuthorizationConfig `json:"authorizationConfig"`
+	AuthorizationConfig OIDCAuthorizationConfig `json:"authorizationConfig,omitempty"`
 
 	// Claims provides the names of token claims that will be used when inspecting an identity from
 	// this OIDC identity provider.

--- a/generated/1.18/apis/supervisor/idp/v1alpha1/types_upstreamoidcprovider.go
+++ b/generated/1.18/apis/supervisor/idp/v1alpha1/types_upstreamoidcprovider.go
@@ -41,7 +41,7 @@ type OIDCAuthorizationConfig struct {
 	// AdditionalScopes are the scopes in addition to "openid" that will be requested as part of the authorization
 	// request flow with an OIDC identity provider. By default only the "openid" scope will be requested.
 	// +optional
-	AdditionalScopes []string `json:"additionalScopes"`
+	AdditionalScopes []string `json:"additionalScopes,omitempty"`
 }
 
 // OIDCClaims provides a mapping from upstream claims into identities.
@@ -82,7 +82,7 @@ type UpstreamOIDCProviderSpec struct {
 	// AuthorizationConfig holds information about how to form the OAuth2 authorization request
 	// parameters to be used with this OIDC identity provider.
 	// +optional
-	AuthorizationConfig OIDCAuthorizationConfig `json:"authorizationConfig"`
+	AuthorizationConfig OIDCAuthorizationConfig `json:"authorizationConfig,omitempty"`
 
 	// Claims provides the names of token claims that will be used when inspecting an identity from
 	// this OIDC identity provider.

--- a/generated/1.19/apis/supervisor/idp/v1alpha1/types_upstreamoidcprovider.go
+++ b/generated/1.19/apis/supervisor/idp/v1alpha1/types_upstreamoidcprovider.go
@@ -41,7 +41,7 @@ type OIDCAuthorizationConfig struct {
 	// AdditionalScopes are the scopes in addition to "openid" that will be requested as part of the authorization
 	// request flow with an OIDC identity provider. By default only the "openid" scope will be requested.
 	// +optional
-	AdditionalScopes []string `json:"additionalScopes"`
+	AdditionalScopes []string `json:"additionalScopes,omitempty"`
 }
 
 // OIDCClaims provides a mapping from upstream claims into identities.
@@ -82,7 +82,7 @@ type UpstreamOIDCProviderSpec struct {
 	// AuthorizationConfig holds information about how to form the OAuth2 authorization request
 	// parameters to be used with this OIDC identity provider.
 	// +optional
-	AuthorizationConfig OIDCAuthorizationConfig `json:"authorizationConfig"`
+	AuthorizationConfig OIDCAuthorizationConfig `json:"authorizationConfig,omitempty"`
 
 	// Claims provides the names of token claims that will be used when inspecting an identity from
 	// this OIDC identity provider.

--- a/test/integration/supervisor_login_test.go
+++ b/test/integration/supervisor_login_test.go
@@ -75,9 +75,6 @@ func TestSupervisorLogin(t *testing.T) {
 		TLS: &idpv1alpha1.TLSSpec{
 			CertificateAuthorityData: base64.StdEncoding.EncodeToString([]byte(env.OIDCUpstream.CABundle)),
 		},
-		AuthorizationConfig: idpv1alpha1.OIDCAuthorizationConfig{
-			AdditionalScopes: []string{},
-		},
 		Client: idpv1alpha1.OIDCClient{
 			SecretName: makeTestClientCredsSecret(t, testClientID, testClientSecret).Name,
 		},

--- a/test/integration/supervisor_upstream_test.go
+++ b/test/integration/supervisor_upstream_test.go
@@ -24,9 +24,6 @@ func TestSupervisorUpstreamOIDCDiscovery(t *testing.T) {
 		t.Parallel()
 		spec := v1alpha1.UpstreamOIDCProviderSpec{
 			Issuer: "https://127.0.0.1:444444/issuer",
-			AuthorizationConfig: v1alpha1.OIDCAuthorizationConfig{
-				AdditionalScopes: []string{"email", "profile"},
-			},
 			Client: v1alpha1.OIDCClient{
 				SecretName: "does-not-exist",
 			},


### PR DESCRIPTION
This allows you to omit the field in creation requests, which was annoying.

**Release note**:

```release-note
NONE
```
