### PR TITLE
Add nonroot SCC to work on OpenShift clusters

### DIFF
--- a/deploy/concierge/rbac.yaml
+++ b/deploy/concierge/rbac.yaml
@@ -24,6 +24,10 @@ rules:
   - apiGroups: [ policy ]
     resources: [ podsecuritypolicies ]
     verbs: [ use ]
+  - apiGroups: [ security.openshift.io ]
+    resources: [ securitycontextconstraints ]
+    verbs: [ use ]
+    resourceNames: [ nonroot ]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
```release-note
pinniped-concierge uses the nonroot SCC on OpenShift.
```
