### PR TITLE
Add a default --client-id in `pinniped login oidc` command.

### DIFF
--- a/cmd/pinniped/cmd/login_oidc.go
+++ b/cmd/pinniped/cmd/login_oidc.go
@@ -48,7 +48,7 @@ func oidcLoginCommand(loginFunc func(issuer string, clientID string, opts ...oid
 		requestAudience   string
 	)
 	cmd.Flags().StringVar(&issuer, "issuer", "", "OpenID Connect issuer URL.")
-	cmd.Flags().StringVar(&clientID, "client-id", "", "OpenID Connect client ID.")
+	cmd.Flags().StringVar(&clientID, "client-id", "pinniped-cli", "OpenID Connect client ID.")
 	cmd.Flags().Uint16Var(&listenPort, "listen-port", 0, "TCP port for localhost listener (authorization code flow only).")
 	cmd.Flags().StringSliceVar(&scopes, "scopes", []string{oidc.ScopeOfflineAccess, oidc.ScopeOpenID}, "OIDC scopes to request during login.")
 	cmd.Flags().BoolVar(&skipBrowser, "skip-browser", false, "Skip opening the browser (just print the URL).")
@@ -57,7 +57,7 @@ func oidcLoginCommand(loginFunc func(issuer string, clientID string, opts ...oid
 	cmd.Flags().BoolVar(&debugSessionCache, "debug-session-cache", false, "Print debug logs related to the session cache.")
 	cmd.Flags().StringVar(&requestAudience, "request-audience", "", "Request a token with an alternate audience using RF8693 token exchange.")
 	mustMarkHidden(&cmd, "debug-session-cache")
-	mustMarkRequired(&cmd, "issuer", "client-id")
+	mustMarkRequired(&cmd, "issuer")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		// Initialize the session cache.

--- a/cmd/pinniped/cmd/login_oidc_test.go
+++ b/cmd/pinniped/cmd/login_oidc_test.go
@@ -42,7 +42,7 @@ func TestLoginOIDCCommand(t *testing.T) {
 
 				Flags:
 					  --ca-bundle strings         Path to TLS certificate authority bundle (PEM format, optional, can be repeated).
-					  --client-id string          OpenID Connect client ID.
+					  --client-id string          OpenID Connect client ID. (default "pinniped-cli")
 				  -h, --help                      help for oidc
 					  --issuer string             OpenID Connect issuer URL.
 					  --listen-port uint16        TCP port for localhost listener (authorization code flow only).
@@ -57,7 +57,7 @@ func TestLoginOIDCCommand(t *testing.T) {
 			args:      []string{},
 			wantError: true,
 			wantStdout: here.Doc(`
-				Error: required flag(s) "client-id", "issuer" not set
+				Error: required flag(s) "issuer" not set
 			`),
 		},
 		{


### PR DESCRIPTION
Adds a default `--client-id=pinniped-cli` to the `pinniped login oidc` command.  This default matches the static client we have defined in the supervisor, which will be the correct value in most cases.

**Release note**:

```release-note
Add a default value for the `--client-id` flag in the `pinniped login oidc` command.
```
