### PR TITLE
Tweak timeouts in oidcclient package.

### DIFF
--- a/pkg/oidcclient/login.go
+++ b/pkg/oidcclient/login.go
@@ -37,9 +37,13 @@ const (
 	// API operation.
 	minIDTokenValidity = 10 * time.Minute
 
-	// 	refreshTimeout is the amount of time allotted for OAuth2 refresh operations. Since these don't involve any
-	// 	user interaction, they should always be roughly as fast as network latency.
-	refreshTimeout = 30 * time.Second
+	// httpRequestTimeout is the timeout for operations that involve one (or a few) non-interactive HTTPS requests.
+	// Since these don't involve any user interaction, they should always be roughly as fast as network latency.
+	httpRequestTimeout = 60 * time.Second
+
+	// overallTimeout is the overall time that a login is allowed to take. This includes several user interactions, so
+	// we set this to be relatively long.
+	overallTimeout = 90 * time.Minute
 )
 
 type handlerState struct {
@@ -198,8 +202,13 @@ func Login(issuer string, clientID string, opts ...Option) (*oidctypes.Token, er
 		}
 	}
 
+	// Copy the configured HTTP client to set a request timeout (the Go default client has no timeout configured).
+	httpClientWithTimeout := *h.httpClient
+	httpClientWithTimeout.Timeout = httpRequestTimeout
+	h.httpClient = &httpClientWithTimeout
+
 	// Always set a long, but non-infinite timeout for this operation.
-	ctx, cancel := context.WithTimeout(h.ctx, 10*time.Minute)
+	ctx, cancel := context.WithTimeout(h.ctx, overallTimeout)
 	defer cancel()
 	ctx = oidc.ClientContext(ctx, h.httpClient)
 	h.ctx = ctx
@@ -404,8 +413,6 @@ func (h *handlerState) tokenExchangeRFC8693(baseToken *oidctypes.Token) (*oidcty
 }
 
 func (h *handlerState) handleRefresh(ctx context.Context, refreshToken *oidctypes.RefreshToken) (*oidctypes.Token, error) {
-	ctx, cancel := context.WithTimeout(ctx, refreshTimeout)
-	defer cancel()
 	refreshSource := h.oauth2Config.TokenSource(ctx, &oauth2.Token{RefreshToken: refreshToken.Token})
 
 	refreshed, err := refreshSource.Token()
@@ -473,7 +480,7 @@ func (h *handlerState) serve(listener net.Listener) func() {
 	return func() {
 		// Gracefully shut down the server, allowing up to 5 seconds for
 		// clients to receive any in-flight responses.
-		shutdownCtx, cancel := context.WithTimeout(h.ctx, 1*time.Second)
+		shutdownCtx, cancel := context.WithTimeout(h.ctx, 5*time.Second)
 		_ = srv.Shutdown(shutdownCtx)
 		cancel()
 	}


### PR DESCRIPTION
This change tweaks the timeouts in the oidcclient package, with the goal of more quickly detecting failure scenarios involving hung network requests (e.g., DNS resolution failing) while also allowing more time for interactive login operations (e.g., run `kubectl`, then go get lunch, come back to my IDP login page waiting in a browser tab).

Specifically:
- The overall timeout for logins is increased to 90 minutes.
- The timeout for token refresh is increased from 30 seconds to 60 seconds to be a bit more tolerant of extremely slow networks.
- A new, matching timeout of 60 seconds has been added for the OIDC discovery, auth code exchange, and RFC8693 token exchange operations.

The new code uses the `http.Client.Timeout` field rather than managing contexts on individual requests. This is easier because the OIDC package stores a context at creation time and tries to use it later when performing key refresh operations.

**Release note**:

```release-note
Adjusted timeouts in the `pinniped login oidc` CLI to better handle more scenarios.
```
