### PR TITLE
Rename all "op" and "opc" usages

### DIFF
--- a/cmd/pinniped-supervisor/main.go
+++ b/cmd/pinniped-supervisor/main.go
@@ -102,7 +102,7 @@ func startControllers(
 			supervisorstorage.GarbageCollectorController(
 				clock.RealClock{},
 				kubeClient,
-				kubeInformers.Core().V1().Secrets(),
+				secretInformer,
 				controllerlib.WithInformer,
 			),
 			singletonWorker,

--- a/internal/controller/supervisorconfig/generator/federation_domain_secrets.go
+++ b/internal/controller/supervisorconfig/generator/federation_domain_secrets.go
@@ -25,12 +25,12 @@ import (
 )
 
 type federationDomainSecretsController struct {
-	secretHelper   SecretHelper
-	secretRefFunc  func(domain *configv1alpha1.FederationDomain) *corev1.LocalObjectReference
-	kubeClient     kubernetes.Interface
-	pinnipedClient pinnipedclientset.Interface
-	opcInformer    configinformers.FederationDomainInformer
-	secretInformer corev1informers.SecretInformer
+	secretHelper             SecretHelper
+	secretRefFunc            func(domain *configv1alpha1.FederationDomain) *corev1.LocalObjectReference
+	kubeClient               kubernetes.Interface
+	pinnipedClient           pinnipedclientset.Interface
+	federationDomainInformer configinformers.FederationDomainInformer
+	secretInformer           corev1informers.SecretInformer
 }
 
 // NewFederationDomainSecretsController returns a controllerlib.Controller that ensures a child Secret
@@ -42,27 +42,27 @@ func NewFederationDomainSecretsController(
 	kubeClient kubernetes.Interface,
 	pinnipedClient pinnipedclientset.Interface,
 	secretInformer corev1informers.SecretInformer,
-	opcInformer configinformers.FederationDomainInformer,
+	federationDomainInformer configinformers.FederationDomainInformer,
 	withInformer pinnipedcontroller.WithInformerOptionFunc,
 ) controllerlib.Controller {
 	return controllerlib.New(
 		controllerlib.Config{
 			Name: fmt.Sprintf("%s%s", secretHelper.NamePrefix(), "controller"),
 			Syncer: &federationDomainSecretsController{
-				secretHelper:   secretHelper,
-				secretRefFunc:  secretRefFunc,
-				kubeClient:     kubeClient,
-				pinnipedClient: pinnipedClient,
-				secretInformer: secretInformer,
-				opcInformer:    opcInformer,
+				secretHelper:             secretHelper,
+				secretRefFunc:            secretRefFunc,
+				kubeClient:               kubeClient,
+				pinnipedClient:           pinnipedClient,
+				secretInformer:           secretInformer,
+				federationDomainInformer: federationDomainInformer,
 			},
 		},
-		// We want to be notified when a OPC's secret gets updated or deleted. When this happens, we
-		// should get notified via the corresponding OPC key.
+		// We want to be notified when a FederationDomain's secret gets updated or deleted. When this happens, we
+		// should get notified via the corresponding FederationDomain key.
 		withInformer(
 			secretInformer,
-			pinnipedcontroller.SimpleFilter(isOPControllee, func(obj metav1.Object) controllerlib.Key {
-				if isOPControllee(obj) {
+			pinnipedcontroller.SimpleFilter(isFederationDomainControllee, func(obj metav1.Object) controllerlib.Key {
+				if isFederationDomainControllee(obj) {
 					controller := metav1.GetControllerOf(obj)
 					return controllerlib.Key{
 						Name:      controller.Name,
@@ -73,9 +73,9 @@ func NewFederationDomainSecretsController(
 			}),
 			controllerlib.InformerOption{},
 		),
-		// We want to be notified when anything happens to an OPC.
+		// We want to be notified when anything happens to an FederationDomain.
 		withInformer(
-			opcInformer,
+			federationDomainInformer,
 			pinnipedcontroller.MatchAnythingFilter(nil), // nil parent func is fine because each event is distinct
 			controllerlib.InformerOption{},
 		),
@@ -83,7 +83,7 @@ func NewFederationDomainSecretsController(
 }
 
 func (c *federationDomainSecretsController) Sync(ctx controllerlib.Context) error {
-	op, err := c.opcInformer.Lister().FederationDomains(ctx.Key.Namespace).Get(ctx.Key.Name)
+	federationDomain, err := c.federationDomainInformer.Lister().FederationDomains(ctx.Key.Namespace).Get(ctx.Key.Name)
 	notFound := k8serrors.IsNotFound(err)
 	if err != nil && !notFound {
 		return fmt.Errorf(
@@ -95,8 +95,8 @@ func (c *federationDomainSecretsController) Sync(ctx controllerlib.Context) erro
 	}
 
 	if notFound {
-		// The corresponding secret to this OP should have been garbage collected since it should have
-		// had this OP as its owner.
+		// The corresponding secret to this FederationDomain should have been garbage collected since it should have
+		// had this FederationDomain as its owner.
 		plog.Debug(
 			"federationdomain deleted",
 			"federationdomain",
@@ -105,13 +105,13 @@ func (c *federationDomainSecretsController) Sync(ctx controllerlib.Context) erro
 		return nil
 	}
 
-	op = op.DeepCopy()
-	newSecret, err := c.secretHelper.Generate(op)
+	federationDomain = federationDomain.DeepCopy()
+	newSecret, err := c.secretHelper.Generate(federationDomain)
 	if err != nil {
 		return fmt.Errorf("failed to generate secret: %w", err)
 	}
 
-	secretNeedsUpdate, existingSecret, err := c.secretNeedsUpdate(op, newSecret.Name)
+	secretNeedsUpdate, existingSecret, err := c.secretNeedsUpdate(federationDomain, newSecret.Name)
 	if err != nil {
 		return fmt.Errorf("failed to determine secret status: %w", err)
 	}
@@ -120,44 +120,44 @@ func (c *federationDomainSecretsController) Sync(ctx controllerlib.Context) erro
 		plog.Debug(
 			"secret is up to date",
 			"federationdomain",
-			klog.KObj(op),
+			klog.KObj(federationDomain),
 			"secret",
 			klog.KObj(existingSecret),
 		)
 
-		op = c.secretHelper.ObserveActiveSecretAndUpdateParentFederationDomain(op, existingSecret)
-		if err := c.updateFederationDomain(ctx.Context, op); err != nil {
+		federationDomain = c.secretHelper.ObserveActiveSecretAndUpdateParentFederationDomain(federationDomain, existingSecret)
+		if err := c.updateFederationDomain(ctx.Context, federationDomain); err != nil {
 			return fmt.Errorf("failed to update federationdomain: %w", err)
 		}
-		plog.Debug("updated federationdomain", "federationdomain", klog.KObj(op), "secret", klog.KObj(newSecret))
+		plog.Debug("updated federationdomain", "federationdomain", klog.KObj(federationDomain), "secret", klog.KObj(newSecret))
 
 		return nil
 	}
 
-	// If the OP does not have a secret associated with it, that secret does not exist, or the secret
+	// If the FederationDomain does not have a secret associated with it, that secret does not exist, or the secret
 	// is invalid, we will create a new secret.
-	if err := c.createOrUpdateSecret(ctx.Context, op, &newSecret); err != nil {
+	if err := c.createOrUpdateSecret(ctx.Context, federationDomain, &newSecret); err != nil {
 		return fmt.Errorf("failed to create or update secret: %w", err)
 	}
-	plog.Debug("created/updated secret", "federationdomain", klog.KObj(op), "secret", klog.KObj(newSecret))
+	plog.Debug("created/updated secret", "federationdomain", klog.KObj(federationDomain), "secret", klog.KObj(newSecret))
 
-	op = c.secretHelper.ObserveActiveSecretAndUpdateParentFederationDomain(op, newSecret)
-	if err := c.updateFederationDomain(ctx.Context, op); err != nil {
+	federationDomain = c.secretHelper.ObserveActiveSecretAndUpdateParentFederationDomain(federationDomain, newSecret)
+	if err := c.updateFederationDomain(ctx.Context, federationDomain); err != nil {
 		return fmt.Errorf("failed to update federationdomain: %w", err)
 	}
-	plog.Debug("updated federationdomain", "federationdomain", klog.KObj(op), "secret", klog.KObj(newSecret))
+	plog.Debug("updated federationdomain", "federationdomain", klog.KObj(federationDomain), "secret", klog.KObj(newSecret))
 
 	return nil
 }
 
-// secretNeedsUpdate returns whether or not the Secret, with name secretName, for FederationDomain op
+// secretNeedsUpdate returns whether or not the Secret, with name secretName, for the federationDomain param
 // needs to be updated. It returns the existing secret as its second argument.
 func (c *federationDomainSecretsController) secretNeedsUpdate(
-	op *configv1alpha1.FederationDomain,
+	federationDomain *configv1alpha1.FederationDomain,
 	secretName string,
 ) (bool, *corev1.Secret, error) {
-	// This OPC says it has a secret associated with it. Let's try to get it from the cache.
-	secret, err := c.secretInformer.Lister().Secrets(op.Namespace).Get(secretName)
+	// This FederationDomain says it has a secret associated with it. Let's try to get it from the cache.
+	secret, err := c.secretInformer.Lister().Secrets(federationDomain.Namespace).Get(secretName)
 	notFound := k8serrors.IsNotFound(err)
 	if err != nil && !notFound {
 		return false, nil, fmt.Errorf("cannot get secret: %w", err)
@@ -167,7 +167,7 @@ func (c *federationDomainSecretsController) secretNeedsUpdate(
 		return true, nil, nil
 	}
 
-	if !c.secretHelper.IsValid(op, secret) {
+	if !c.secretHelper.IsValid(federationDomain, secret) {
 		// If this secret is invalid, we need to generate a new one.
 		return true, secret, nil
 	}
@@ -177,7 +177,7 @@ func (c *federationDomainSecretsController) secretNeedsUpdate(
 
 func (c *federationDomainSecretsController) createOrUpdateSecret(
 	ctx context.Context,
-	op *configv1alpha1.FederationDomain,
+	federationDomain *configv1alpha1.FederationDomain,
 	newSecret **corev1.Secret,
 ) error {
 	secretClient := c.kubeClient.CoreV1().Secrets((*newSecret).Namespace)
@@ -198,7 +198,7 @@ func (c *federationDomainSecretsController) createOrUpdateSecret(
 		}
 
 		// New secret already exists, so ensure it is up to date.
-		if c.secretHelper.IsValid(op, oldSecret) {
+		if c.secretHelper.IsValid(federationDomain, oldSecret) {
 			// If the secret already has valid a valid Secret, then we are good to go and we don't need an
 			// update.
 			*newSecret = oldSecret
@@ -216,23 +216,23 @@ func (c *federationDomainSecretsController) createOrUpdateSecret(
 
 func (c *federationDomainSecretsController) updateFederationDomain(
 	ctx context.Context,
-	newOP *configv1alpha1.FederationDomain,
+	newFederationDomain *configv1alpha1.FederationDomain,
 ) error {
-	opcClient := c.pinnipedClient.ConfigV1alpha1().FederationDomains(newOP.Namespace)
+	federationDomainClient := c.pinnipedClient.ConfigV1alpha1().FederationDomains(newFederationDomain.Namespace)
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		oldOP, err := opcClient.Get(ctx, newOP.Name, metav1.GetOptions{})
+		oldFederationDomain, err := federationDomainClient.Get(ctx, newFederationDomain.Name, metav1.GetOptions{})
 		if err != nil {
-			return fmt.Errorf("failed to get federationdomain %s/%s: %w", newOP.Namespace, newOP.Name, err)
+			return fmt.Errorf("failed to get federationdomain %s/%s: %w", newFederationDomain.Namespace, newFederationDomain.Name, err)
 		}
 
-		oldOPSecretRef := c.secretRefFunc(oldOP)
-		newOPSecretRef := c.secretRefFunc(newOP)
-		if reflect.DeepEqual(oldOPSecretRef, newOPSecretRef) {
+		oldFederationDomainSecretRef := c.secretRefFunc(oldFederationDomain)
+		newFederationDomainSecretRef := c.secretRefFunc(newFederationDomain)
+		if reflect.DeepEqual(oldFederationDomainSecretRef, newFederationDomainSecretRef) {
 			return nil
 		}
 
-		*oldOPSecretRef = *newOPSecretRef
-		_, err = opcClient.Update(ctx, oldOP, metav1.UpdateOptions{})
+		*oldFederationDomainSecretRef = *newFederationDomainSecretRef
+		_, err = federationDomainClient.Update(ctx, oldFederationDomain, metav1.UpdateOptions{})
 		return err
 	})
 }

--- a/internal/controller/supervisorconfig/generator/generator.go
+++ b/internal/controller/supervisorconfig/generator/generator.go
@@ -95,8 +95,8 @@ func generateSecret(namespace, name string, labels map[string]string, secretData
 	}, nil
 }
 
-// isOPCControlle returns whether the provided obj is controlled by an OPC.
-func isOPControllee(obj metav1.Object) bool {
+// isFederationDomainControllee returns whether the provided obj is controlled by an FederationDomain.
+func isFederationDomainControllee(obj metav1.Object) bool {
 	controller := metav1.GetControllerOf(obj)
 	return controller != nil &&
 		controller.APIVersion == configv1alpha1.SchemeGroupVersion.String() &&

--- a/internal/controller/supervisorconfig/jwks_writer.go
+++ b/internal/controller/supervisorconfig/jwks_writer.go
@@ -30,7 +30,7 @@ import (
 	"go.pinniped.dev/internal/plog"
 )
 
-// These constants are the keys in an OPC's Secret's Data map.
+// These constants are the keys in a FederationDomain's Secret's Data map.
 const (
 	// activeJWKKey points to the current private key used for signing tokens.
 	//
@@ -43,7 +43,7 @@ const (
 )
 
 const (
-	opcKind = "FederationDomain"
+	federationDomainKind = "FederationDomain"
 )
 
 // generateKey is stubbed out for the purpose of testing. The default behavior is to generate an EC key.
@@ -54,44 +54,44 @@ func generateECKey(r io.Reader) (interface{}, error) {
 	return ecdsa.GenerateKey(elliptic.P256(), r)
 }
 
-// jwkController holds the fields necessary for the JWKS controller to communicate with OPC's and
+// jwkController holds the fields necessary for the JWKS controller to communicate with FederationDomains and
 // secrets, both via a cache and via the API.
 type jwksWriterController struct {
-	jwksSecretLabels map[string]string
-	pinnipedClient   pinnipedclientset.Interface
-	kubeClient       kubernetes.Interface
-	opcInformer      configinformers.FederationDomainInformer
-	secretInformer   corev1informers.SecretInformer
+	jwksSecretLabels         map[string]string
+	pinnipedClient           pinnipedclientset.Interface
+	kubeClient               kubernetes.Interface
+	federationDomainInformer configinformers.FederationDomainInformer
+	secretInformer           corev1informers.SecretInformer
 }
 
-// NewJWKSWriterController returns a controllerlib.Controller that ensures an OPC has a corresponding
+// NewJWKSWriterController returns a controllerlib.Controller that ensures a FederationDomain has a corresponding
 // Secret that contains a valid active JWK and JWKS.
 func NewJWKSWriterController(
 	jwksSecretLabels map[string]string,
 	kubeClient kubernetes.Interface,
 	pinnipedClient pinnipedclientset.Interface,
 	secretInformer corev1informers.SecretInformer,
-	opcInformer configinformers.FederationDomainInformer,
+	federationDomainInformer configinformers.FederationDomainInformer,
 	withInformer pinnipedcontroller.WithInformerOptionFunc,
 ) controllerlib.Controller {
 	return controllerlib.New(
 		controllerlib.Config{
 			Name: "JWKSController",
 			Syncer: &jwksWriterController{
-				jwksSecretLabels: jwksSecretLabels,
-				kubeClient:       kubeClient,
-				pinnipedClient:   pinnipedClient,
-				secretInformer:   secretInformer,
-				opcInformer:      opcInformer,
+				jwksSecretLabels:         jwksSecretLabels,
+				kubeClient:               kubeClient,
+				pinnipedClient:           pinnipedClient,
+				secretInformer:           secretInformer,
+				federationDomainInformer: federationDomainInformer,
 			},
 		},
-		// We want to be notified when a OPC's secret gets updated or deleted. When this happens, we
-		// should get notified via the corresponding OPC key.
+		// We want to be notified when a FederationDomain's secret gets updated or deleted. When this happens, we
+		// should get notified via the corresponding FederationDomain key.
 		withInformer(
 			secretInformer,
 			controllerlib.FilterFuncs{
 				ParentFunc: func(obj metav1.Object) controllerlib.Key {
-					if isOPCControllee(obj) {
+					if isFederationDomainControllee(obj) {
 						controller := metav1.GetControllerOf(obj)
 						return controllerlib.Key{
 							Name:      controller.Name,
@@ -100,17 +100,17 @@ func NewJWKSWriterController(
 					}
 					return controllerlib.Key{}
 				},
-				AddFunc: isOPCControllee,
+				AddFunc: isFederationDomainControllee,
 				UpdateFunc: func(oldObj, newObj metav1.Object) bool {
-					return isOPCControllee(oldObj) || isOPCControllee(newObj)
+					return isFederationDomainControllee(oldObj) || isFederationDomainControllee(newObj)
 				},
-				DeleteFunc: isOPCControllee,
+				DeleteFunc: isFederationDomainControllee,
 			},
 			controllerlib.InformerOption{},
 		),
-		// We want to be notified when anything happens to an OPC.
+		// We want to be notified when anything happens to an FederationDomain.
 		withInformer(
-			opcInformer,
+			federationDomainInformer,
 			pinnipedcontroller.MatchAnythingFilter(nil), // nil parent func is fine because each event is distinct
 			controllerlib.InformerOption{},
 		),
@@ -119,7 +119,7 @@ func NewJWKSWriterController(
 
 // Sync implements controllerlib.Syncer.
 func (c *jwksWriterController) Sync(ctx controllerlib.Context) error {
-	opc, err := c.opcInformer.Lister().FederationDomains(ctx.Key.Namespace).Get(ctx.Key.Name)
+	federationDomain, err := c.federationDomainInformer.Lister().FederationDomains(ctx.Key.Namespace).Get(ctx.Key.Name)
 	notFound := k8serrors.IsNotFound(err)
 	if err != nil && !notFound {
 		return fmt.Errorf(
@@ -131,17 +131,17 @@ func (c *jwksWriterController) Sync(ctx controllerlib.Context) error {
 	}
 
 	if notFound {
-		// The corresponding secret to this OPC should have been garbage collected since it should have
-		// had this OPC as its owner.
+		// The corresponding secret to this FederationDomain should have been garbage collected since it should have
+		// had this FederationDomain as its owner.
 		plog.Debug(
-			"federationdomain deleted",
+			"FederationDomain deleted",
 			"federationdomain",
 			klog.KRef(ctx.Key.Namespace, ctx.Key.Name),
 		)
 		return nil
 	}
 
-	secretNeedsUpdate, err := c.secretNeedsUpdate(opc)
+	secretNeedsUpdate, err := c.secretNeedsUpdate(federationDomain)
 	if err != nil {
 		return fmt.Errorf("cannot determine secret status: %w", err)
 	}
@@ -155,9 +155,9 @@ func (c *jwksWriterController) Sync(ctx controllerlib.Context) error {
 		return nil
 	}
 
-	// If the OPC does not have a secret associated with it, that secret does not exist, or the secret
+	// If the FederationDomain does not have a secret associated with it, that secret does not exist, or the secret
 	// is invalid, we will generate a new secret (i.e., a JWKS).
-	secret, err := c.generateSecret(opc)
+	secret, err := c.generateSecret(federationDomain)
 	if err != nil {
 		return fmt.Errorf("cannot generate secret: %w", err)
 	}
@@ -167,25 +167,25 @@ func (c *jwksWriterController) Sync(ctx controllerlib.Context) error {
 	}
 	plog.Debug("created/updated secret", "secret", klog.KObj(secret))
 
-	// Ensure that the OPC points to the secret.
-	newOPC := opc.DeepCopy()
-	newOPC.Status.Secrets.JWKS.Name = secret.Name
-	if err := c.updateOPC(ctx.Context, newOPC); err != nil {
-		return fmt.Errorf("cannot update opc: %w", err)
+	// Ensure that the FederationDomain points to the secret.
+	newFederationDomain := federationDomain.DeepCopy()
+	newFederationDomain.Status.Secrets.JWKS.Name = secret.Name
+	if err := c.updateFederationDomain(ctx.Context, newFederationDomain); err != nil {
+		return fmt.Errorf("cannot update FederationDomain: %w", err)
 	}
-	plog.Debug("updated federationdomain", "federationdomain", klog.KObj(newOPC))
+	plog.Debug("updated FederationDomain", "federationdomain", klog.KObj(newFederationDomain))
 
 	return nil
 }
 
-func (c *jwksWriterController) secretNeedsUpdate(opc *configv1alpha1.FederationDomain) (bool, error) {
-	if opc.Status.Secrets.JWKS.Name == "" {
-		// If the OPC says it doesn't have a secret associated with it, then let's create one.
+func (c *jwksWriterController) secretNeedsUpdate(federationDomain *configv1alpha1.FederationDomain) (bool, error) {
+	if federationDomain.Status.Secrets.JWKS.Name == "" {
+		// If the FederationDomain says it doesn't have a secret associated with it, then let's create one.
 		return true, nil
 	}
 
-	// This OPC says it has a secret associated with it. Let's try to get it from the cache.
-	secret, err := c.secretInformer.Lister().Secrets(opc.Namespace).Get(opc.Status.Secrets.JWKS.Name)
+	// This FederationDomain says it has a secret associated with it. Let's try to get it from the cache.
+	secret, err := c.secretInformer.Lister().Secrets(federationDomain.Namespace).Get(federationDomain.Status.Secrets.JWKS.Name)
 	notFound := k8serrors.IsNotFound(err)
 	if err != nil && !notFound {
 		return false, fmt.Errorf("cannot get secret: %w", err)
@@ -203,9 +203,9 @@ func (c *jwksWriterController) secretNeedsUpdate(opc *configv1alpha1.FederationD
 	return false, nil
 }
 
-func (c *jwksWriterController) generateSecret(opc *configv1alpha1.FederationDomain) (*corev1.Secret, error) {
-	// Note! This is where we could potentially add more handling of OPC spec fields which tell us how
-	// this OIDC provider should sign and verify ID tokens (e.g., hardcoded token secret, gRPC
+func (c *jwksWriterController) generateSecret(federationDomain *configv1alpha1.FederationDomain) (*corev1.Secret, error) {
+	// Note! This is where we could potentially add more handling of FederationDomain spec fields which tell us how
+	// this FederationDomain should sign and verify ID tokens (e.g., hardcoded token secret, gRPC
 	// connection to KMS, etc).
 	//
 	// For now, we just generate an new RSA keypair and put that in the secret.
@@ -236,14 +236,14 @@ func (c *jwksWriterController) generateSecret(opc *configv1alpha1.FederationDoma
 
 	s := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      opc.Name + "-jwks",
-			Namespace: opc.Namespace,
+			Name:      federationDomain.Name + "-jwks",
+			Namespace: federationDomain.Namespace,
 			Labels:    c.jwksSecretLabels,
 			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(opc, schema.GroupVersionKind{
+				*metav1.NewControllerRef(federationDomain, schema.GroupVersionKind{
 					Group:   configv1alpha1.SchemeGroupVersion.Group,
 					Version: configv1alpha1.SchemeGroupVersion.Version,
-					Kind:    opcKind,
+					Kind:    federationDomainKind,
 				}),
 			},
 		},
@@ -290,34 +290,34 @@ func (c *jwksWriterController) createOrUpdateSecret(
 	})
 }
 
-func (c *jwksWriterController) updateOPC(
+func (c *jwksWriterController) updateFederationDomain(
 	ctx context.Context,
-	newOPC *configv1alpha1.FederationDomain,
+	newFederationDomain *configv1alpha1.FederationDomain,
 ) error {
-	opcClient := c.pinnipedClient.ConfigV1alpha1().FederationDomains(newOPC.Namespace)
+	federationDomainClient := c.pinnipedClient.ConfigV1alpha1().FederationDomains(newFederationDomain.Namespace)
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		oldOPC, err := opcClient.Get(ctx, newOPC.Name, metav1.GetOptions{})
+		oldFederationDomain, err := federationDomainClient.Get(ctx, newFederationDomain.Name, metav1.GetOptions{})
 		if err != nil {
-			return fmt.Errorf("cannot get opc: %w", err)
+			return fmt.Errorf("cannot get FederationDomain: %w", err)
 		}
 
-		if newOPC.Status.Secrets.JWKS.Name == oldOPC.Status.Secrets.JWKS.Name {
-			// If the existing OPC is up to date, we don't need to update it.
+		if newFederationDomain.Status.Secrets.JWKS.Name == oldFederationDomain.Status.Secrets.JWKS.Name {
+			// If the existing FederationDomain is up to date, we don't need to update it.
 			return nil
 		}
 
-		oldOPC.Status.Secrets.JWKS.Name = newOPC.Status.Secrets.JWKS.Name
-		_, err = opcClient.Update(ctx, oldOPC, metav1.UpdateOptions{})
+		oldFederationDomain.Status.Secrets.JWKS.Name = newFederationDomain.Status.Secrets.JWKS.Name
+		_, err = federationDomainClient.Update(ctx, oldFederationDomain, metav1.UpdateOptions{})
 		return err
 	})
 }
 
-// isOPCControlle returns whether the provided obj is controlled by an OPC.
-func isOPCControllee(obj metav1.Object) bool {
+// isFederationDomainControlle returns whether the provided obj is controlled by a FederationDomain.
+func isFederationDomainControllee(obj metav1.Object) bool {
 	controller := metav1.GetControllerOf(obj)
 	return controller != nil &&
 		controller.APIVersion == configv1alpha1.SchemeGroupVersion.String() &&
-		controller.Kind == opcKind
+		controller.Kind == federationDomainKind
 }
 
 // isValid returns whether the provided secret contains a valid active JWK and verification JWKS.

--- a/internal/oidc/provider/federation_domain_issuer.go
+++ b/internal/oidc/provider/federation_domain_issuer.go
@@ -11,15 +11,16 @@ import (
 	"go.pinniped.dev/internal/constable"
 )
 
-// FederationDomain represents all of the settings and state for an OIDC provider.
-type FederationDomain struct {
+// FederationDomainIssuer represents all of the settings and state for a downstream OIDC provider
+// as defined by a FederationDomain.
+type FederationDomainIssuer struct {
 	issuer     string
 	issuerHost string
 	issuerPath string
 }
 
-func NewFederationDomain(issuer string) (*FederationDomain, error) {
-	p := FederationDomain{issuer: issuer}
+func NewFederationDomainIssuer(issuer string) (*FederationDomainIssuer, error) {
+	p := FederationDomainIssuer{issuer: issuer}
 	err := p.validate()
 	if err != nil {
 		return nil, err
@@ -27,9 +28,9 @@ func NewFederationDomain(issuer string) (*FederationDomain, error) {
 	return &p, nil
 }
 
-func (p *FederationDomain) validate() error {
+func (p *FederationDomainIssuer) validate() error {
 	if p.issuer == "" {
-		return constable.Error("provider must have an issuer")
+		return constable.Error("federation domain must have an issuer")
 	}
 
 	issuerURL, err := url.Parse(p.issuer)
@@ -63,14 +64,14 @@ func (p *FederationDomain) validate() error {
 	return nil
 }
 
-func (p *FederationDomain) Issuer() string {
+func (p *FederationDomainIssuer) Issuer() string {
 	return p.issuer
 }
 
-func (p *FederationDomain) IssuerHost() string {
+func (p *FederationDomainIssuer) IssuerHost() string {
 	return p.issuerHost
 }
 
-func (p *FederationDomain) IssuerPath() string {
+func (p *FederationDomainIssuer) IssuerPath() string {
 	return p.issuerPath
 }

--- a/internal/oidc/provider/federation_domain_issuer_test.go
+++ b/internal/oidc/provider/federation_domain_issuer_test.go
@@ -9,16 +9,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFederationDomainValidations(t *testing.T) {
+func TestFederationDomainIssuerValidations(t *testing.T) {
 	tests := []struct {
 		name      string
 		issuer    string
 		wantError string
 	}{
 		{
-			name:      "provider must have an issuer",
+			name:      "must have an issuer",
 			issuer:    "",
-			wantError: "provider must have an issuer",
+			wantError: "federation domain must have an issuer",
 		},
 		{
 			name:      "no scheme",
@@ -72,7 +72,7 @@ func TestFederationDomainValidations(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := NewFederationDomain(tt.issuer)
+			_, err := NewFederationDomainIssuer(tt.issuer)
 			if tt.wantError != "" {
 				require.EqualError(t, err, tt.wantError)
 			} else {

--- a/internal/oidc/provider/manager/manager.go
+++ b/internal/oidc/provider/manager/manager.go
@@ -32,7 +32,7 @@ import (
 // It is thread-safe.
 type Manager struct {
 	mu                  sync.RWMutex
-	providers           []*provider.FederationDomain
+	providers           []*provider.FederationDomainIssuer
 	providerHandlers    map[string]http.Handler  // map of all routes for all providers
 	nextHandler         http.Handler             // the next handler in a chain, called when this manager didn't know how to handle a request
 	dynamicJWKSProvider jwks.DynamicJWKSProvider // in-memory cache of per-issuer JWKS data
@@ -68,9 +68,9 @@ func NewManager(
 // It also removes any providerHandlers that were previously added but were not passed in to
 // the current invocation.
 //
-// This method assumes that all of the FederationDomain arguments have already been validated
+// This method assumes that all of the FederationDomainIssuer arguments have already been validated
 // by someone else before they are passed to this method.
-func (m *Manager) SetProviders(federationDomains ...*provider.FederationDomain) {
+func (m *Manager) SetProviders(federationDomains ...*provider.FederationDomainIssuer) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/internal/oidc/provider/manager/manager_test.go
+++ b/internal/oidc/provider/manager/manager_test.go
@@ -348,9 +348,9 @@ func TestManager(t *testing.T) {
 
 		when("given some valid providers via SetProviders()", func() {
 			it.Before(func() {
-				p1, err := provider.NewFederationDomain(issuer1)
+				p1, err := provider.NewFederationDomainIssuer(issuer1)
 				r.NoError(err)
-				p2, err := provider.NewFederationDomain(issuer2)
+				p2, err := provider.NewFederationDomainIssuer(issuer2)
 				r.NoError(err)
 				subject.SetProviders(p1, p2)
 
@@ -391,9 +391,9 @@ func TestManager(t *testing.T) {
 
 		when("given the same valid providers as arguments to SetProviders() in reverse order", func() {
 			it.Before(func() {
-				p1, err := provider.NewFederationDomain(issuer1)
+				p1, err := provider.NewFederationDomainIssuer(issuer1)
 				r.NoError(err)
-				p2, err := provider.NewFederationDomain(issuer2)
+				p2, err := provider.NewFederationDomainIssuer(issuer2)
 				r.NoError(err)
 				subject.SetProviders(p2, p1)
 

--- a/test/integration/supervisor_discovery_test.go
+++ b/test/integration/supervisor_discovery_test.go
@@ -595,17 +595,17 @@ func requireStatus(t *testing.T, client pinnipedclientset.Interface, ns, name st
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
-	var opc *v1alpha1.FederationDomain
+	var federationDomain *v1alpha1.FederationDomain
 	var err error
 	assert.Eventually(t, func() bool {
-		opc, err = client.ConfigV1alpha1().FederationDomains(ns).Get(ctx, name, metav1.GetOptions{})
+		federationDomain, err = client.ConfigV1alpha1().FederationDomains(ns).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			t.Logf("error trying to get FederationDomain: %s", err.Error())
 		}
-		return err == nil && opc.Status.Status == status
+		return err == nil && federationDomain.Status.Status == status
 	}, time.Minute, 200*time.Millisecond)
 	require.NoError(t, err)
-	require.Equalf(t, status, opc.Status.Status, "unexpected status (message = '%s')", opc.Status.Message)
+	require.Equalf(t, status, federationDomain.Status.Status, "unexpected status (message = '%s')", federationDomain.Status.Message)
 }
 
 func newHTTPClient(t *testing.T, caBundle string, dnsOverrides map[string]string) *http.Client {


### PR DESCRIPTION
Rename some files and internal types and local variables. No user-facing or functional changes.

**Release note**:

```release-note
NONE
```
