### PR TITLE
Fix documentation comment for the UpstreamOIDCProvider's spec.client.secretName type.

### DIFF
--- a/apis/supervisor/idp/v1alpha1/types_upstreamoidcprovider.go.tmpl
+++ b/apis/supervisor/idp/v1alpha1/types_upstreamoidcprovider.go.tmpl
@@ -62,7 +62,7 @@ type OIDCClaims struct {
 type OIDCClient struct {
 	// SecretName contains the name of a namespace-local Secret object that provides the clientID and
 	// clientSecret for an OIDC client. If only the SecretName is specified in an OIDCClient
-	// struct, then it is expected that the Secret is of type "secrets.pinniped.dev/oidc" with keys
+	// struct, then it is expected that the Secret is of type "secrets.pinniped.dev/oidc-client" with keys
 	// "clientID" and "clientSecret".
 	SecretName string `json:"secretName"`
 }

--- a/deploy/supervisor/idp.supervisor.pinniped.dev_upstreamoidcproviders.yaml
+++ b/deploy/supervisor/idp.supervisor.pinniped.dev_upstreamoidcproviders.yaml
@@ -86,7 +86,7 @@ spec:
                     description: SecretName contains the name of a namespace-local
                       Secret object that provides the clientID and clientSecret for
                       an OIDC client. If only the SecretName is specified in an OIDCClient
-                      struct, then it is expected that the Secret is of type "secrets.pinniped.dev/oidc"
+                      struct, then it is expected that the Secret is of type "secrets.pinniped.dev/oidc-client"
                       with keys "clientID" and "clientSecret".
                     type: string
                 required:

--- a/generated/1.17/README.adoc
+++ b/generated/1.17/README.adoc
@@ -442,7 +442,7 @@ OIDCClient contains information about an OIDC client (e.g., client ID and client
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`secretName`* __string__ | SecretName contains the name of a namespace-local Secret object that provides the clientID and clientSecret for an OIDC client. If only the SecretName is specified in an OIDCClient struct, then it is expected that the Secret is of type "secrets.pinniped.dev/oidc" with keys "clientID" and "clientSecret".
+| *`secretName`* __string__ | SecretName contains the name of a namespace-local Secret object that provides the clientID and clientSecret for an OIDC client. If only the SecretName is specified in an OIDCClient struct, then it is expected that the Secret is of type "secrets.pinniped.dev/oidc-client" with keys "clientID" and "clientSecret".
 |===
 
 

--- a/generated/1.17/apis/supervisor/idp/v1alpha1/types_upstreamoidcprovider.go
+++ b/generated/1.17/apis/supervisor/idp/v1alpha1/types_upstreamoidcprovider.go
@@ -62,7 +62,7 @@ type OIDCClaims struct {
 type OIDCClient struct {
 	// SecretName contains the name of a namespace-local Secret object that provides the clientID and
 	// clientSecret for an OIDC client. If only the SecretName is specified in an OIDCClient
-	// struct, then it is expected that the Secret is of type "secrets.pinniped.dev/oidc" with keys
+	// struct, then it is expected that the Secret is of type "secrets.pinniped.dev/oidc-client" with keys
 	// "clientID" and "clientSecret".
 	SecretName string `json:"secretName"`
 }

--- a/generated/1.17/crds/idp.supervisor.pinniped.dev_upstreamoidcproviders.yaml
+++ b/generated/1.17/crds/idp.supervisor.pinniped.dev_upstreamoidcproviders.yaml
@@ -86,7 +86,7 @@ spec:
                     description: SecretName contains the name of a namespace-local
                       Secret object that provides the clientID and clientSecret for
                       an OIDC client. If only the SecretName is specified in an OIDCClient
-                      struct, then it is expected that the Secret is of type "secrets.pinniped.dev/oidc"
+                      struct, then it is expected that the Secret is of type "secrets.pinniped.dev/oidc-client"
                       with keys "clientID" and "clientSecret".
                     type: string
                 required:

--- a/generated/1.18/README.adoc
+++ b/generated/1.18/README.adoc
@@ -442,7 +442,7 @@ OIDCClient contains information about an OIDC client (e.g., client ID and client
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`secretName`* __string__ | SecretName contains the name of a namespace-local Secret object that provides the clientID and clientSecret for an OIDC client. If only the SecretName is specified in an OIDCClient struct, then it is expected that the Secret is of type "secrets.pinniped.dev/oidc" with keys "clientID" and "clientSecret".
+| *`secretName`* __string__ | SecretName contains the name of a namespace-local Secret object that provides the clientID and clientSecret for an OIDC client. If only the SecretName is specified in an OIDCClient struct, then it is expected that the Secret is of type "secrets.pinniped.dev/oidc-client" with keys "clientID" and "clientSecret".
 |===
 
 

--- a/generated/1.18/apis/supervisor/idp/v1alpha1/types_upstreamoidcprovider.go
+++ b/generated/1.18/apis/supervisor/idp/v1alpha1/types_upstreamoidcprovider.go
@@ -62,7 +62,7 @@ type OIDCClaims struct {
 type OIDCClient struct {
 	// SecretName contains the name of a namespace-local Secret object that provides the clientID and
 	// clientSecret for an OIDC client. If only the SecretName is specified in an OIDCClient
-	// struct, then it is expected that the Secret is of type "secrets.pinniped.dev/oidc" with keys
+	// struct, then it is expected that the Secret is of type "secrets.pinniped.dev/oidc-client" with keys
 	// "clientID" and "clientSecret".
 	SecretName string `json:"secretName"`
 }

--- a/generated/1.18/crds/idp.supervisor.pinniped.dev_upstreamoidcproviders.yaml
+++ b/generated/1.18/crds/idp.supervisor.pinniped.dev_upstreamoidcproviders.yaml
@@ -86,7 +86,7 @@ spec:
                     description: SecretName contains the name of a namespace-local
                       Secret object that provides the clientID and clientSecret for
                       an OIDC client. If only the SecretName is specified in an OIDCClient
-                      struct, then it is expected that the Secret is of type "secrets.pinniped.dev/oidc"
+                      struct, then it is expected that the Secret is of type "secrets.pinniped.dev/oidc-client"
                       with keys "clientID" and "clientSecret".
                     type: string
                 required:

--- a/generated/1.19/README.adoc
+++ b/generated/1.19/README.adoc
@@ -442,7 +442,7 @@ OIDCClient contains information about an OIDC client (e.g., client ID and client
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`secretName`* __string__ | SecretName contains the name of a namespace-local Secret object that provides the clientID and clientSecret for an OIDC client. If only the SecretName is specified in an OIDCClient struct, then it is expected that the Secret is of type "secrets.pinniped.dev/oidc" with keys "clientID" and "clientSecret".
+| *`secretName`* __string__ | SecretName contains the name of a namespace-local Secret object that provides the clientID and clientSecret for an OIDC client. If only the SecretName is specified in an OIDCClient struct, then it is expected that the Secret is of type "secrets.pinniped.dev/oidc-client" with keys "clientID" and "clientSecret".
 |===
 
 

--- a/generated/1.19/apis/supervisor/idp/v1alpha1/types_upstreamoidcprovider.go
+++ b/generated/1.19/apis/supervisor/idp/v1alpha1/types_upstreamoidcprovider.go
@@ -62,7 +62,7 @@ type OIDCClaims struct {
 type OIDCClient struct {
 	// SecretName contains the name of a namespace-local Secret object that provides the clientID and
 	// clientSecret for an OIDC client. If only the SecretName is specified in an OIDCClient
-	// struct, then it is expected that the Secret is of type "secrets.pinniped.dev/oidc" with keys
+	// struct, then it is expected that the Secret is of type "secrets.pinniped.dev/oidc-client" with keys
 	// "clientID" and "clientSecret".
 	SecretName string `json:"secretName"`
 }

--- a/generated/1.19/crds/idp.supervisor.pinniped.dev_upstreamoidcproviders.yaml
+++ b/generated/1.19/crds/idp.supervisor.pinniped.dev_upstreamoidcproviders.yaml
@@ -86,7 +86,7 @@ spec:
                     description: SecretName contains the name of a namespace-local
                       Secret object that provides the clientID and clientSecret for
                       an OIDC client. If only the SecretName is specified in an OIDCClient
-                      struct, then it is expected that the Secret is of type "secrets.pinniped.dev/oidc"
+                      struct, then it is expected that the Secret is of type "secrets.pinniped.dev/oidc-client"
                       with keys "clientID" and "clientSecret".
                     type: string
                 required:


### PR DESCRIPTION
The value is correctly validated as `secrets.pinniped.dev/oidc-client` elsewhere, only this comment was wrong.

Fixes #264.

**Release note**:

No release note, since this is just a minor docs change.

```release-note
NONE
```
