### PR TITLE
Restore max in flight check when updating to 0.19.5 #243

### DIFF
--- a/internal/concierge/server/server.go
+++ b/internal/concierge/server/server.go
@@ -191,13 +191,6 @@ func getAggregatedAPIServerConfig(
 		return nil, err
 	}
 
-	// temporarily disable max inflight checks for mutating requests until we
-	// pick up a fix for https://github.com/kubernetes/kubernetes/issues/95300
-	// we do not need to set MaxRequestsInFlight to 0 because we are constantly
-	// hammered by the kubelet for /healthz and the api server for discovery
-	// which keeps the non-mutating request watermark histograms up to date
-	serverConfig.Config.MaxMutatingRequestsInFlight = 0
-
 	apiServerConfig := &apiserver.Config{
 		GenericConfig: serverConfig,
 		ExtraConfig: apiserver.ExtraConfig{


### PR DESCRIPTION
This reverts commit 4a28d1f80083fb7a46180c102e65c1e5a6f977d6.

This commit was originally made to fix a bug that caused TokenCredentialRequest
to become slow when the server was idle for an extended period of time. This was
to address a Kubernetes issue that was fixed in 1.19.5 and onward. We are now
running with Kubernetes 1.20, so we should be able to pick up this fix.

Fixes #243.

<!--
Thank you for submitting a pull request for Pinniped!

Before submitting, please see the guidelines in CONTRIBUTING.md in this repo.

Please note that a project maintainer will need to review and provide an
initial approval on the PR to cause CI tests to automatically start.
Also note that if you push additional commits to the PR, those commits
will need another initial approval before CI will pick them up.

Reminder: Did you remember to run all the linter, unit tests, and integration tests
described in CONTRIBUTING.md on your branch before submitting this PR?

Below is a template to help you describe your PR.
-->

<!--
Provide a summary of your change. Feel free to use paragraphs or a bulleted list, for example:

- Improves performance by 10,000%.
- Fixes all bugs.
- Boils the oceans.

-->

<!--
Does this PR fix one or more reported issues?
If yes, use `Fixes #<issue number>` to automatically close the fixed issue(s) when the PR is merged.
-->

**Release note**:

<!--
Does this PR introduce a user-facing change?

If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
-->
```release-note
Max in-flight checks were restored on the Concierge aggregated API thanks to a bug being fixed in upstream Kubernetes.
```
