### PR TITLE
Add no-op list support to token credential request

### DIFF
--- a/internal/concierge/apiserver/apiserver.go
+++ b/internal/concierge/apiserver/apiserver.go
@@ -71,7 +71,7 @@ func (c completedConfig) New() (*PinnipedServer, error) {
 	}
 
 	gvr := c.ExtraConfig.GroupVersion.WithResource("tokencredentialrequests")
-	storage := credentialrequest.NewREST(c.ExtraConfig.Authenticator, c.ExtraConfig.Issuer)
+	storage := credentialrequest.NewREST(c.ExtraConfig.Authenticator, c.ExtraConfig.Issuer, gvr.GroupResource())
 	if err := s.GenericAPIServer.InstallAPIGroup(&genericapiserver.APIGroupInfo{
 		PrioritizedVersions:          []schema.GroupVersion{gvr.GroupVersion()},
 		VersionedResourcesStorageMap: map[string]map[string]rest.Storage{gvr.Version: {gvr.Resource: storage}},

--- a/test/integration/category_test.go
+++ b/test/integration/category_test.go
@@ -1,0 +1,96 @@
+// Copyright 2021 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"bytes"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.pinniped.dev/test/library"
+)
+
+func TestGetPinnipedCategory(t *testing.T) {
+	env := library.IntegrationEnv(t)
+	dotSuffix := "." + env.APIGroupSuffix
+
+	t.Run("category, no special params", func(t *testing.T) {
+		var stdOut, stdErr bytes.Buffer
+
+		cmd := exec.Command("kubectl", "get", "pinniped", "-A")
+		cmd.Stdout = &stdOut
+		cmd.Stderr = &stdErr
+		err := cmd.Run()
+		require.NoError(t, err, stdErr.String(), stdOut.String())
+		require.Empty(t, stdErr.String())
+
+		require.NotContains(t, stdOut.String(), "MethodNotAllowed")
+		require.Contains(t, stdOut.String(), dotSuffix)
+	})
+
+	t.Run("category, table params", func(t *testing.T) {
+		var stdOut, stdErr bytes.Buffer
+
+		cmd := exec.Command("kubectl", "get", "pinniped", "-A", "-o", "wide", "-v", "10")
+		cmd.Stdout = &stdOut
+		cmd.Stderr = &stdErr
+		err := cmd.Run()
+		require.NoError(t, err, stdErr.String(), stdOut.String())
+
+		require.NotContains(t, stdOut.String(), "MethodNotAllowed")
+		require.Contains(t, stdOut.String(), dotSuffix)
+
+		require.Contains(t, stdErr.String(), `"kind":"Table"`)
+		require.Contains(t, stdErr.String(), `"resourceVersion":"0"`)
+	})
+
+	t.Run("list, no special params", func(t *testing.T) {
+		var stdOut, stdErr bytes.Buffer
+
+		//nolint: gosec  // input is part of test env
+		cmd := exec.Command("kubectl", "get", "tokencredentialrequests.login.concierge"+dotSuffix, "-A")
+		cmd.Stdout = &stdOut
+		cmd.Stderr = &stdErr
+		err := cmd.Run()
+		require.NoError(t, err, stdErr.String(), stdOut.String())
+		require.Empty(t, stdOut.String())
+
+		require.NotContains(t, stdErr.String(), "MethodNotAllowed")
+		require.Contains(t, stdErr.String(), `No resources found`)
+	})
+
+	t.Run("list, table params", func(t *testing.T) {
+		var stdOut, stdErr bytes.Buffer
+
+		//nolint: gosec  // input is part of test env
+		cmd := exec.Command("kubectl", "get", "tokencredentialrequests.login.concierge"+dotSuffix, "-A", "-o", "wide", "-v", "10")
+		cmd.Stdout = &stdOut
+		cmd.Stderr = &stdErr
+		err := cmd.Run()
+		require.NoError(t, err, stdErr.String(), stdOut.String())
+		require.Empty(t, stdOut.String())
+
+		require.NotContains(t, stdErr.String(), "MethodNotAllowed")
+		require.Contains(t, stdErr.String(), `"kind":"Table"`)
+		require.Contains(t, stdErr.String(), `"resourceVersion":"0"`)
+	})
+
+	t.Run("raw request to see body", func(t *testing.T) {
+		var stdOut, stdErr bytes.Buffer
+
+		//nolint: gosec  // input is part of test env
+		cmd := exec.Command("kubectl", "get", "--raw", "/apis/login.concierge"+dotSuffix+"/v1alpha1/tokencredentialrequests")
+		cmd.Stdout = &stdOut
+		cmd.Stderr = &stdErr
+		err := cmd.Run()
+		require.NoError(t, err, stdErr.String(), stdOut.String())
+		require.Empty(t, stdErr.String())
+
+		require.NotContains(t, stdOut.String(), "MethodNotAllowed")
+		require.Contains(t, stdOut.String(), `{"kind":"TokenCredentialRequestList","apiVersion":"login.concierge`+
+			dotSuffix+`/v1alpha1","metadata":{"resourceVersion":"0"},"items":[]}`)
+	})
+}

--- a/test/integration/kube_api_discovery_test.go
+++ b/test/integration/kube_api_discovery_test.go
@@ -72,7 +72,7 @@ func TestGetAPIResourceList(t *testing.T) {
 					{
 						Name:       "tokencredentialrequests",
 						Kind:       "TokenCredentialRequest",
-						Verbs:      []string{"create"},
+						Verbs:      []string{"create", "list"},
 						Namespaced: true,
 						Categories: []string{"pinniped"},
 					},


### PR DESCRIPTION
This allows us to keep all of our resources in the `pinniped` category while not having `kubectl` return errors for calls such as:

```
kubectl get pinniped -A
```

Signed-off-by: Monis Khan <mok@vmware.com>

Fixes #371

**Release note**:

```release-note
NONE
```