### PR TITLE
Clean up docs using https://get.pinniped.dev redirects.

### DIFF
--- a/deploy/concierge/README.md
+++ b/deploy/concierge/README.md
@@ -10,17 +10,17 @@ for details.
 ## Installing the Latest Version with Default Options
 
 ```bash
-kubectl apply -f https://github.com/vmware-tanzu/pinniped/releases/download/$(curl https://api.github.com/repos/vmware-tanzu/pinniped/releases/latest -s | jq .name -r)/install-pinniped-concierge.yaml
+kubectl apply -f https://get.pinniped.dev/latest/install-pinniped-concierge.yaml
 ```
 
-## Installing an Older Version with Default Options
+## Installing a Specific Version with Default Options
 
 Choose your preferred [release](https://github.com/vmware-tanzu/pinniped/releases) version number
 and use it to replace the version number in the URL below.
 
 ```bash
-# Replace v0.2.0 with your preferred version in the URL below
-kubectl apply -f https://github.com/vmware-tanzu/pinniped/releases/download/v0.2.0/install-pinniped-concierge.yaml
+# Replace v0.4.1 with your preferred version in the URL below
+kubectl apply -f https://get.pinniped.dev/v0.4.1/install-pinniped-concierge.yaml
 ```
 
 ## Installing with Custom Options

--- a/deploy/local-user-authenticator/README.md
+++ b/deploy/local-user-authenticator/README.md
@@ -15,17 +15,17 @@ User accounts can be created and edited dynamically using `kubectl` commands (se
 ## Installing the Latest Version with Default Options
 
 ```bash
-kubectl apply -f https://github.com/vmware-tanzu/pinniped/releases/latest/download/install-local-user-authenticator.yaml
+kubectl apply -f https://get.pinniped.dev/latest/install-local-user-authenticator.yaml
 ```
 
-## Installing an Older Version with Default Options
+## Installing a Specific Version with Default Options
 
 Choose your preferred [release](https://github.com/vmware-tanzu/pinniped/releases) version number
 and use it to replace the version number in the URL below.
 
 ```bash
-# Replace v0.2.0 with your preferred version in the URL below
-kubectl apply -f https://github.com/vmware-tanzu/pinniped/releases/download/v0.2.0/install-local-user-authenticator.yaml
+# Replace v0.4.1 with your preferred version in the URL below
+kubectl apply -f https://get.pinniped.dev/v0.4.1/install-local-user-authenticator.yaml
 ```
 
 ## Installing with Custom Options

--- a/deploy/supervisor/README.md
+++ b/deploy/supervisor/README.md
@@ -8,17 +8,17 @@ It can be deployed when those features are needed.
 ## Installing the Latest Version with Default Options
 
 ```bash
-kubectl apply -f https://github.com/vmware-tanzu/pinniped/releases/latest/download/install-pinniped-supervisor.yaml
+kubectl apply -f https://get.pinniped.dev/latest/install-pinniped-supervisor.yaml
 ```
 
-## Installing an Older Version with Default Options
+## Installing a Specific Version with Default Options
 
 Choose your preferred [release](https://github.com/vmware-tanzu/pinniped/releases) version number
 and use it to replace the version number in the URL below.
 
 ```bash
-# Replace v0.3.0 with your preferred version in the URL below
-kubectl apply -f https://github.com/vmware-tanzu/pinniped/releases/download/v0.3.0/install-pinniped-supervisor.yaml
+# Replace v0.4.1 with your preferred version in the URL below
+kubectl apply -f https://get.pinniped.dev/v0.4.1/install-pinniped-supervisor.yaml
 ```
 
 ## Installing with Custom Options

--- a/site/config.yaml
+++ b/site/config.yaml
@@ -20,7 +20,7 @@ markup:
     lineNos: false
     lineNumbersInTable: true
     noClasses: false
-    style: monokai
+    style: monokailight
     tabWidth: 4
 menu:
   docs:

--- a/site/content/docs/concierge-and-supervisor-demo.md
+++ b/site/content/docs/concierge-and-supervisor-demo.md
@@ -138,32 +138,19 @@ to authenticate federated identities from the Supervisor.
    EOF
    ```
 
-1. Query GitHub's API for the git tag of the latest Pinniped
-   [release](https://github.com/vmware-tanzu/pinniped/releases/latest).
-
-   ```bash
-   pinniped_version=$(curl https://api.github.com/repos/vmware-tanzu/pinniped/releases/latest -s | jq .name -r)
-   ```
-
-   Alternatively, you can manually select [any release version](https://github.com/vmware-tanzu/pinniped/releases)
-   of Pinniped.
-
-   ```bash
-   # Example of manually choosing a release version...
-   pinniped_version=v0.3.0
-   ```
-
 1. Deploy the Pinniped Concierge.
 
    ```bash
    kubectl apply \
      --context kind-pinniped-concierge \
-     -f https://github.com/vmware-tanzu/pinniped/releases/download/$pinniped_version/install-pinniped-concierge.yaml
+     -f https://get.pinniped.dev/latest/install-pinniped-concierge.yaml
    ```
 
    The `install-pinniped-concierge.yaml` file includes the default deployment options.
    If you would prefer to customize the available options, please see [deploy/concierge/README.md](https://github.com/vmware-tanzu/pinniped/blob/main/deploy/concierge/README.md)
    for instructions on how to deploy using `ytt`.
+
+   If you prefer to install a specific version, replace `latest` in the above URL with the version number such as `v0.4.1`.
 
 1. Generate a random audience value for this cluster.
 

--- a/site/content/docs/concierge-only-demo.md
+++ b/site/content/docs/concierge-only-demo.md
@@ -55,38 +55,22 @@ as the authenticator.
      installed on some Linux systems via the `apache2-utils` package (e.g., `apt-get install
      apache2-utils`).
 
-   - One of the steps below optionally uses `jq` to help find the latest release version number. It is not required.
-     Install `jq` if you would like, e.g. `brew install jq` on MacOS.
-
 1. Create a new Kubernetes cluster using `kind create cluster`. Optionally provide a cluster name using the `--name` flag.
    kind will automatically update your kubeconfig to point to the new cluster as a user with admin-like permissions.
-
-1. Query GitHub's API for the git tag of the latest Pinniped
-   [release](https://github.com/vmware-tanzu/pinniped/releases/latest).
-
-   ```bash
-   pinniped_version=$(curl https://api.github.com/repos/vmware-tanzu/pinniped/releases/latest -s | jq .name -r)
-   ```
-
-   Alternatively, you can manually select [any release version](https://github.com/vmware-tanzu/pinniped/releases)
-   of Pinniped.
-
-   ```bash
-   # Example of manually choosing a release version...
-   pinniped_version=v0.3.0
-   ```
 
 1. Deploy the local-user-authenticator app. This is a demo authenticator. In production, you would configure
    an authenticator that works with your real identity provider, and therefore would not need to deploy or configure local-user-authenticator.
 
     ```bash
-    kubectl apply -f https://github.com/vmware-tanzu/pinniped/releases/download/$pinniped_version/install-local-user-authenticator.yaml
+    kubectl apply -f https://get.pinniped.dev/latest/install-local-user-authenticator.yaml
     ```
 
    The `install-local-user-authenticator.yaml` file includes the default deployment options.
    If you would prefer to customize the available options, please
    see [deploy/local-user-authenticator/README.md](https://github.com/vmware-tanzu/pinniped/blob/main/deploy/local-user-authenticator/README.md)
    for instructions on how to deploy using `ytt`.
+
+   If you prefer to install a specific version, replace `latest` in the above URL with the version number such as `v0.4.1`.
 
 1. Create a test user named `pinny-the-seal` in the local-user-authenticator namespace.
 
@@ -108,7 +92,7 @@ as the authenticator.
 1. Deploy the Pinniped Concierge.
 
    ```bash
-    kubectl apply -f https://github.com/vmware-tanzu/pinniped/releases/download/$pinniped_version/install-pinniped-concierge.yaml
+   kubectl apply -f https://get.pinniped.dev/latest/install-pinniped-concierge.yaml
    ```
 
    The `install-pinniped-concierge.yaml` file includes the default deployment options.

--- a/site/themes/pinniped/assets/scss/_syntax.css
+++ b/site/themes/pinniped/assets/scss/_syntax.css
@@ -1,0 +1,82 @@
+/* Background */ .chroma { color: #272822; background-color: #fafafa }
+/* Other */ .chroma .x {  }
+/* Error */ .chroma .err { color: #960050; background-color: #1e0010 }
+/* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
+/* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; width: auto; overflow: auto; display: block; }
+/* LineHighlight */ .chroma .hl { display: block; width: 100%;background-color: #ffffcc }
+/* LineNumbersTable */ .chroma .lnt { margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
+/* LineNumbers */ .chroma .ln { margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
+/* Keyword */ .chroma .k { color: #00a8c8 }
+/* KeywordConstant */ .chroma .kc { color: #00a8c8 }
+/* KeywordDeclaration */ .chroma .kd { color: #00a8c8 }
+/* KeywordNamespace */ .chroma .kn { color: #f92672 }
+/* KeywordPseudo */ .chroma .kp { color: #00a8c8 }
+/* KeywordReserved */ .chroma .kr { color: #00a8c8 }
+/* KeywordType */ .chroma .kt { color: #00a8c8 }
+/* Name */ .chroma .n { color: #111111 }
+/* NameAttribute */ .chroma .na { color: #75af00 }
+/* NameBuiltin */ .chroma .nb { color: #111111 }
+/* NameBuiltinPseudo */ .chroma .bp { color: #111111 }
+/* NameClass */ .chroma .nc { color: #75af00 }
+/* NameConstant */ .chroma .no { color: #00a8c8 }
+/* NameDecorator */ .chroma .nd { color: #75af00 }
+/* NameEntity */ .chroma .ni { color: #111111 }
+/* NameException */ .chroma .ne { color: #75af00 }
+/* NameFunction */ .chroma .nf { color: #75af00 }
+/* NameFunctionMagic */ .chroma .fm { color: #111111 }
+/* NameLabel */ .chroma .nl { color: #111111 }
+/* NameNamespace */ .chroma .nn { color: #111111 }
+/* NameOther */ .chroma .nx { color: #75af00 }
+/* NameProperty */ .chroma .py { color: #111111 }
+/* NameTag */ .chroma .nt { color: #f92672 }
+/* NameVariable */ .chroma .nv { color: #111111 }
+/* NameVariableClass */ .chroma .vc { color: #111111 }
+/* NameVariableGlobal */ .chroma .vg { color: #111111 }
+/* NameVariableInstance */ .chroma .vi { color: #111111 }
+/* NameVariableMagic */ .chroma .vm { color: #111111 }
+/* Literal */ .chroma .l { color: #ae81ff }
+/* LiteralDate */ .chroma .ld { color: #d88200 }
+/* LiteralString */ .chroma .s { color: #d88200 }
+/* LiteralStringAffix */ .chroma .sa { color: #d88200 }
+/* LiteralStringBacktick */ .chroma .sb { color: #d88200 }
+/* LiteralStringChar */ .chroma .sc { color: #d88200 }
+/* LiteralStringDelimiter */ .chroma .dl { color: #d88200 }
+/* LiteralStringDoc */ .chroma .sd { color: #d88200 }
+/* LiteralStringDouble */ .chroma .s2 { color: #d88200 }
+/* LiteralStringEscape */ .chroma .se { color: #8045ff }
+/* LiteralStringHeredoc */ .chroma .sh { color: #d88200 }
+/* LiteralStringInterpol */ .chroma .si { color: #d88200 }
+/* LiteralStringOther */ .chroma .sx { color: #d88200 }
+/* LiteralStringRegex */ .chroma .sr { color: #d88200 }
+/* LiteralStringSingle */ .chroma .s1 { color: #d88200 }
+/* LiteralStringSymbol */ .chroma .ss { color: #d88200 }
+/* LiteralNumber */ .chroma .m { color: #ae81ff }
+/* LiteralNumberBin */ .chroma .mb { color: #ae81ff }
+/* LiteralNumberFloat */ .chroma .mf { color: #ae81ff }
+/* LiteralNumberHex */ .chroma .mh { color: #ae81ff }
+/* LiteralNumberInteger */ .chroma .mi { color: #ae81ff }
+/* LiteralNumberIntegerLong */ .chroma .il { color: #ae81ff }
+/* LiteralNumberOct */ .chroma .mo { color: #ae81ff }
+/* Operator */ .chroma .o { color: #f92672 }
+/* OperatorWord */ .chroma .ow { color: #f92672 }
+/* Punctuation */ .chroma .p { color: #111111 }
+/* Comment */ .chroma .c { color: #75715e }
+/* CommentHashbang */ .chroma .ch { color: #75715e }
+/* CommentMultiline */ .chroma .cm { color: #75715e }
+/* CommentSingle */ .chroma .c1 { color: #75715e }
+/* CommentSpecial */ .chroma .cs { color: #75715e }
+/* CommentPreproc */ .chroma .cp { color: #75715e }
+/* CommentPreprocFile */ .chroma .cpf { color: #75715e }
+/* Generic */ .chroma .g {  }
+/* GenericDeleted */ .chroma .gd {  }
+/* GenericEmph */ .chroma .ge { font-style: italic }
+/* GenericError */ .chroma .gr {  }
+/* GenericHeading */ .chroma .gh {  }
+/* GenericInserted */ .chroma .gi {  }
+/* GenericOutput */ .chroma .go {  }
+/* GenericPrompt */ .chroma .gp {  }
+/* GenericStrong */ .chroma .gs { font-weight: bold }
+/* GenericSubheading */ .chroma .gu {  }
+/* GenericTraceback */ .chroma .gt {  }
+/* GenericUnderline */ .chroma .gl {  }
+/* TextWhitespace */ .chroma .w {  }

--- a/site/themes/pinniped/assets/scss/site.scss
+++ b/site/themes/pinniped/assets/scss/site.scss
@@ -4,3 +4,4 @@
 @import 'variables';
 @import 'components';
 @import 'mixins';
+@import 'syntax';


### PR DESCRIPTION
We have these redirects set up to make the `kubectl apply -f [...]` commands cleaner, but we never went back and fixed up the documentation to use them until now.

I also reformatted the concierge demo a tiny bit, mostly to show the example output you get from running each step. I was hoping this makes it more useful to someone who is only reading the doc and not following along on their own cluster.

For reference, the redirects we're using here are configured in https://github.com/vmware-tanzu/pinniped/blob/main/site/redirects/get.pinniped.dev/netlify.toml.

**Release note**:

```release-note
NONE
```
