### PR TITLE
Upgrade Go from 1.15.7 to 1.15.8.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.15.7 as build-env
+FROM golang:1.15.8 as build-env
 
 WORKDIR /work
 COPY . .


### PR DESCRIPTION
This is just a simple replacement for https://github.com/vmware-tanzu/pinniped/pull/391 to avoid dealing with the CLA bot.

**Release note**:
```release-note
Upgraded Go to 1.15.8.
```
