### PR TITLE
Upgrade the Dex we use for local testing to v2.27.0.

### DIFF
--- a/test/deploy/dex/dex.yaml
+++ b/test/deploy/dex/dex.yaml
@@ -12,7 +12,7 @@ storage:
   config:
     file: ":memory:"
 web:
-  https: 0.0.0.0:443
+  https: 0.0.0.0:8443
   tlsCert: /var/certs/dex.pem
   tlsKey: /var/certs/dex-key.pem
 oauth2:
@@ -20,7 +20,7 @@ oauth2:
 staticClients:
 - id: pinniped-cli
   name: 'Pinniped CLI'
-  #! we can't have "public: true" until https://github.com/dexidp/dex/pull/1822 lands in Dex.
+  public: true
   redirectURIs:
   - #@ "http://127.0.0.1:" + str(data.values.ports.cli) + "/callback"
   - #@ "http://[::1]:" + str(data.values.ports.cli) + "/callback"
@@ -76,7 +76,7 @@ spec:
     spec:
       containers:
       - name: dex
-        image: quay.io/dexidp/dex:v2.10.0
+        image: ghcr.io/dexidp/dex:v2.27.0
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/dex
@@ -84,7 +84,7 @@ spec:
         - /etc/dex/cfg/config.yaml
         ports:
         - name: https
-          containerPort: 443
+          containerPort: 8443
         volumeMounts:
         - name: dex-config
           mountPath: /etc/dex/cfg
@@ -111,5 +111,7 @@ spec:
   selector:
     app: dex
   ports:
-  - port: 443
-    name: https
+  - name: https
+    port: 443
+    targetPort: 8443
+


### PR DESCRIPTION
We're not affected by the recent SAML vulnerabilities, but it seems good to keep up with the latest releases.

**Release note**:

This change affects the local/CI test environment only.

```release-note
NONE
```
