### PR TITLE
Fix an issue in TestE2EFullIntegration groups assertions.

### DIFF
--- a/test/integration/e2e_test.go
+++ b/test/integration/e2e_test.go
@@ -292,14 +292,12 @@ func TestE2EFullIntegration(t *testing.T) {
 	require.NotNil(t, token)
 
 	idTokenClaims := token.IDToken.Claims
-	username := idTokenClaims[oidc.DownstreamUsernameClaim].(string)
-	groups, _ := idTokenClaims[oidc.DownstreamGroupsClaim].([]string)
+	require.Equal(t, env.SupervisorTestUpstream.Username, idTokenClaims[oidc.DownstreamUsernameClaim])
 
-	require.Equal(t, env.SupervisorTestUpstream.Username, username)
-	if len(env.SupervisorTestUpstream.ExpectedGroups) == 0 {
-		// We only put a groups claim in our downstream ID token if we got groups from the upstream.
-		require.Nil(t, groups)
-	} else {
-		require.Equal(t, env.SupervisorTestUpstream.ExpectedGroups, groups)
+	// The groups claim in the file ends up as an []interface{}, so adjust our expectation to match.
+	expectedGroups := make([]interface{}, 0, len(env.SupervisorTestUpstream.ExpectedGroups))
+	for _, g := range env.SupervisorTestUpstream.ExpectedGroups {
+		expectedGroups = append(expectedGroups, g)
 	}
+	require.Equal(t, expectedGroups, idTokenClaims[oidc.DownstreamGroupsClaim])
 }


### PR DESCRIPTION
The group claims read from the session cache file are loaded as `[]interface{}` (slice of empty interfaces) so when we previously did a `groups, _ := idTokenClaims[oidc.DownstreamGroupsClaim].([]string)`, then `groups` would always end up nil.

The solution I tried here was to convert the expected value to also be `[]interface{}` so that `require.Equal(t, ...)` does the right thing.

This bug only showed up in our acceptance environnment against Okta, since we don't have any other integration test coverage with IDPs that pass a groups claim.

This is a minor test-only regression from #333.

**Release note**:

```release-note
NONE
```
