### PR TITLE
Prefactor before adding CLI "request audience" functionality.

### DIFF
--- a/internal/mocks/mockupstreamoidcidentityprovider/mockupstreamoidcidentityprovider.go
+++ b/internal/mocks/mockupstreamoidcidentityprovider/mockupstreamoidcidentityprovider.go
@@ -43,13 +43,12 @@ func (m *MockUpstreamOIDCIdentityProviderI) EXPECT() *MockUpstreamOIDCIdentityPr
 }
 
 // ExchangeAuthcodeAndValidateTokens mocks base method
-func (m *MockUpstreamOIDCIdentityProviderI) ExchangeAuthcodeAndValidateTokens(arg0 context.Context, arg1 string, arg2 pkce.Code, arg3 nonce.Nonce, arg4 string) (oidctypes.Token, map[string]interface{}, error) {
+func (m *MockUpstreamOIDCIdentityProviderI) ExchangeAuthcodeAndValidateTokens(arg0 context.Context, arg1 string, arg2 pkce.Code, arg3 nonce.Nonce, arg4 string) (*oidctypes.Token, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExchangeAuthcodeAndValidateTokens", arg0, arg1, arg2, arg3, arg4)
-	ret0, _ := ret[0].(oidctypes.Token)
-	ret1, _ := ret[1].(map[string]interface{})
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret0, _ := ret[0].(*oidctypes.Token)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // ExchangeAuthcodeAndValidateTokens indicates an expected call of ExchangeAuthcodeAndValidateTokens
@@ -143,13 +142,12 @@ func (mr *MockUpstreamOIDCIdentityProviderIMockRecorder) GetUsernameClaim() *gom
 }
 
 // ValidateToken mocks base method
-func (m *MockUpstreamOIDCIdentityProviderI) ValidateToken(arg0 context.Context, arg1 *oauth2.Token, arg2 nonce.Nonce) (oidctypes.Token, map[string]interface{}, error) {
+func (m *MockUpstreamOIDCIdentityProviderI) ValidateToken(arg0 context.Context, arg1 *oauth2.Token, arg2 nonce.Nonce) (*oidctypes.Token, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidateToken", arg0, arg1, arg2)
-	ret0, _ := ret[0].(oidctypes.Token)
-	ret1, _ := ret[1].(map[string]interface{})
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret0, _ := ret[0].(*oidctypes.Token)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // ValidateToken indicates an expected call of ValidateToken

--- a/internal/oidc/callback/callback_handler.go
+++ b/internal/oidc/callback/callback_handler.go
@@ -73,7 +73,7 @@ func NewHandler(
 		// Grant the openid scope only if it was requested.
 		grantOpenIDScopeIfRequested(authorizeRequester)
 
-		_, idTokenClaims, err := upstreamIDPConfig.ExchangeAuthcodeAndValidateTokens(
+		token, err := upstreamIDPConfig.ExchangeAuthcodeAndValidateTokens(
 			r.Context(),
 			authcode(r),
 			state.PKCECode,
@@ -85,12 +85,12 @@ func NewHandler(
 			return httperr.New(http.StatusBadGateway, "error exchanging and validating upstream tokens")
 		}
 
-		username, err := getUsernameFromUpstreamIDToken(upstreamIDPConfig, idTokenClaims)
+		username, err := getUsernameFromUpstreamIDToken(upstreamIDPConfig, token.IDToken.Claims)
 		if err != nil {
 			return err
 		}
 
-		groups, err := getGroupsFromUpstreamIDToken(upstreamIDPConfig, idTokenClaims)
+		groups, err := getGroupsFromUpstreamIDToken(upstreamIDPConfig, token.IDToken.Claims)
 		if err != nil {
 			return err
 		}

--- a/internal/oidc/callback/callback_handler_test.go
+++ b/internal/oidc/callback/callback_handler_test.go
@@ -682,8 +682,11 @@ func (u *upstreamOIDCIdentityProviderBuilder) Build() oidctestutil.TestUpstreamO
 		UsernameClaim: u.usernameClaim,
 		GroupsClaim:   u.groupsClaim,
 		Scopes:        []string{"scope1", "scope2"},
-		ExchangeAuthcodeAndValidateTokensFunc: func(ctx context.Context, authcode string, pkceCodeVerifier pkce.Code, expectedIDTokenNonce nonce.Nonce) (oidctypes.Token, map[string]interface{}, error) {
-			return oidctypes.Token{}, u.idToken, u.authcodeExchangeErr
+		ExchangeAuthcodeAndValidateTokensFunc: func(ctx context.Context, authcode string, pkceCodeVerifier pkce.Code, expectedIDTokenNonce nonce.Nonce) (*oidctypes.Token, error) {
+			if u.authcodeExchangeErr != nil {
+				return nil, u.authcodeExchangeErr
+			}
+			return &oidctypes.Token{IDToken: &oidctypes.IDToken{Claims: u.idToken}}, nil
 		},
 	}
 }

--- a/internal/oidc/oidctestutil/oidc.go
+++ b/internal/oidc/oidctestutil/oidc.go
@@ -39,7 +39,7 @@ type TestUpstreamOIDCIdentityProvider struct {
 		authcode string,
 		pkceCodeVerifier pkce.Code,
 		expectedIDTokenNonce nonce.Nonce,
-	) (oidctypes.Token, map[string]interface{}, error)
+	) (*oidctypes.Token, error)
 
 	exchangeAuthcodeAndValidateTokensCallCount int
 	exchangeAuthcodeAndValidateTokensArgs      []*ExchangeAuthcodeAndValidateTokenArgs
@@ -75,7 +75,7 @@ func (u *TestUpstreamOIDCIdentityProvider) ExchangeAuthcodeAndValidateTokens(
 	pkceCodeVerifier pkce.Code,
 	expectedIDTokenNonce nonce.Nonce,
 	redirectURI string,
-) (oidctypes.Token, map[string]interface{}, error) {
+) (*oidctypes.Token, error) {
 	if u.exchangeAuthcodeAndValidateTokensArgs == nil {
 		u.exchangeAuthcodeAndValidateTokensArgs = make([]*ExchangeAuthcodeAndValidateTokenArgs, 0)
 	}
@@ -101,7 +101,7 @@ func (u *TestUpstreamOIDCIdentityProvider) ExchangeAuthcodeAndValidateTokensArgs
 	return u.exchangeAuthcodeAndValidateTokensArgs[call]
 }
 
-func (u *TestUpstreamOIDCIdentityProvider) ValidateToken(ctx context.Context, tok *oauth2.Token, expectedIDTokenNonce nonce.Nonce) (oidctypes.Token, map[string]interface{}, error) {
+func (u *TestUpstreamOIDCIdentityProvider) ValidateToken(_ context.Context, _ *oauth2.Token, _ nonce.Nonce) (*oidctypes.Token, error) {
 	panic("implement me")
 }
 

--- a/internal/oidc/provider/dynamic_upstream_idp_provider.go
+++ b/internal/oidc/provider/dynamic_upstream_idp_provider.go
@@ -43,9 +43,9 @@ type UpstreamOIDCIdentityProviderI interface {
 		pkceCodeVerifier pkce.Code,
 		expectedIDTokenNonce nonce.Nonce,
 		redirectURI string,
-	) (tokens oidctypes.Token, parsedIDTokenClaims map[string]interface{}, err error)
+	) (*oidctypes.Token, error)
 
-	ValidateToken(ctx context.Context, tok *oauth2.Token, expectedIDTokenNonce nonce.Nonce) (oidctypes.Token, map[string]interface{}, error)
+	ValidateToken(ctx context.Context, tok *oauth2.Token, expectedIDTokenNonce nonce.Nonce) (*oidctypes.Token, error)
 }
 
 type DynamicUpstreamIDPProvider interface {

--- a/internal/oidc/provider/manager/manager_test.go
+++ b/internal/oidc/provider/manager/manager_test.go
@@ -172,15 +172,17 @@ func TestManager(t *testing.T) {
 				ClientID:         "test-client-id",
 				AuthorizationURL: *parsedUpstreamIDPAuthorizationURL,
 				Scopes:           []string{"test-scope"},
-				ExchangeAuthcodeAndValidateTokensFunc: func(ctx context.Context, authcode string, pkceCodeVerifier pkce.Code, expectedIDTokenNonce nonce.Nonce) (oidctypes.Token, map[string]interface{}, error) {
-					return oidctypes.Token{},
-						map[string]interface{}{
-							"iss":      "https://some-issuer.com",
-							"sub":      "some-subject",
-							"username": "test-username",
-							"groups":   "test-group1",
+				ExchangeAuthcodeAndValidateTokensFunc: func(ctx context.Context, authcode string, pkceCodeVerifier pkce.Code, expectedIDTokenNonce nonce.Nonce) (*oidctypes.Token, error) {
+					return &oidctypes.Token{
+						IDToken: &oidctypes.IDToken{
+							Claims: map[string]interface{}{
+								"iss":      "https://some-issuer.com",
+								"sub":      "some-subject",
+								"username": "test-username",
+								"groups":   "test-group1",
+							},
 						},
-						nil
+					}, nil
 				},
 			})
 

--- a/pkg/oidcclient/filesession/cachefile_test.go
+++ b/pkg/oidcclient/filesession/cachefile_test.go
@@ -38,6 +38,13 @@ var validSession = sessionCache{
 				IDToken: &oidctypes.IDToken{
 					Token:  "test-id-token",
 					Expiry: metav1.NewTime(time.Date(2020, 10, 20, 19, 42, 07, 0, time.UTC).Local()),
+					Claims: map[string]interface{}{
+						"foo": "bar",
+						"nested": map[string]interface{}{
+							"key1": "value1",
+							"key2": "value2",
+						},
+					},
 				},
 				RefreshToken: &oidctypes.RefreshToken{
 					Token: "test-refresh-token",

--- a/pkg/oidcclient/filesession/testdata/valid.yaml
+++ b/pkg/oidcclient/filesession/testdata/valid.yaml
@@ -20,5 +20,10 @@ sessions:
       id:
         expiryTimestamp: "2020-10-20T19:42:07Z"
         token: test-id-token
+        claims:
+          foo: bar
+          nested:
+            key1: value1
+            key2: value2
       refresh:
         token: test-refresh-token

--- a/pkg/oidcclient/login.go
+++ b/pkg/oidcclient/login.go
@@ -295,11 +295,7 @@ func (h *handlerState) handleRefresh(ctx context.Context, refreshToken *oidctype
 
 	// The spec is not 100% clear about whether an ID token from the refresh flow should include a nonce, and at least
 	// some providers do not include one, so we skip the nonce validation here (but not other validations).
-	token, _, err := h.getProvider(h.oauth2Config, h.provider, h.httpClient).ValidateToken(ctx, refreshed, "")
-	if err != nil {
-		return nil, err
-	}
-	return &token, nil
+	return h.getProvider(h.oauth2Config, h.provider, h.httpClient).ValidateToken(ctx, refreshed, "")
 }
 
 func (h *handlerState) handleAuthCodeCallback(w http.ResponseWriter, r *http.Request) (err error) {
@@ -328,7 +324,7 @@ func (h *handlerState) handleAuthCodeCallback(w http.ResponseWriter, r *http.Req
 
 	// Exchange the authorization code for access, ID, and refresh tokens and perform required
 	// validations on the returned ID token.
-	token, _, err := h.getProvider(h.oauth2Config, h.provider, h.httpClient).
+	token, err := h.getProvider(h.oauth2Config, h.provider, h.httpClient).
 		ExchangeAuthcodeAndValidateTokens(
 			r.Context(),
 			params.Get("code"),
@@ -340,7 +336,7 @@ func (h *handlerState) handleAuthCodeCallback(w http.ResponseWriter, r *http.Req
 		return httperr.Wrap(http.StatusBadRequest, "could not complete code exchange", err)
 	}
 
-	h.callbacks <- callbackResult{token: &token}
+	h.callbacks <- callbackResult{token: token}
 	_, _ = w.Write([]byte("you have been logged in and may now close this tab"))
 	return nil
 }

--- a/pkg/oidcclient/login_test.go
+++ b/pkg/oidcclient/login_test.go
@@ -242,7 +242,7 @@ func TestLogin(t *testing.T) {
 						mock := mockUpstream(t)
 						mock.EXPECT().
 							ValidateToken(gomock.Any(), HasAccessToken(testToken.AccessToken.Token), nonce.Nonce("")).
-							Return(testToken, nil, nil)
+							Return(&testToken, nil)
 						return mock
 					}
 
@@ -281,7 +281,7 @@ func TestLogin(t *testing.T) {
 						mock := mockUpstream(t)
 						mock.EXPECT().
 							ValidateToken(gomock.Any(), HasAccessToken(testToken.AccessToken.Token), nonce.Nonce("")).
-							Return(oidctypes.Token{}, nil, fmt.Errorf("some validation error"))
+							Return(nil, fmt.Errorf("some validation error"))
 						return mock
 					}
 
@@ -529,7 +529,7 @@ func TestHandleAuthCodeCallback(t *testing.T) {
 						mock := mockUpstream(t)
 						mock.EXPECT().
 							ExchangeAuthcodeAndValidateTokens(gomock.Any(), "invalid", pkce.Code("test-pkce"), nonce.Nonce("test-nonce"), testRedirectURI).
-							Return(oidctypes.Token{}, nil, fmt.Errorf("some exchange error"))
+							Return(nil, fmt.Errorf("some exchange error"))
 						return mock
 					}
 					return nil
@@ -546,7 +546,7 @@ func TestHandleAuthCodeCallback(t *testing.T) {
 						mock := mockUpstream(t)
 						mock.EXPECT().
 							ExchangeAuthcodeAndValidateTokens(gomock.Any(), "valid", pkce.Code("test-pkce"), nonce.Nonce("test-nonce"), testRedirectURI).
-							Return(oidctypes.Token{IDToken: &oidctypes.IDToken{Token: "test-id-token"}}, nil, nil)
+							Return(&oidctypes.Token{IDToken: &oidctypes.IDToken{Token: "test-id-token"}}, nil)
 						return mock
 					}
 					return nil

--- a/pkg/oidcclient/oidctypes/oidctypes.go
+++ b/pkg/oidcclient/oidctypes/oidctypes.go
@@ -31,6 +31,9 @@ type IDToken struct {
 
 	// Expiry is the optional expiration time of the ID token.
 	Expiry v1.Time `json:"expiryTimestamp,omitempty"`
+
+	// Claims are the claims expressed by the Token.
+	Claims map[string]interface{} `json:"claims,omitempty"`
 }
 
 // Token contains the elements of an OIDC session.


### PR DESCRIPTION
This change refactors some of our OIDC types and interfaces to prepare for implementing the `pinniped login oidc --request-audience` flag (name TBD):

1.  Add validated ID token claims to the `oidctypes.Token` structure.

    This is just a more convenient copy of these values which are already stored inside the ID token. This will save us from having to pass them around seprately or re-parse them later.

1. Refactor how the `provider.UpstreamOIDCIdentityProviderI` interface returns validated claims.

   This refactors the `UpstreamOIDCIdentityProviderI` interface and its implementations to pass ID token claims through a `*oidctypes.Token` return parameter rather than as a third return parameter.

**Release note**:

```release-note
NONE
```
