### PR TITLE
Move our main image references to the VMware Harbor registry.

### DIFF
--- a/deploy/concierge/values.yaml
+++ b/deploy/concierge/values.yaml
@@ -25,7 +25,7 @@ custom_labels: {} #! e.g. {myCustomLabelName: myCustomLabelValue, otherCustomLab
 replicas: 2
 
 #! Specify either an image_digest or an image_tag. If both are given, only image_digest will be used.
-image_repo: docker.io/getpinniped/pinniped-server
+image_repo: projects.registry.vmware.com/pinniped/pinniped-server
 image_digest: #! e.g. sha256:f3c4fdfd3ef865d4b97a1fd295d94acc3f0c654c46b6f27ffad5cf80216903c8
 image_tag: latest
 

--- a/deploy/local-user-authenticator/values.yaml
+++ b/deploy/local-user-authenticator/values.yaml
@@ -5,7 +5,7 @@
 ---
 
 #! Specify either an image_digest or an image_tag. If both are given, only image_digest will be used.
-image_repo: docker.io/getpinniped/pinniped-server
+image_repo: projects.registry.vmware.com/pinniped/pinniped-server
 image_digest: #! e.g. sha256:f3c4fdfd3ef865d4b97a1fd295d94acc3f0c654c46b6f27ffad5cf80216903c8
 image_tag: latest
 

--- a/deploy/supervisor/values.yaml
+++ b/deploy/supervisor/values.yaml
@@ -25,7 +25,7 @@ custom_labels: {} #! e.g. {myCustomLabelName: myCustomLabelValue, otherCustomLab
 replicas: 2
 
 #! Specify either an image_digest or an image_tag. If both are given, only image_digest will be used.
-image_repo: docker.io/getpinniped/pinniped-server
+image_repo: projects.registry.vmware.com/pinniped/pinniped-server
 image_digest: #! e.g. sha256:f3c4fdfd3ef865d4b97a1fd295d94acc3f0c654c46b6f27ffad5cf80216903c8
 image_tag: latest
 

--- a/hack/prepare-for-integration-tests.sh
+++ b/hack/prepare-for-integration-tests.sh
@@ -130,7 +130,7 @@ if ! tilt_mode; then
     fi
   fi
 
-  registry="docker.io"
+  registry="pinniped.local"
   repo="test/build"
   registry_repo="$registry/$repo"
   tag=$(uuidgen) # always a new tag to force K8s to reload the image on redeploy

--- a/test/deploy/dex/proxy.yaml
+++ b/test/deploy/dex/proxy.yaml
@@ -25,7 +25,7 @@ spec:
           emptyDir: {}
       containers:
         - name: proxy
-          image: docker.io/getpinniped/test-forward-proxy
+          image: projects.registry.vmware.com/pinniped/test-forward-proxy
           imagePullPolicy: Always
           ports:
           - name: http


### PR DESCRIPTION
This is primarily to help avoid DockerHub rate limiting. We will continue to distribute the main release images on DockerHub as well, for anyone that prefers to pull from there.

**Release note**:

```release-note
Switched main container registry to https://projects.registry.vmware.com/
```
