### PR TITLE
test/integration: fix intermittent failures on GKE

### DIFF
--- a/test/integration/concierge_credentialissuerconfig_test.go
+++ b/test/integration/concierge_credentialissuerconfig_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package integration
@@ -60,6 +60,16 @@ func TestCredentialIssuer(t *testing.T) {
 				},
 				actualStatusKubeConfigInfo,
 			)
+
+			// Only validate LastUpdateTime when cluster signing key is available. The last update time
+			// will be set every time our controllers resync, but only when there exists controller
+			// manager pods (all other pods will be filtered out), hence why this assertion is in this
+			// if branch.
+			//
+			// This behavior is up for debate. We should eventually discuss the contract for this
+			// LastUpdateTime field and ensure that the implementation is the same for when the cluster
+			// signing key is available and not available.
+			require.WithinDuration(t, time.Now(), actualStatusStrategy.LastUpdateTime.Local(), 10*time.Minute)
 		} else {
 			require.Equal(t, configv1alpha1.ErrorStrategyStatus, actualStatusStrategy.Status)
 			require.Equal(t, configv1alpha1.CouldNotFetchKeyStrategyReason, actualStatusStrategy.Reason)
@@ -69,7 +79,5 @@ func TestCredentialIssuer(t *testing.T) {
 			// Require `nil` to remind us to address this later for other types of clusters where it is available.
 			require.Nil(t, actualStatusKubeConfigInfo)
 		}
-
-		require.WithinDuration(t, time.Now(), actualStatusStrategy.LastUpdateTime.Local(), 10*time.Minute)
 	})
 }


### PR DESCRIPTION
See comment. This is at least a first step to make our GKE acceptance
environment greener. Previously, this test assumed that the Pinniped-under-test
had been deployed in (roughly) the last 10 minutes, which is not an assumption
that we make anywhere else in the integration test suite.

Signed-off-by: Andrew Keesler <akeesler@vmware.com>

<!--
Thank you for submitting a pull request for Pinniped!

Before submitting, please see the guidelines in CONTRIBUTING.md in this repo.

Please note that a project maintainer will need to review and provide an
initial approval on the PR to cause CI tests to automatically start.
Also note that if you push additional commits to the PR, those commits
will need another initial approval before CI will pick them up.

Reminder: Did you remember to run all the linter, unit tests, and integration tests
described in CONTRIBUTING.md on your branch before submitting this PR?

Below is a template to help you describe your PR.
-->

<!--
Provide a summary of your change. Feel free to use paragraphs or a bulleted list, for example:

- Improves performance by 10,000%.
- Fixes all bugs.
- Boils the oceans.

-->

<!--
Does this PR fix one or more reported issues?
If yes, use `Fixes #<issue number>` to automatically close the fixed issue(s) when the PR is merged.
-->

**Release note**:

<!--
Does this PR introduce a user-facing change?

If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
-->
```release-note
NONE
```
