### PR TITLE
Upgrade base images to Debian 10.7-slim.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN mkdir out \
   && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o out ./cmd/local-user-authenticator/...
 
 # Use a runtime image based on Debian slim
-FROM debian:10.6-slim
+FROM debian:10.7-slim
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 
 # Copy the binaries from the build-env stage

--- a/hack/lib/tilt/Tiltfile
+++ b/hack/lib/tilt/Tiltfile
@@ -148,7 +148,7 @@ k8s_yaml(local([
     '--data-value namespace=concierge ' +
     '--data-value image_repo=image/concierge ' +
     '--data-value image_tag=tilt-dev ' +
-    '--data-value kube_cert_agent_image=debian:10.6-slim ' +
+    '--data-value kube_cert_agent_image=debian:10.7-slim ' +
     '--data-value discovery_url=$(TERM=dumb kubectl cluster-info | awk \'/master|control plane/ {print $NF}\') ' +
     '--data-value log_level=debug ' +
     '--data-value-yaml replicas=1 ' +

--- a/hack/lib/tilt/concierge.Dockerfile
+++ b/hack/lib/tilt/concierge.Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Use a runtime image based on Debian slim
-FROM debian:10.6-slim
+FROM debian:10.7-slim
 
 # Copy the binary which was built outside the container.
 COPY build/pinniped-concierge /usr/local/bin/pinniped-concierge

--- a/hack/lib/tilt/local-user-authenticator.Dockerfile
+++ b/hack/lib/tilt/local-user-authenticator.Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Use a runtime image based on Debian slim
-FROM debian:10.6-slim
+FROM debian:10.7-slim
 
 # Copy the binary which was built outside the container.
 COPY build/local-user-authenticator /usr/local/bin/local-user-authenticator

--- a/hack/lib/tilt/supervisor.Dockerfile
+++ b/hack/lib/tilt/supervisor.Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Use a runtime image based on Debian slim
-FROM debian:10.6-slim
+FROM debian:10.7-slim
 
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 

--- a/test/deploy/dex/proxy.yaml
+++ b/test/deploy/dex/proxy.yaml
@@ -48,7 +48,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 2
         - name: accesslogs
-          image: debian:10.6-slim
+          image: debian:10.7-slim
           command:
             - "/bin/sh"
             - "-c"


### PR DESCRIPTION
This upgrades our base images from `debian:10.6-slim` to the latest `debian:10.7-slim`.

**Release note**:

```release-note
Updated base images to Debian 10.7.
```
