### PR TITLE
Only set single secret status field in FederationDomainSecretsController

### DIFF
--- a/cmd/pinniped-supervisor/main.go
+++ b/cmd/pinniped-supervisor/main.go
@@ -15,9 +15,8 @@ import (
 	"strings"
 	"time"
 
-	"go.pinniped.dev/internal/secret"
-
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/clock"
 	kubeinformers "k8s.io/client-go/informers"
@@ -29,6 +28,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
 
+	configv1alpha1 "go.pinniped.dev/generated/1.19/apis/supervisor/config/v1alpha1"
 	pinnipedclientset "go.pinniped.dev/generated/1.19/client/supervisor/clientset/versioned"
 	pinnipedinformers "go.pinniped.dev/generated/1.19/client/supervisor/informers/externalversions"
 	"go.pinniped.dev/internal/config/supervisor"
@@ -42,6 +42,7 @@ import (
 	"go.pinniped.dev/internal/oidc/provider"
 	"go.pinniped.dev/internal/oidc/provider/manager"
 	"go.pinniped.dev/internal/plog"
+	"go.pinniped.dev/internal/secret"
 )
 
 const (
@@ -173,6 +174,9 @@ func startControllers(
 						secretCache.SetTokenHMACKey(federationDomainIssuer, symmetricKey)
 					},
 				),
+				func(fd *configv1alpha1.FederationDomain) *corev1.LocalObjectReference {
+					return &fd.Status.Secrets.TokenSigningKey
+				},
 				kubeClient,
 				pinnipedClient,
 				secretInformer,
@@ -193,6 +197,9 @@ func startControllers(
 						secretCache.SetStateEncoderHashKey(federationDomainIssuer, symmetricKey)
 					},
 				),
+				func(fd *configv1alpha1.FederationDomain) *corev1.LocalObjectReference {
+					return &fd.Status.Secrets.StateSigningKey
+				},
 				kubeClient,
 				pinnipedClient,
 				secretInformer,
@@ -213,6 +220,9 @@ func startControllers(
 						secretCache.SetStateEncoderBlockKey(federationDomainIssuer, symmetricKey)
 					},
 				),
+				func(fd *configv1alpha1.FederationDomain) *corev1.LocalObjectReference {
+					return &fd.Status.Secrets.StateEncryptionKey
+				},
 				kubeClient,
 				pinnipedClient,
 				secretInformer,


### PR DESCRIPTION
This implementation is janky because I wanted to make the smallest change
possible to try to get the code back to stable so we can release.

Also deep copy an object so we aren't mutating the cache.

Signed-off-by: Andrew Keesler <akeesler@vmware.com>

<!--
Thank you for submitting a pull request for Pinniped!

Before submitting, please see the guidelines in CONTRIBUTING.md in this repo.

Please note that a project maintainer will need to review and provide an
initial approval on the PR to cause CI tests to automatically start.
Also note that if you push additional commits to the PR, those commits
will need another initial approval before CI will pick them up.

Reminder: Did you remember to run all the linter, unit tests, and integration tests
described in CONTRIBUTING.md on your branch before submitting this PR?

Below is a template to help you describe your PR.
-->

<!--
Provide a summary of your change. Feel free to use paragraphs or a bulleted list, for example:

- Improves performance by 10,000%.
- Fixes all bugs.
- Boils the oceans.

-->

<!--
Does this PR fix one or more reported issues?
If yes, use `Fixes #<issue number>` to automatically close the fixed issue(s) when the PR is merged.
-->

**Release note**:

<!--
Does this PR introduce a user-facing change?

If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
-->
```release-note
NONE
```
