### PR TITLE
Copyright year validation in linter and pre-commit hook

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -61,8 +61,12 @@ linters-settings:
     lines: 150
     statements: 50
   goheader:
+    values:
+      regexp:
+        # YYYY or YYYY-YYYY
+        YEARS: \d\d\d\d(-\d\d\d\d)?
     template: |-
-        Copyright 2020 the Pinniped contributors. All Rights Reserved.
+        Copyright {{YEARS}} the Pinniped contributors. All Rights Reserved.
         SPDX-License-Identifier: Apache-2.0
   goimports:
     local-prefixes: go.pinniped.dev

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,7 @@ repos:
   - id: detect-private-key
     exclude: testdata
   - id: mixed-line-ending
+- repo: .
+  rev: main
+  hooks:
+  - id: validate-copyright-year

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,9 @@ repos:
   - id: detect-private-key
     exclude: testdata
   - id: mixed-line-ending
-- repo: .
-  rev: main
+- repo: local
   hooks:
   - id: validate-copyright-year
+    name: Validate copyright year
+    entry: hack/check-copyright-year.sh
+    language: script

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,4 @@
+- id: validate-copyright-year
+  name: Validate copyright year
+  entry: hack/check-copyright-year.sh
+  language: script

--- a/hack/check-copyright-year.sh
+++ b/hack/check-copyright-year.sh
@@ -1,0 +1,21 @@
+#
+# Check if copyright statements include the current year
+#
+files=git diff --cached --name-only
+year=date +"%Y"
+
+for f in $files; do
+    head -10 $f | grep -i copyright 2>&1 1>/dev/null || continue
+
+    if ! grep -i -e "copyright.*$year" $f 2>&1 1>/dev/null; then
+        missing_copyright_files="$missing_copyright_files $f"
+    fi
+done
+
+if [ -n "$missing_copyright_files" ]; then
+    echo "$year is missing in the copyright notice of the following files:"
+    for f in $missing_copyright_files; do
+        echo "    $f"
+    done 
+    exit 1
+fi

--- a/hack/check-copyright-year.sh
+++ b/hack/check-copyright-year.sh
@@ -1,3 +1,7 @@
+#!/bin/bash
+
+# Copyright 2021 the Pinniped contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Check if copyright statements include the current year
 #
@@ -16,6 +20,6 @@ if [ -n "$missing_copyright_files" ]; then
     echo "$year is missing in the copyright notice of the following files:"
     for f in $missing_copyright_files; do
         echo "    $f"
-    done 
+    done
     exit 1
 fi

--- a/hack/check-copyright-year.sh
+++ b/hack/check-copyright-year.sh
@@ -17,6 +17,7 @@ for f in $files; do
 done
 
 if [ -n "$missing_copyright_files" ]; then
+    echo "Copyright notice should include the year the file was created and the year the file was last modified."
     echo "$year is missing in the copyright notice of the following files:"
     for f in $missing_copyright_files; do
         echo "    $f"

--- a/hack/check-copyright-year.sh
+++ b/hack/check-copyright-year.sh
@@ -1,8 +1,8 @@
 #
 # Check if copyright statements include the current year
 #
-files=git diff --cached --name-only
-year=date +"%Y"
+files=$(git diff --cached --name-only)
+year=$(date +"%Y")
 
 for f in $files; do
     head -10 $f | grep -i copyright 2>&1 1>/dev/null || continue

--- a/internal/controller/supervisorconfig/generator/supervisor_secrets_test.go
+++ b/internal/controller/supervisorconfig/generator/supervisor_secrets_test.go
@@ -25,6 +25,7 @@ import (
 	"go.pinniped.dev/internal/testutil"
 )
 
+// this is a comment
 var (
 	owner = &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/supervisorconfig/generator/supervisor_secrets_test.go
+++ b/internal/controller/supervisorconfig/generator/supervisor_secrets_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package generator
@@ -25,7 +25,6 @@ import (
 	"go.pinniped.dev/internal/testutil"
 )
 
-// this is a comment
 var (
 	owner = &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--
Thank you for submitting a pull request for Pinniped!

Before submitting, please see the guidelines in CONTRIBUTING.md in this repo.

Please note that a project maintainer will need to review and provide an
initial approval on the PR to cause CI tests to automatically start.
Also note that if you push additional commits to the PR, those commits
will need another initial approval before CI will pick them up.

Reminder: Did you remember to run all the linter, unit tests, and integration tests
described in CONTRIBUTING.md on your branch before submitting this PR?

Below is a template to help you describe your PR.
-->

<!--
Provide a summary of your change. Feel free to use paragraphs or a bulleted list, for example:

- Improves performance by 10,000%.
- Fixes all bugs.
- Boils the oceans.

-->

<!--
Does this PR fix one or more reported issues?
If yes, use `Fixes #<issue number>` to automatically close the fixed issue(s) when the PR is merged.
-->
Resolves #308 

**Release note**:

<!--
Does this PR introduce a user-facing change?

If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
-->
```release-note
NONE
```

This changes the linter to allow either a single year (ex. `Copyright 2021`) or both the year created and the year last modified (ex. `Copyright 2020-2021`).
It also adds a pre-commit hook that requires the current year to be included in any modified files.
