### PR TITLE
Fix a test regression with IPv6 localhost interfaces.

### DIFF
--- a/test/integration/supervisor_discovery_test.go
+++ b/test/integration/supervisor_discovery_test.go
@@ -232,11 +232,10 @@ func TestSupervisorTLSTerminationWithDefaultCerts(t *testing.T) {
 		port = hostAndPortSegments[1]
 	}
 
-	ips, err := net.DefaultResolver.LookupIPAddr(ctx, hostname)
+	ips, err := library.LookupIP(ctx, hostname)
 	require.NoError(t, err)
-	ip := ips[0]
-	ipAsString := ip.String()
-	ipWithPort := ipAsString + ":" + port
+	require.NotEmpty(t, ips)
+	ipWithPort := ips[0].String() + ":" + port
 
 	issuerUsingIPAddress := fmt.Sprintf("%s://%s/issuer1", scheme, ipWithPort)
 	issuerUsingHostname := fmt.Sprintf("%s://%s/issuer1", scheme, address)
@@ -249,7 +248,7 @@ func TestSupervisorTLSTerminationWithDefaultCerts(t *testing.T) {
 	requireEndpointHasTLSErrorBecauseCertificatesAreNotReady(t, issuerUsingIPAddress)
 
 	// Create a Secret at the special name which represents the default TLS cert.
-	defaultCA := createTLSCertificateSecret(ctx, t, ns, "cert-hostname-doesnt-matter", []net.IP{ip.IP}, defaultTLSCertSecretName(env), kubeClient)
+	defaultCA := createTLSCertificateSecret(ctx, t, ns, "cert-hostname-doesnt-matter", []net.IP{ips[0]}, defaultTLSCertSecretName(env), kubeClient)
 
 	// Now that the Secret exists, we should be able to access the endpoints by IP address using the CA.
 	_ = requireDiscoveryEndpointsAreWorking(t, scheme, ipWithPort, string(defaultCA.Bundle()), issuerUsingIPAddress, nil)

--- a/test/library/iplookup.go
+++ b/test/library/iplookup.go
@@ -1,0 +1,16 @@
+// Copyright 2020 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// +build !go1.14
+
+package library
+
+import (
+	"context"
+	"net"
+)
+
+// LookupIP looks up the IP address of the provided hostname, preferring IPv4.
+func LookupIP(ctx context.Context, hostname string) ([]net.IP, error) {
+	return net.DefaultResolver.LookupIP(ctx, "ip4", hostname)
+}

--- a/test/library/iplookup_go1.14.go
+++ b/test/library/iplookup_go1.14.go
@@ -1,0 +1,28 @@
+// Copyright 2020 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// +build go1.14
+
+package library
+
+import (
+	"context"
+	"net"
+)
+
+// LookupIP looks up the IP address of the provided hostname, preferring IPv4.
+func LookupIP(ctx context.Context, hostname string) ([]net.IP, error) {
+	ips, err := net.DefaultResolver.LookupIPAddr(ctx, hostname)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter out to only IPv4 addresses
+	var results []net.IP
+	for _, ip := range ips {
+		if ip.IP.To4() != nil {
+			results = append(results, ip.IP)
+		}
+	}
+	return results, nil
+}


### PR DESCRIPTION
This fixes a regression introduced by #246. It could occasionally cause the tests to fail when run on a machine with an IPv6 localhost interface. As a fix I added a wrapper for the new Go 1.15 `LookupIP()` method, and created a partially-functional backport for Go 1.14. This should be easy to delete in the future.

**Release note**:

```release-note
NONE
```
