### PR TITLE
Remove blockOwnerDeletion from the supervisor secrets

### DIFF
--- a/internal/controller/supervisorconfig/generator/supervisor_secrets.go
+++ b/internal/controller/supervisorconfig/generator/supervisor_secrets.go
@@ -206,7 +206,6 @@ func generateSecret(namespace, name string, labels map[string]string, secretData
 		Kind:    "Deployment",
 	}
 
-	blockOwnerDeletion := true
 	isController := false
 
 	return &corev1.Secret{
@@ -215,12 +214,11 @@ func generateSecret(namespace, name string, labels map[string]string, secretData
 			Namespace: namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion:         deploymentGVK.GroupVersion().String(),
-					Kind:               deploymentGVK.Kind,
-					Name:               owner.GetName(),
-					UID:                owner.GetUID(),
-					BlockOwnerDeletion: &blockOwnerDeletion,
-					Controller:         &isController,
+					APIVersion: deploymentGVK.GroupVersion().String(),
+					Kind:       deploymentGVK.Kind,
+					Name:       owner.GetName(),
+					UID:        owner.GetUID(),
+					Controller: &isController,
 				},
 			},
 			Labels: labels,

--- a/internal/controller/supervisorconfig/generator/supervisor_secrets_test.go
+++ b/internal/controller/supervisorconfig/generator/supervisor_secrets_test.go
@@ -268,20 +268,18 @@ func TestSupervisorSecretsControllerSync(t *testing.T) {
 		generatedSymmetricKey      = []byte("some-neato-32-byte-generated-key")
 		otherGeneratedSymmetricKey = []byte("some-funio-32-byte-generated-key")
 
-		blockOwnerDeletion = true
-		isController       = false
-		generatedSecret    = &corev1.Secret{
+		isController    = false
+		generatedSecret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      generatedSecretName,
 				Namespace: generatedSecretNamespace,
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						APIVersion:         ownerGVK.GroupVersion().String(),
-						Kind:               ownerGVK.Kind,
-						Name:               owner.GetName(),
-						UID:                owner.GetUID(),
-						BlockOwnerDeletion: &blockOwnerDeletion,
-						Controller:         &isController,
+						APIVersion: ownerGVK.GroupVersion().String(),
+						Kind:       ownerGVK.Kind,
+						Name:       owner.GetName(),
+						UID:        owner.GetUID(),
+						Controller: &isController,
 					},
 				},
 				Labels: labels,
@@ -298,12 +296,11 @@ func TestSupervisorSecretsControllerSync(t *testing.T) {
 				Namespace: generatedSecretNamespace,
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						APIVersion:         ownerGVK.GroupVersion().String(),
-						Kind:               ownerGVK.Kind,
-						Name:               owner.GetName(),
-						UID:                owner.GetUID(),
-						BlockOwnerDeletion: &blockOwnerDeletion,
-						Controller:         &isController,
+						APIVersion: ownerGVK.GroupVersion().String(),
+						Kind:       ownerGVK.Kind,
+						Name:       owner.GetName(),
+						UID:        owner.GetUID(),
+						Controller: &isController,
 					},
 				},
 				Labels: labels,


### PR DESCRIPTION
Resolves #304 

<!--
Thank you for submitting a pull request for Pinniped!

Before submitting, please see the guidelines in CONTRIBUTING.md in this repo.

Please note that a project maintainer will need to review and provide an
initial approval on the PR to cause CI tests to automatically start.
Also note that if you push additional commits to the PR, those commits
will need another initial approval before CI will pick them up.

Reminder: Did you remember to run all the linter, unit tests, and integration tests
described in CONTRIBUTING.md on your branch before submitting this PR?

Below is a template to help you describe your PR.
-->

<!--
Provide a summary of your change. Feel free to use paragraphs or a bulleted list, for example:

- Improves performance by 10,000%.
- Fixes all bugs.
- Boils the oceans.

-->

<!--
Does this PR fix one or more reported issues?
If yes, use `Fixes #<issue number>` to automatically close the fixed issue(s) when the PR is merged.
-->

**Release note**:

<!--
Does this PR introduce a user-facing change?

If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
-->
```release-note
Supervisor secrets do not block deletion of the supervisor deployment.
```
