### PR TITLE
SameIssuerHostMustUseSameSecret is a valid OIDCProvider status, and help some test flakes

### DIFF
--- a/apis/supervisor/config/v1alpha1/types_oidcprovider.go.tmpl
+++ b/apis/supervisor/config/v1alpha1/types_oidcprovider.go.tmpl
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// +kubebuilder:validation:Enum=Success;Duplicate;Invalid
+// +kubebuilder:validation:Enum=Success;Duplicate;Invalid;SameIssuerHostMustUseSameSecret
 type OIDCProviderStatusCondition string
 
 const (

--- a/deploy/supervisor/config.supervisor.pinniped.dev_oidcproviders.yaml
+++ b/deploy/supervisor/config.supervisor.pinniped.dev_oidcproviders.yaml
@@ -108,6 +108,7 @@ spec:
                 - Success
                 - Duplicate
                 - Invalid
+                - SameIssuerHostMustUseSameSecret
                 type: string
             type: object
         required:

--- a/generated/1.17/apis/supervisor/config/v1alpha1/types_oidcprovider.go
+++ b/generated/1.17/apis/supervisor/config/v1alpha1/types_oidcprovider.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// +kubebuilder:validation:Enum=Success;Duplicate;Invalid
+// +kubebuilder:validation:Enum=Success;Duplicate;Invalid;SameIssuerHostMustUseSameSecret
 type OIDCProviderStatusCondition string
 
 const (

--- a/generated/1.17/crds/config.supervisor.pinniped.dev_oidcproviders.yaml
+++ b/generated/1.17/crds/config.supervisor.pinniped.dev_oidcproviders.yaml
@@ -108,6 +108,7 @@ spec:
                 - Success
                 - Duplicate
                 - Invalid
+                - SameIssuerHostMustUseSameSecret
                 type: string
             type: object
         required:

--- a/generated/1.18/apis/supervisor/config/v1alpha1/types_oidcprovider.go
+++ b/generated/1.18/apis/supervisor/config/v1alpha1/types_oidcprovider.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// +kubebuilder:validation:Enum=Success;Duplicate;Invalid
+// +kubebuilder:validation:Enum=Success;Duplicate;Invalid;SameIssuerHostMustUseSameSecret
 type OIDCProviderStatusCondition string
 
 const (

--- a/generated/1.18/crds/config.supervisor.pinniped.dev_oidcproviders.yaml
+++ b/generated/1.18/crds/config.supervisor.pinniped.dev_oidcproviders.yaml
@@ -108,6 +108,7 @@ spec:
                 - Success
                 - Duplicate
                 - Invalid
+                - SameIssuerHostMustUseSameSecret
                 type: string
             type: object
         required:

--- a/generated/1.19/apis/supervisor/config/v1alpha1/types_oidcprovider.go
+++ b/generated/1.19/apis/supervisor/config/v1alpha1/types_oidcprovider.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// +kubebuilder:validation:Enum=Success;Duplicate;Invalid
+// +kubebuilder:validation:Enum=Success;Duplicate;Invalid;SameIssuerHostMustUseSameSecret
 type OIDCProviderStatusCondition string
 
 const (

--- a/generated/1.19/crds/config.supervisor.pinniped.dev_oidcproviders.yaml
+++ b/generated/1.19/crds/config.supervisor.pinniped.dev_oidcproviders.yaml
@@ -108,6 +108,7 @@ spec:
                 - Success
                 - Duplicate
                 - Invalid
+                - SameIssuerHostMustUseSameSecret
                 type: string
             type: object
         required:

--- a/test/integration/supervisor_login_test.go
+++ b/test/integration/supervisor_login_test.go
@@ -165,8 +165,12 @@ func TestSupervisorLogin(t *testing.T) {
 	authcode := callback.URL.Query().Get("code")
 	require.NotEmpty(t, authcode)
 
-	// Call the token endpoint to get tokens.
-	tokenResponse, err := downstreamOAuth2Config.Exchange(oidcHTTPClientContext, authcode, pkceParam.Verifier())
+	// Call the token endpoint to get tokens. Give the Supervisor a couple of seconds to wire up its signing key.
+	var tokenResponse *oauth2.Token
+	assert.Eventually(t, func() bool {
+		tokenResponse, err = downstreamOAuth2Config.Exchange(oidcHTTPClientContext, authcode, pkceParam.Verifier())
+		return err == nil
+	}, time.Second*5, time.Second*1)
 	require.NoError(t, err)
 
 	expectedIDTokenClaims := []string{"iss", "exp", "sub", "aud", "auth_time", "iat", "jti", "nonce", "rat"}

--- a/test/library/client.go
+++ b/test/library/client.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -265,12 +266,13 @@ func CreateTestOIDCProvider(ctx context.Context, t *testing.T, issuer string, ce
 
 	// Wait for the OIDCProvider to enter the expected phase (or time out).
 	var result *configv1alpha1.OIDCProvider
-	require.Eventuallyf(t, func() bool {
+	assert.Eventuallyf(t, func() bool {
 		var err error
 		result, err = opcs.Get(ctx, opc.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		return result.Status.Status == expectStatus
-	}, 60*time.Second, 1*time.Second, "expected the UpstreamOIDCProvider to go into phase %s", expectStatus)
+	}, 60*time.Second, 1*time.Second, "expected the OIDCProvider to have status %q", expectStatus)
+	require.Equal(t, expectStatus, result.Status.Status)
 
 	return opc
 }


### PR DESCRIPTION
I saw this message in our CI logs, which led me to this fix.
  could not update status: OIDCProvider.config.supervisor.pinniped.dev "acceptance-provider" is invalid: status.status: Unsupported value: "SameIssuerHostMustUseSameSecret": supported values: "Success", "Duplicate", "Invalid"

Also - correct an integration test error message that was misleading.

Signed-off-by: Andrew Keesler <akeesler@vmware.com>

<!--
Thank you for submitting a pull request for Pinniped!

Before submitting, please see the guidelines in CONTRIBUTING.md in this repo.

Please note that a project maintainer will need to review and provide an
initial approval on the PR to cause CI tests to automatically start.
Also note that if you push additional commits to the PR, those commits
will need another initial approval before CI will pick them up.

Reminder: Did you remember to run all the linter, unit tests, and integration tests
described in CONTRIBUTING.md on your branch before submitting this PR?

Below is a template to help you describe your PR.
-->

<!--
Provide a summary of your change. Feel free to use paragraphs or a bulleted list, for example:

- Improves performance by 10,000%.
- Fixes all bugs.
- Boils the oceans.

-->

<!--
Does this PR fix one or more reported issues?
If yes, use `Fixes #<issue number>` to automatically close the fixed issue(s) when the PR is merged.
-->

**Release note**:

<!--
Does this PR introduce a user-facing change?

If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
-->
```release-note
NONE
```
