### PR TITLE
Fix `JWTAuthenticator` CA bundle

### DIFF
--- a/hack/lib/tilt/Tiltfile
+++ b/hack/lib/tilt/Tiltfile
@@ -149,7 +149,7 @@ k8s_yaml(local([
     '--data-value image_repo=image/concierge ' +
     '--data-value image_tag=tilt-dev ' +
     '--data-value kube_cert_agent_image=debian:10.6-slim ' +
-    '--data-value discovery_url=$(TERM=dumb kubectl cluster-info | awk \'/Kubernetes master/ {print $NF}\') ' +
+    '--data-value discovery_url=$(TERM=dumb kubectl cluster-info | awk \'/master|control plane/ {print $NF}\') ' +
     '--data-value log_level=debug ' +
     '--data-value-yaml replicas=1 ' +
     '--data-value-yaml "custom_labels={myConciergeCustomLabelName: myConciergeCustomLabelValue}"'

--- a/hack/prepare-for-integration-tests.sh
+++ b/hack/prepare-for-integration-tests.sh
@@ -123,7 +123,7 @@ if ! tilt_mode; then
     # Our kind config exposes node port 31234 as 127.0.0.1:12345, 31243 as 127.0.0.1:12344, and 31235 as 127.0.0.1:12346
     ./hack/kind-up.sh
   else
-    if ! kubectl cluster-info | grep master | grep -q 127.0.0.1; then
+    if ! kubectl cluster-info | grep -E '(master|control plane)' | grep -q 127.0.0.1; then
       log_error "Seems like your kubeconfig is not targeting a local cluster."
       log_error "Exiting to avoid accidentally running tests against a real cluster."
       exit 1
@@ -249,7 +249,7 @@ concierge_app_name="pinniped-concierge"
 concierge_namespace="concierge"
 webhook_url="https://local-user-authenticator.local-user-authenticator.svc/authenticate"
 webhook_ca_bundle="$(kubectl get secret local-user-authenticator-tls-serving-certificate --namespace local-user-authenticator -o 'jsonpath={.data.caCertificate}')"
-discovery_url="$(TERM=dumb kubectl cluster-info | awk '/Kubernetes master/ {print $NF}')"
+discovery_url="$(TERM=dumb kubectl cluster-info | awk '/master|control plane/ {print $NF}')"
 concierge_custom_labels="{myConciergeCustomLabelName: myConciergeCustomLabelValue}"
 
 if ! tilt_mode; then


### PR DESCRIPTION
<!--
Thank you for submitting a pull request for Pinniped!

Before submitting, please see the guidelines in CONTRIBUTING.md in this repo.

Please note that a project maintainer will need to review and provide an
initial approval on the PR to cause CI tests to automatically start.
Also note that if you push additional commits to the PR, those commits
will need another initial approval before CI will pick them up.

Reminder: Did you remember to run all the linter, unit tests, and integration tests
described in CONTRIBUTING.md on your branch before submitting this PR?

Below is a template to help you describe your PR.
-->

<!--
Provide a summary of your change. Feel free to use paragraphs or a bulleted list, for example:

- Improves performance by 10,000%.
- Fixes all bugs.
- Boils the oceans.

-->

<!--
Does this PR fix one or more reported issues?
If yes, use `Fixes #<issue number>` to automatically close the fixed issue(s) when the PR is merged.
-->

See comment from code. Our acceptance environments don't set an upstream CA bundle, because the upstream uses well-known certs that can be verified using an OS's root CA store.
```
	// If the test upstream does not have a CA bundle specified, then don't configure one in the
	// JWTAuthenticator. Leaving TLSSpec set to nil will result in OIDC discovery using the OS's root
	// CA store.
```

Bonus commit: fix `prepare-for-integration-tests.sh` and `Tiltfile` for `kubectl` 1.20.

**Release note**:

<!--
Does this PR introduce a user-facing change?

If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
-->
```release-note
NONE
```
