### PR TITLE
Add some trivial unit tests to internal/oidc/csrftoken.

### DIFF
--- a/internal/oidc/csrftoken/csrftoken_test.go
+++ b/internal/oidc/csrftoken/csrftoken_test.go
@@ -1,0 +1,22 @@
+// Copyright 2021 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package csrftoken
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCSRFToken(t *testing.T) {
+	tok, err := Generate()
+	require.NoError(t, err)
+	require.Len(t, tok, 64)
+
+	var empty bytes.Buffer
+	tok, err = generate(&empty)
+	require.EqualError(t, err, "could not generate CSRFToken: EOF")
+	require.Empty(t, tok)
+}


### PR DESCRIPTION
This change is primarily to test that our test coverage reporting is working as expected.

**Release note**:
```release-note
NONE
```
