### PR TITLE
Tweak default CLI `--scopes` parameter to match supervisor use case.

### DIFF
--- a/cmd/pinniped/cmd/login_oidc.go
+++ b/cmd/pinniped/cmd/login_oidc.go
@@ -50,7 +50,7 @@ func oidcLoginCommand(loginFunc func(issuer string, clientID string, opts ...oid
 	cmd.Flags().StringVar(&issuer, "issuer", "", "OpenID Connect issuer URL.")
 	cmd.Flags().StringVar(&clientID, "client-id", "pinniped-cli", "OpenID Connect client ID.")
 	cmd.Flags().Uint16Var(&listenPort, "listen-port", 0, "TCP port for localhost listener (authorization code flow only).")
-	cmd.Flags().StringSliceVar(&scopes, "scopes", []string{oidc.ScopeOfflineAccess, oidc.ScopeOpenID}, "OIDC scopes to request during login.")
+	cmd.Flags().StringSliceVar(&scopes, "scopes", []string{oidc.ScopeOfflineAccess, oidc.ScopeOpenID, "pinniped.sts.unrestricted"}, "OIDC scopes to request during login.")
 	cmd.Flags().BoolVar(&skipBrowser, "skip-browser", false, "Skip opening the browser (just print the URL).")
 	cmd.Flags().StringVar(&sessionCachePath, "session-cache", filepath.Join(mustGetConfigDir(), "sessions.yaml"), "Path to session cache file.")
 	cmd.Flags().StringSliceVar(&caBundlePaths, "ca-bundle", nil, "Path to TLS certificate authority bundle (PEM format, optional, can be repeated).")

--- a/cmd/pinniped/cmd/login_oidc_test.go
+++ b/cmd/pinniped/cmd/login_oidc_test.go
@@ -47,7 +47,7 @@ func TestLoginOIDCCommand(t *testing.T) {
 					  --issuer string             OpenID Connect issuer URL.
 					  --listen-port uint16        TCP port for localhost listener (authorization code flow only).
 					  --request-audience string   Request a token with an alternate audience using RF8693 token exchange.
-					  --scopes strings            OIDC scopes to request during login. (default [offline_access,openid])
+					  --scopes strings            OIDC scopes to request during login. (default [offline_access,openid,pinniped.sts.unrestricted])
 					  --session-cache string      Path to session cache file. (default "` + cfgDir + `/sessions.yaml")
 					  --skip-browser              Skip opening the browser (just print the URL).
 			`),


### PR DESCRIPTION
This should be a better default for most cases.

This is another change like #270 that improves the UX of the CLI+supervisor use case.

**Release note**:

```release-note
Adjusted the `pinniped login oidc` defaults to more easily fit the supervisor login flow.
```
