### PR TITLE
Add Codecov configuration file.

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,13 @@
+codecov:
+  strict_yaml_branch: main
+  require_ci_to_pass: no
+  notify:
+    wait_for_ci: no  
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
This configures how our coverage reports are processed on https://codecov.io. See https://docs.codecov.io/docs/codecov-yaml for reference.

**Release note**:
```release-note
NONE
```
