### PR TITLE
Run Tilt images as root for faster reload

### DIFF
--- a/deploy/concierge/deployment.yaml
+++ b/deploy/concierge/deployment.yaml
@@ -90,8 +90,8 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
       securityContext:
-        runAsUser: 1001
-        runAsGroup: 1001
+        runAsUser: #@ data.values.run_as_user
+        runAsGroup: #@ data.values.run_as_group
       serviceAccountName: #@ defaultResourceName()
       #@ if data.values.image_pull_dockerconfigjson and data.values.image_pull_dockerconfigjson != "":
       imagePullSecrets:

--- a/deploy/concierge/values.yaml
+++ b/deploy/concierge/values.yaml
@@ -1,4 +1,4 @@
-#! Copyright 2020 the Pinniped contributors. All Rights Reserved.
+#! Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
 #! SPDX-License-Identifier: Apache-2.0
 
 #@data/values
@@ -54,3 +54,6 @@ api_serving_certificate_renew_before_seconds: 2160000
 #! Specify the verbosity of logging: info ("nice to know" information), debug (developer
 #! information), trace (timing information), all (kitchen sink).
 log_level: #! By default, when this value is left unset, only warnings and errors are printed. There is no way to suppress warning and error logs.
+
+run_as_user: 1001 #! run_as_user specifies the user ID that will own the local-user-authenticator process
+run_as_group: 1001 #! run_as_group specifies the group ID that will own the local-user-authenticator process

--- a/deploy/local-user-authenticator/deployment.yaml
+++ b/deploy/local-user-authenticator/deployment.yaml
@@ -1,4 +1,4 @@
-#! Copyright 2020 the Pinniped contributors. All Rights Reserved.
+#! Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
 #! SPDX-License-Identifier: Apache-2.0
 
 #@ load("@ytt:data", "data")
@@ -48,8 +48,8 @@ spec:
         app: local-user-authenticator
     spec:
       securityContext:
-        runAsUser: 1001
-        runAsGroup: 1001
+        runAsUser: #@ data.values.run_as_user
+        runAsGroup: #@ data.values.run_as_group
       serviceAccountName: local-user-authenticator
       #@ if data.values.image_pull_dockerconfigjson and data.values.image_pull_dockerconfigjson != "":
       imagePullSecrets:

--- a/deploy/local-user-authenticator/values.yaml
+++ b/deploy/local-user-authenticator/values.yaml
@@ -1,4 +1,4 @@
-#! Copyright 2020 the Pinniped contributors. All Rights Reserved.
+#! Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
 #! SPDX-License-Identifier: Apache-2.0
 
 #@data/values
@@ -14,3 +14,6 @@ image_tag: latest
 #! Typically the value would be the output of: kubectl create secret docker-registry x --docker-server=https://example.io --docker-username="USERNAME" --docker-password="PASSWORD" --dry-run=client -o json | jq -r '.data[".dockerconfigjson"]'
 #! Optional.
 image_pull_dockerconfigjson: #! e.g. {"auths":{"https://registry.example.com":{"username":"USERNAME","password":"PASSWORD","auth":"BASE64_ENCODED_USERNAME_COLON_PASSWORD"}}}
+
+run_as_user: 1001 #! run_as_user specifies the user ID that will own the local-user-authenticator process
+run_as_group: 1001 #! run_as_group specifies the group ID that will own the local-user-authenticator process

--- a/deploy/supervisor/deployment.yaml
+++ b/deploy/supervisor/deployment.yaml
@@ -1,4 +1,4 @@
-#! Copyright 2020 the Pinniped contributors. All Rights Reserved.
+#! Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
 #! SPDX-License-Identifier: Apache-2.0
 
 #@ load("@ytt:data", "data")
@@ -64,8 +64,8 @@ spec:
       labels: #@ defaultLabel()
     spec:
       securityContext:
-        runAsUser: 1001
-        runAsGroup: 1001
+        runAsUser: #@ data.values.run_as_user
+        runAsGroup: #@ data.values.run_as_group
       serviceAccountName: #@ defaultResourceName()
       #@ if data.values.image_pull_dockerconfigjson and data.values.image_pull_dockerconfigjson != "":
       imagePullSecrets:

--- a/deploy/supervisor/values.yaml
+++ b/deploy/supervisor/values.yaml
@@ -1,4 +1,4 @@
-#! Copyright 2020 the Pinniped contributors. All Rights Reserved.
+#! Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
 #! SPDX-License-Identifier: Apache-2.0
 
 #@data/values
@@ -56,3 +56,6 @@ service_loadbalancer_ip: #! e.g. 1.2.3.4
 #! Specify the verbosity of logging: info ("nice to know" information), debug (developer
 #! information), trace (timing information), all (kitchen sink).
 log_level: #! By default, when this value is left unset, only warnings and errors are printed. There is no way to suppress warning and error logs.
+
+run_as_user: 1001 #! run_as_user specifies the user ID that will own the local-user-authenticator process
+run_as_group: 1001 #! run_as_group specifies the group ID that will own the local-user-authenticator process

--- a/hack/lib/tilt/Tiltfile
+++ b/hack/lib/tilt/Tiltfile
@@ -60,6 +60,8 @@ k8s_yaml(local([
     '--file', '../../../deploy/local-user-authenticator',
     '--data-value', 'image_repo=image/local-user-auth',
     '--data-value', 'image_tag=tilt-dev',
+    '--data-value-yaml', 'run_as_user=0',
+    '--data-value-yaml', 'run_as_group=0',
 ]))
 # Tell tilt to watch all of those files for changes.
 watch_file('../../../deploy/local-user-authenticator')
@@ -108,6 +110,8 @@ k8s_yaml(local([
     '--data-value-yaml', 'service_https_nodeport_nodeport=31243',
     '--data-value-yaml', 'service_https_clusterip_port=443',
     '--data-value-yaml', 'custom_labels={mySupervisorCustomLabelName: mySupervisorCustomLabelValue}',
+    '--data-value-yaml', 'run_as_user=0',
+    '--data-value-yaml', 'run_as_group=0',
 ]))
 # Tell tilt to watch all of those files for changes.
 watch_file('../../../deploy/supervisor')
@@ -152,7 +156,9 @@ k8s_yaml(local([
     '--data-value discovery_url=$(TERM=dumb kubectl cluster-info | awk \'/master|control plane/ {print $NF}\') ' +
     '--data-value log_level=debug ' +
     '--data-value-yaml replicas=1 ' +
-    '--data-value-yaml "custom_labels={myConciergeCustomLabelName: myConciergeCustomLabelValue}"'
+    '--data-value-yaml "custom_labels={myConciergeCustomLabelName: myConciergeCustomLabelValue}" ' +
+    '--data-value-yaml run_as_user=0 ' +
+    '--data-value-yaml run_as_group=0',
 ]))
 # Tell tilt to watch all of those files for changes.
 watch_file('../../../deploy/concierge')


### PR DESCRIPTION
Previously, when triggering a Tilt reload via a *.go file change, a reload would
take ~13 seconds and we would see this error message in the Tilt logs for each
component.
```
  Live Update failed with unexpected error:
    command terminated with exit code 2
  Falling back to a full image build + deploy
```
Now, Tilt should reload images a lot faster (~3 seconds) since we are running
the images as root.

Note! Reloading the Concierge component still takes ~13 seconds because there
are 2 containers running in the Concierge namespace that use the Concierge
image: the main Concierge app and the kube cert agent pod. Tilt can't live
reload both of these at once, so the reload takes longer and we see this error
message.
```
  Will not perform Live Update because:
    Error retrieving container info: can only get container info for a single pod; image target image:image/concierge has 2 pods
  Falling back to a full image build + deploy
```

<!--
Thank you for submitting a pull request for Pinniped!

Before submitting, please see the guidelines in CONTRIBUTING.md in this repo.

Please note that a project maintainer will need to review and provide an
initial approval on the PR to cause CI tests to automatically start.
Also note that if you push additional commits to the PR, those commits
will need another initial approval before CI will pick them up.

Reminder: Did you remember to run all the linter, unit tests, and integration tests
described in CONTRIBUTING.md on your branch before submitting this PR?

Below is a template to help you describe your PR.
-->

<!--
Provide a summary of your change. Feel free to use paragraphs or a bulleted list, for example:

- Improves performance by 10,000%.
- Fixes all bugs.
- Boils the oceans.

-->

<!--
Does this PR fix one or more reported issues?
If yes, use `Fixes #<issue number>` to automatically close the fixed issue(s) when the PR is merged.
-->

Fixes #248.

**Release note**:

<!--
Does this PR introduce a user-facing change?

If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
-->
```release-note
NONE
```
