### PR TITLE
Fix get.pinniped.dev latest version redirects.

### DIFF
--- a/site/redirects/get.pinniped.dev/netlify.toml
+++ b/site/redirects/get.pinniped.dev/netlify.toml
@@ -1,7 +1,7 @@
 
 [[redirects]]
   from = "/latest/*"
-  to = "https://github.com/vmware-tanzu/pinniped/releases/download/v0.4.1/:splat"
+  to = "https://github.com/vmware-tanzu/pinniped/releases/download/latest/:splat"
   status = 302
   force = true
 

--- a/site/redirects/get.pinniped.dev/netlify.toml
+++ b/site/redirects/get.pinniped.dev/netlify.toml
@@ -1,7 +1,7 @@
 
 [[redirects]]
   from = "/latest/*"
-  to = "https://github.com/vmware-tanzu/pinniped/releases/download/v0.2.0/:splat"
+  to = "https://github.com/vmware-tanzu/pinniped/releases/download/v0.4.1/:splat"
   status = 302
   force = true
 


### PR DESCRIPTION
Fix the "latest" version redirect for `get.pinniped.dev`.

Thanks @cfryanr for catching this.

**Release note**:
```release-note
NONE
```
