### PR TITLE
Add a `--request-audience` flag to the `pinniped login oidc` CLI command

### DIFF
--- a/cmd/pinniped/cmd/login_oidc.go
+++ b/cmd/pinniped/cmd/login_oidc.go
@@ -44,6 +44,7 @@ func oidcLoginCommand(loginFunc func(issuer string, clientID string, opts ...oid
 		sessionCachePath  string
 		caBundlePaths     []string
 		debugSessionCache bool
+		requestAudience   string
 	)
 	cmd.Flags().StringVar(&issuer, "issuer", "", "OpenID Connect issuer URL.")
 	cmd.Flags().StringVar(&clientID, "client-id", "", "OpenID Connect client ID.")
@@ -53,6 +54,7 @@ func oidcLoginCommand(loginFunc func(issuer string, clientID string, opts ...oid
 	cmd.Flags().StringVar(&sessionCachePath, "session-cache", filepath.Join(mustGetConfigDir(), "sessions.yaml"), "Path to session cache file.")
 	cmd.Flags().StringSliceVar(&caBundlePaths, "ca-bundle", nil, "Path to TLS certificate authority bundle (PEM format, optional, can be repeated).")
 	cmd.Flags().BoolVar(&debugSessionCache, "debug-session-cache", false, "Print debug logs related to the session cache.")
+	cmd.Flags().StringVar(&requestAudience, "request-audience", "", "Request a token with an alternate audience using RF8693 token exchange.")
 	mustMarkHidden(&cmd, "debug-session-cache")
 	mustMarkRequired(&cmd, "issuer", "client-id")
 
@@ -78,6 +80,10 @@ func oidcLoginCommand(loginFunc func(issuer string, clientID string, opts ...oid
 
 		if listenPort != 0 {
 			opts = append(opts, oidcclient.WithListenPort(listenPort))
+		}
+
+		if requestAudience != "" {
+			opts = append(opts, oidcclient.WithRequestAudience(requestAudience))
 		}
 
 		// --skip-browser replaces the default "browser open" function with one that prints to stderr.

--- a/cmd/pinniped/cmd/login_oidc_test.go
+++ b/cmd/pinniped/cmd/login_oidc_test.go
@@ -41,14 +41,15 @@ func TestLoginOIDCCommand(t *testing.T) {
 				  oidc --issuer ISSUER --client-id CLIENT_ID [flags]
 
 				Flags:
-					  --ca-bundle strings      Path to TLS certificate authority bundle (PEM format, optional, can be repeated).
-					  --client-id string       OpenID Connect client ID.
-				  -h, --help                   help for oidc
-					  --issuer string          OpenID Connect issuer URL.
-					  --listen-port uint16     TCP port for localhost listener (authorization code flow only).
-					  --scopes strings         OIDC scopes to request during login. (default [offline_access,openid])
-					  --session-cache string   Path to session cache file. (default "` + cfgDir + `/sessions.yaml")
-					  --skip-browser           Skip opening the browser (just print the URL).
+					  --ca-bundle strings         Path to TLS certificate authority bundle (PEM format, optional, can be repeated).
+					  --client-id string          OpenID Connect client ID.
+				  -h, --help                      help for oidc
+					  --issuer string             OpenID Connect issuer URL.
+					  --listen-port uint16        TCP port for localhost listener (authorization code flow only).
+					  --request-audience string   Request a token with an alternate audience using RF8693 token exchange.
+					  --scopes strings            OIDC scopes to request during login. (default [offline_access,openid])
+					  --session-cache string      Path to session cache file. (default "` + cfgDir + `/sessions.yaml")
+					  --skip-browser              Skip opening the browser (just print the URL).
 			`),
 		},
 		{


### PR DESCRIPTION
This change adds a new optional `--request-audience` flag to the `pinniped login oidc` CLI command. The default behavior remains unchanged, but if a specific audience is requested, the CLI will perform an additional token exchange using `grant_type=urn:ietf:params:oauth:grant-type:token-exchange` ([RFC8693](https://tools.ietf.org/html/rfc8693)).

**Release note**:

```release-note
Added a new optional `--request-audience` flag to the `pinniped login oidc` CLI command.
```
