### PR TITLE
Remove "email" and "profile" from default scopes requested by CLI.

### DIFF
--- a/cmd/pinniped/cmd/login_oidc.go
+++ b/cmd/pinniped/cmd/login_oidc.go
@@ -48,7 +48,7 @@ func oidcLoginCommand(loginFunc func(issuer string, clientID string, opts ...oid
 	cmd.Flags().StringVar(&issuer, "issuer", "", "OpenID Connect issuer URL.")
 	cmd.Flags().StringVar(&clientID, "client-id", "", "OpenID Connect client ID.")
 	cmd.Flags().Uint16Var(&listenPort, "listen-port", 0, "TCP port for localhost listener (authorization code flow only).")
-	cmd.Flags().StringSliceVar(&scopes, "scopes", []string{"offline_access", "openid", "email", "profile"}, "OIDC scopes to request during login.")
+	cmd.Flags().StringSliceVar(&scopes, "scopes", []string{"offline_access", "openid"}, "OIDC scopes to request during login.")
 	cmd.Flags().BoolVar(&skipBrowser, "skip-browser", false, "Skip opening the browser (just print the URL).")
 	cmd.Flags().StringVar(&sessionCachePath, "session-cache", filepath.Join(mustGetConfigDir(), "sessions.yaml"), "Path to session cache file.")
 	cmd.Flags().StringSliceVar(&caBundlePaths, "ca-bundle", nil, "Path to TLS certificate authority bundle (PEM format, optional, can be repeated).")

--- a/cmd/pinniped/cmd/login_oidc_test.go
+++ b/cmd/pinniped/cmd/login_oidc_test.go
@@ -46,7 +46,7 @@ func TestLoginOIDCCommand(t *testing.T) {
 				  -h, --help                   help for oidc
 					  --issuer string          OpenID Connect issuer URL.
 					  --listen-port uint16     TCP port for localhost listener (authorization code flow only).
-					  --scopes strings         OIDC scopes to request during login. (default [offline_access,openid,email,profile])
+					  --scopes strings         OIDC scopes to request during login. (default [offline_access,openid])
 					  --session-cache string   Path to session cache file. (default "` + cfgDir + `/sessions.yaml")
 					  --skip-browser           Skip opening the browser (just print the URL).
 			`),

--- a/test/integration/cli_test.go
+++ b/test/integration/cli_test.go
@@ -313,6 +313,7 @@ func oidcLoginCommand(ctx context.Context, t *testing.T, pinnipedExe string, ses
 	cmd := exec.CommandContext(ctx, pinnipedExe, "login", "oidc",
 		"--issuer", env.CLITestUpstream.Issuer,
 		"--client-id", env.CLITestUpstream.ClientID,
+		"--scopes", "offline_access,openid,email,profile",
 		"--listen-port", callbackURL.Port(),
 		"--session-cache", sessionCachePath,
 		"--skip-browser",


### PR DESCRIPTION
We don't really need these in every case, since we'll be returning username and groups in a custom claim.

**Release note**:

```release-note
Removed "email" and "profile" from the default OIDC scopes requested by the `pinniped login oidc` command.
```
