### PR TITLE
Fix bug in handling response content-type in oidcclient.

### DIFF
--- a/pkg/oidcclient/login.go
+++ b/pkg/oidcclient/login.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"mime"
 	"net"
 	"net/http"
 	"net/url"
@@ -364,8 +365,12 @@ func (h *handlerState) tokenExchangeRFC8693(baseToken *oidctypes.Token) (*oidcty
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("unexpected HTTP response status %d", resp.StatusCode)
 	}
-	if contentType := resp.Header.Get("content-type"); contentType != "application/json" {
-		return nil, fmt.Errorf("unexpected HTTP response content type %q", contentType)
+	mediaType, _, err := mime.ParseMediaType(resp.Header.Get("content-type"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode content-type header: %w", err)
+	}
+	if mediaType != "application/json" {
+		return nil, fmt.Errorf("unexpected HTTP response content type %q", mediaType)
 	}
 
 	// Decode the JSON response body.


### PR DESCRIPTION
Before this, we weren't properly parsing the `Content-Type` header. This breaks in integration with the Supervisor since it sends an extra encoding parameter like `application/json;charset=UTF-8`.

This change switches to properly parsing with the [`mime.ParseMediaType`](https://golang.org/pkg/mime/#FormatMediaType) function, and adds test cases to match the supervisor behavior.

**Release note**:

No release note because this functionality is new since the previous release.

```release-note
NONE
```
