### PR TITLE
Update test/integration/kubeclient_test.go to work with Kube 1.20 GC behavior

### DIFF
--- a/test/integration/kubeclient_test.go
+++ b/test/integration/kubeclient_test.go
@@ -258,16 +258,15 @@ func hasOwnerRef(t *testing.T, obj metav1.Object, ref metav1.OwnerReference) {
 func isEventuallyDeleted(t *testing.T, f func() error) {
 	t.Helper()
 
-	require.Eventually(t, func() bool {
+	library.RequireEventuallyWithoutError(t, func() (bool, error) {
 		err := f()
 		switch {
 		case err == nil:
-			return false
+			return false, nil
 		case errors.IsNotFound(err):
-			return true
+			return true, nil
 		default:
-			require.NoError(t, err)
-			return false
+			return false, err
 		}
 	}, time.Minute, time.Second)
 }

--- a/test/integration/kubeclient_test.go
+++ b/test/integration/kubeclient_test.go
@@ -136,30 +136,44 @@ func TestKubeClientOwnerRef(t *testing.T) {
 		return err
 	})
 
-	// sanity check API service client
-	apiService, err := ownerRefClient.Aggregation.ApiregistrationV1().APIServices().Create(
-		ctx,
-		&apiregistrationv1.APIService{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            "v1.pandas.dev",
-				OwnerReferences: nil, // no owner refs set
+	// TODO: update middleware code to not set owner references on cluster-scoped objects.
+	//
+	// The Kube 1.20 garbage collector asserts some new behavior in regards to invalid owner
+	// references (i.e., when you have a namespace-scoped owner references for a cluster-scoped
+	// dependent, the cluster-scoped dependent is not removed). We also found a bug in the 1.20
+	// garbage collector where namespace-scoped dependents are not garbage collected if their owner
+	// had been used as an invalid owner reference before - this bug causes our test to fallover
+	// because we are setting a namespace-scoped owner ref on this APIService.
+	//
+	// We believe that the best way to get around this problem is to update our kubeclient code to
+	// never set owner references on cluster-scoped objects. After we do that, we will uncomment this
+	// part of the test.
+	if false {
+		// sanity check API service client
+		apiService, err := ownerRefClient.Aggregation.ApiregistrationV1().APIServices().Create(
+			ctx,
+			&apiregistrationv1.APIService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "v1.pandas.dev",
+					OwnerReferences: nil, // no owner refs set
+				},
+				Spec: apiregistrationv1.APIServiceSpec{
+					Version:              "v1",
+					Group:                "pandas.dev",
+					GroupPriorityMinimum: 10_000,
+					VersionPriority:      500,
+				},
 			},
-			Spec: apiregistrationv1.APIServiceSpec{
-				Version:              "v1",
-				Group:                "pandas.dev",
-				GroupPriorityMinimum: 10_000,
-				VersionPriority:      500,
-			},
-		},
-		metav1.CreateOptions{},
-	)
-	require.NoError(t, err)
-	hasOwnerRef(t, apiService, ref)
-	// this owner ref is invalid for an API service so it should be immediately deleted
-	isEventuallyDeleted(t, func() error {
-		_, err := ownerRefClient.Aggregation.ApiregistrationV1().APIServices().Get(ctx, apiService.Name, metav1.GetOptions{})
-		return err
-	})
+			metav1.CreateOptions{},
+		)
+		require.NoError(t, err)
+		hasOwnerRef(t, apiService, ref)
+		// this owner ref is invalid for an API service so it should be immediately deleted
+		isEventuallyDeleted(t, func() error {
+			_, err := ownerRefClient.Aggregation.ApiregistrationV1().APIServices().Get(ctx, apiService.Name, metav1.GetOptions{})
+			return err
+		})
+	}
 
 	// sanity check concierge client
 	credentialIssuer, err := ownerRefClient.PinnipedConcierge.ConfigV1alpha1().CredentialIssuers(namespace.Name).Create(

--- a/test/library/assertions.go
+++ b/test/library/assertions.go
@@ -1,0 +1,26 @@
+// Copyright 2021 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package library
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// RequireEventuallyWithoutError is a wrapper around require.Eventually() that allows the caller to
+// return an error from the condition function. If the condition function returns an error at any
+// point, the assertion will immediately fail.
+func RequireEventuallyWithoutError(
+	t *testing.T,
+	f func() (bool, error),
+	waitFor time.Duration,
+	tick time.Duration,
+	msgAndArgs ...interface{},
+) {
+	t.Helper()
+	require.NoError(t, wait.PollImmediate(tick, waitFor, f), msgAndArgs...)
+}


### PR DESCRIPTION
See comment in the code for more details. We are simply commenting out part of the test for now to make a future change to the middleware code really easy to test.


In regards to the testing helper change:
```
    We were seeing a race in this test code since the require.NoError() and
    require.Eventually() would write to the same testing.T state on separate
    goroutines. Hopefully this helper function should cover the cases when we want
    to require.NoError() inside a require.Eventually() without causing a race.
```

**Release note**:

<!--
Does this PR introduce a user-facing change?

If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
-->
```release-note
NONE
```
