### PR TITLE
Use middleware to mutate TokenCredentialRequest.Spec.Authenticator.APIGroup

### DIFF
--- a/internal/kubeclient/middleware_test.go
+++ b/internal/kubeclient/middleware_test.go
@@ -15,7 +15,7 @@ import (
 func Test_request_mutate(t *testing.T) {
 	tests := []struct {
 		name     string
-		reqFuncs []func(Object)
+		reqFuncs []func(Object) error
 		obj      Object
 		want     *mutationResult
 		wantObj  Object
@@ -23,10 +23,11 @@ func Test_request_mutate(t *testing.T) {
 	}{
 		{
 			name: "mutate config map data",
-			reqFuncs: []func(Object){
-				func(obj Object) {
+			reqFuncs: []func(Object) error{
+				func(obj Object) error {
 					cm := obj.(*corev1.ConfigMap)
 					cm.Data = map[string]string{"new": "stuff"}
+					return nil
 				},
 			},
 			obj: &corev1.ConfigMap{

--- a/internal/kubeclient/verb_test.go
+++ b/internal/kubeclient/verb_test.go
@@ -42,7 +42,7 @@ func Test_verb(t *testing.T) {
 			f: func() string {
 				return fmt.Errorf("%#v", request{verb: VerbPatch}).Error()
 			},
-			want: `kubeclient.request{verb:"patch", namespace:"", resource:schema.GroupVersionResource{Group:"", Version:"", Resource:""}, reqFuncs:[]func(kubeclient.Object)(nil), respFuncs:[]func(kubeclient.Object)(nil), subresource:""}`,
+			want: `kubeclient.request{verb:"patch", namespace:"", resource:schema.GroupVersionResource{Group:"", Version:"", Resource:""}, reqFuncs:[]func(kubeclient.Object) error(nil), respFuncs:[]func(kubeclient.Object) error(nil), subresource:""}`,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/ownerref/ownerref.go
+++ b/internal/ownerref/ownerref.go
@@ -51,13 +51,15 @@ func New(refObj kubeclient.Object) kubeclient.Middleware {
 			return
 		}
 
-		rt.MutateRequest(func(obj kubeclient.Object) {
+		rt.MutateRequest(func(obj kubeclient.Object) error {
 			// we only want to set the owner ref on create and when one is not already present
 			if len(obj.GetOwnerReferences()) != 0 {
-				return
+				return nil
 			}
 
 			obj.SetOwnerReferences([]metav1.OwnerReference{ref})
+
+			return nil
 		})
 	})
 }

--- a/internal/ownerref/ownerref_test.go
+++ b/internal/ownerref/ownerref_test.go
@@ -213,7 +213,7 @@ func TestOwnerReferenceMiddleware(t *testing.T) {
 			orig := tt.args.obj.DeepCopyObject().(kubeclient.Object)
 			for _, mutateRequest := range rt.MutateRequests {
 				mutateRequest := mutateRequest
-				mutateRequest(tt.args.obj)
+				require.NoError(t, mutateRequest(tt.args.obj))
 			}
 			if !tt.wantMutates {
 				require.Equal(t, orig, tt.args.obj)

--- a/internal/plog/klog.go
+++ b/internal/plog/klog.go
@@ -4,6 +4,7 @@
 package plog
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/spf13/pflag"
@@ -30,6 +31,17 @@ func RemoveKlogGlobalFlags() {
 	if pflag.CommandLine.Changed(globalLogFlushFlag) {
 		panic("unsupported global klog flag set")
 	}
+}
+
+// KRef is (mostly) copied from klog - it is a standard way to represent a a metav1.Object in logs
+// when you only have access to the namespace and name of the object.
+func KRef(namespace, name string) string {
+	return fmt.Sprintf("%s/%s", namespace, name)
+}
+
+// KObj is (mostly) copied from klog - it is a standard way to represent a metav1.Object in logs.
+func KObj(obj klog.KMetadata) string {
+	return fmt.Sprintf("%s/%s", obj.GetNamespace(), obj.GetName())
 }
 
 func klogLevelForPlogLevel(plogLevel LogLevel) (klogLevel klog.Level) {

--- a/internal/testutil/roundtrip.go
+++ b/internal/testutil/roundtrip.go
@@ -17,7 +17,7 @@ type RoundTrip struct {
 	resource        schema.GroupVersionResource
 	subresource     string
 
-	MutateRequests, MutateResponses []func(kubeclient.Object)
+	MutateRequests, MutateResponses []func(kubeclient.Object) error
 }
 
 func (rt *RoundTrip) WithVerb(verb kubeclient.Verb) *RoundTrip {
@@ -61,10 +61,10 @@ func (rt *RoundTrip) Subresource() string {
 	return rt.subresource
 }
 
-func (rt *RoundTrip) MutateRequest(fn func(kubeclient.Object)) {
+func (rt *RoundTrip) MutateRequest(fn func(kubeclient.Object) error) {
 	rt.MutateRequests = append(rt.MutateRequests, fn)
 }
 
-func (rt *RoundTrip) MutateResponse(fn func(kubeclient.Object)) {
+func (rt *RoundTrip) MutateResponse(fn func(kubeclient.Object) error) {
 	rt.MutateResponses = append(rt.MutateResponses, fn)
 }

--- a/pkg/conciergeclient/conciergeclient_test.go
+++ b/pkg/conciergeclient/conciergeclient_test.go
@@ -21,7 +21,6 @@ import (
 
 	loginv1alpha1 "go.pinniped.dev/generated/1.20/apis/concierge/login/v1alpha1"
 	"go.pinniped.dev/internal/certauthority"
-	"go.pinniped.dev/internal/here"
 	"go.pinniped.dev/internal/testutil"
 )
 
@@ -221,7 +220,47 @@ func TestExchangeToken(t *testing.T) {
 		t.Parallel()
 		expires := metav1.NewTime(time.Now().Truncate(time.Second))
 
-		caBundle, endpoint := runFakeServer(t, expires, "pinniped.dev")
+		// Start a test server that returns successfully and asserts various properties of the request.
+		caBundle, endpoint := testutil.TLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, http.MethodPost, r.Method)
+			require.Equal(t, "/apis/login.concierge.pinniped.dev/v1alpha1/namespaces/test-namespace/tokencredentialrequests", r.URL.Path)
+			require.Equal(t, "application/json", r.Header.Get("content-type"))
+
+			body, err := ioutil.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.JSONEq(t,
+				`{
+				  "kind": "TokenCredentialRequest",
+				  "apiVersion": "login.concierge.pinniped.dev/v1alpha1",
+				  "metadata": {
+					"creationTimestamp": null,
+					"namespace": "test-namespace"
+				  },
+				  "spec": {
+					"token": "test-token",
+					"authenticator": {
+						"apiGroup": "authentication.concierge.pinniped.dev",
+						"kind": "WebhookAuthenticator",
+						"name": "test-webhook"
+					}
+				  },
+				  "status": {}
+				}`,
+				string(body),
+			)
+
+			w.Header().Set("content-type", "application/json")
+			_ = json.NewEncoder(w).Encode(&loginv1alpha1.TokenCredentialRequest{
+				TypeMeta: metav1.TypeMeta{APIVersion: "login.concierge.pinniped.dev/v1alpha1", Kind: "TokenCredentialRequest"},
+				Status: loginv1alpha1.TokenCredentialRequestStatus{
+					Credential: &loginv1alpha1.ClusterCredential{
+						ExpirationTimestamp:   expires,
+						ClientCertificateData: "test-certificate",
+						ClientKeyData:         "test-key",
+					},
+				},
+			})
+		})
 
 		client, err := New(WithNamespace("test-namespace"), WithEndpoint(endpoint), WithCABundle(caBundle), WithAuthenticator("webhook", "test-webhook"))
 		require.NoError(t, err)
@@ -240,78 +279,4 @@ func TestExchangeToken(t *testing.T) {
 			},
 		}, got)
 	})
-
-	t.Run("changing the API group suffix for the client sends the custom suffix on the CredentialRequest's APIGroup and on its spec.Authenticator.APIGroup", func(t *testing.T) {
-		t.Parallel()
-		expires := metav1.NewTime(time.Now().Truncate(time.Second))
-
-		caBundle, endpoint := runFakeServer(t, expires, "suffix.com")
-
-		client, err := New(WithAPIGroupSuffix("suffix.com"), WithNamespace("test-namespace"), WithEndpoint(endpoint), WithCABundle(caBundle), WithAuthenticator("webhook", "test-webhook"))
-		require.NoError(t, err)
-
-		got, err := client.ExchangeToken(ctx, "test-token")
-		require.NoError(t, err)
-		require.Equal(t, &clientauthenticationv1beta1.ExecCredential{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "ExecCredential",
-				APIVersion: "client.authentication.k8s.io/v1beta1",
-			},
-			Status: &clientauthenticationv1beta1.ExecCredentialStatus{
-				ClientCertificateData: "test-certificate",
-				ClientKeyData:         "test-key",
-				ExpirationTimestamp:   &expires,
-			},
-		}, got)
-	})
-}
-
-// Start a test server that returns successfully and asserts various properties of the request.
-func runFakeServer(t *testing.T, expires metav1.Time, pinnipedAPIGroupSuffix string) (string, string) {
-	caBundle, endpoint := testutil.TLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, http.MethodPost, r.Method)
-		require.Equal(t,
-			fmt.Sprintf("/apis/login.concierge.%s/v1alpha1/namespaces/test-namespace/tokencredentialrequests", pinnipedAPIGroupSuffix),
-			r.URL.Path)
-		require.Equal(t, "application/json", r.Header.Get("content-type"))
-
-		body, err := ioutil.ReadAll(r.Body)
-		require.NoError(t, err)
-		require.JSONEq(t, here.Docf(
-			`{
-				  "kind": "TokenCredentialRequest",
-				  "apiVersion": "login.concierge.%s/v1alpha1",
-				  "metadata": {
-					"creationTimestamp": null,
-					"namespace": "test-namespace"
-				  },
-				  "spec": {
-					"token": "test-token",
-					"authenticator": {
-						"apiGroup": "authentication.concierge.%s",
-						"kind": "WebhookAuthenticator",
-						"name": "test-webhook"
-					}
-				  },
-				  "status": {}
-				}`, pinnipedAPIGroupSuffix, pinnipedAPIGroupSuffix),
-			string(body),
-		)
-
-		w.Header().Set("content-type", "application/json")
-		_ = json.NewEncoder(w).Encode(&loginv1alpha1.TokenCredentialRequest{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: fmt.Sprintf("login.concierge.%s/v1alpha1", pinnipedAPIGroupSuffix),
-				Kind:       "TokenCredentialRequest",
-			},
-			Status: loginv1alpha1.TokenCredentialRequestStatus{
-				Credential: &loginv1alpha1.ClusterCredential{
-					ExpirationTimestamp:   expires,
-					ClientCertificateData: "test-certificate",
-					ClientKeyData:         "test-key",
-				},
-			},
-		})
-	})
-	return caBundle, endpoint
 }

--- a/test/integration/concierge_credentialrequest_test.go
+++ b/test/integration/concierge_credentialrequest_test.go
@@ -135,7 +135,16 @@ func TestFailedCredentialRequestWhenTheRequestIsValidButTheTokenDoesNotAuthentic
 
 	library.AssertNoRestartsDuringTest(t, env.ConciergeNamespace, "")
 
-	response, err := makeRequest(context.Background(), t, loginv1alpha1.TokenCredentialRequestSpec{Token: "not a good token"})
+	// Create a testWebhook so we have a legitimate authenticator to pass to the
+	// TokenCredentialRequest API.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+	testWebhook := library.CreateTestWebhookAuthenticator(ctx, t)
+
+	response, err := makeRequest(context.Background(), t, loginv1alpha1.TokenCredentialRequestSpec{
+		Token:         "not a good token",
+		Authenticator: testWebhook,
+	})
 
 	require.NoError(t, err)
 
@@ -149,7 +158,16 @@ func TestCredentialRequest_ShouldFailWhenRequestDoesNotIncludeToken(t *testing.T
 
 	library.AssertNoRestartsDuringTest(t, env.ConciergeNamespace, "")
 
-	response, err := makeRequest(context.Background(), t, loginv1alpha1.TokenCredentialRequestSpec{Token: ""})
+	// Create a testWebhook so we have a legitimate authenticator to pass to the
+	// TokenCredentialRequest API.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+	testWebhook := library.CreateTestWebhookAuthenticator(ctx, t)
+
+	response, err := makeRequest(context.Background(), t, loginv1alpha1.TokenCredentialRequestSpec{
+		Token:         "",
+		Authenticator: testWebhook,
+	})
 
 	require.Error(t, err)
 	statusError, isStatus := err.(*errors.StatusError)

--- a/test/library/client.go
+++ b/test/library/client.go
@@ -180,11 +180,8 @@ func CreateTestWebhookAuthenticator(ctx context.Context, t *testing.T) corev1.Ty
 		require.NoErrorf(t, err, "could not cleanup test WebhookAuthenticator %s/%s", webhook.Namespace, webhook.Name)
 	})
 
-	apiGroup, replacedSuffix := groupsuffix.Replace(auth1alpha1.SchemeGroupVersion.Group, testEnv.APIGroupSuffix)
-	require.True(t, replacedSuffix)
-
 	return corev1.TypedLocalObjectReference{
-		APIGroup: &apiGroup,
+		APIGroup: &auth1alpha1.SchemeGroupVersion.Group,
 		Kind:     "WebhookAuthenticator",
 		Name:     webhook.Name,
 	}
@@ -253,11 +250,8 @@ func CreateTestJWTAuthenticator(ctx context.Context, t *testing.T, spec auth1alp
 		require.NoErrorf(t, err, "could not cleanup test JWTAuthenticator %s/%s", jwtAuthenticator.Namespace, jwtAuthenticator.Name)
 	})
 
-	apiGroup, replacedSuffix := groupsuffix.Replace(auth1alpha1.SchemeGroupVersion.Group, testEnv.APIGroupSuffix)
-	require.True(t, replacedSuffix)
-
 	return corev1.TypedLocalObjectReference{
-		APIGroup: &apiGroup,
+		APIGroup: &auth1alpha1.SchemeGroupVersion.Group,
 		Kind:     "JWTAuthenticator",
 		Name:     jwtAuthenticator.Name,
 	}


### PR DESCRIPTION
This PR leverages middleware to mutate `TokenCredentialRequest.Spec.Authenticator.APIGroup` instead of doing one-off mutation.

For some reason I thought this would be more difficult/not work back in 288d9c999efe. Oh well. I'll blame it on the lack of sleep. The `internal/conciergeclient` changes in this PR are a manual revert of the changes in that package from 288d9c999efe.

I left the server side alone because, like back in 288d9c999efe, I couldn't figure out a simple way to mutate server-side requests on the way in.

**Release note**:

```release-note
NONE
```
