### PR TITLE
Cluster scope all concierge APIs

### DIFF
--- a/apis/concierge/authentication/v1alpha1/types_jwt.go.tmpl
+++ b/apis/concierge/authentication/v1alpha1/types_jwt.go.tmpl
@@ -61,6 +61,7 @@ type JWTTokenClaims struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators,scope=Cluster
 // +kubebuilder:printcolumn:name="Issuer",type=string,JSONPath=`.spec.issuer`
+// +kubebuilder:subresource:status
 type JWTAuthenticator struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/concierge/authentication/v1alpha1/types_jwt.go.tmpl
+++ b/apis/concierge/authentication/v1alpha1/types_jwt.go.tmpl
@@ -57,6 +57,7 @@ type JWTTokenClaims struct {
 // signature, existence of claims, etc.) and extract the username and groups from the token.
 //
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators
 // +kubebuilder:printcolumn:name="Issuer",type=string,JSONPath=`.spec.issuer`

--- a/apis/concierge/authentication/v1alpha1/types_jwt.go.tmpl
+++ b/apis/concierge/authentication/v1alpha1/types_jwt.go.tmpl
@@ -59,7 +59,7 @@ type JWTTokenClaims struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators
+// +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators,scope=Cluster
 // +kubebuilder:printcolumn:name="Issuer",type=string,JSONPath=`.spec.issuer`
 type JWTAuthenticator struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/concierge/authentication/v1alpha1/types_webhook.go.tmpl
+++ b/apis/concierge/authentication/v1alpha1/types_webhook.go.tmpl
@@ -31,7 +31,7 @@ type WebhookAuthenticatorSpec struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators
+// +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators,scope=Cluster
 // +kubebuilder:printcolumn:name="Endpoint",type=string,JSONPath=`.spec.endpoint`
 type WebhookAuthenticator struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/concierge/authentication/v1alpha1/types_webhook.go.tmpl
+++ b/apis/concierge/authentication/v1alpha1/types_webhook.go.tmpl
@@ -29,6 +29,7 @@ type WebhookAuthenticatorSpec struct {
 
 // WebhookAuthenticator describes the configuration of a webhook authenticator.
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators
 // +kubebuilder:printcolumn:name="Endpoint",type=string,JSONPath=`.spec.endpoint`

--- a/apis/concierge/authentication/v1alpha1/types_webhook.go.tmpl
+++ b/apis/concierge/authentication/v1alpha1/types_webhook.go.tmpl
@@ -33,6 +33,7 @@ type WebhookAuthenticatorSpec struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators,scope=Cluster
 // +kubebuilder:printcolumn:name="Endpoint",type=string,JSONPath=`.spec.endpoint`
+// +kubebuilder:subresource:status
 type WebhookAuthenticator struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/concierge/config/v1alpha1/types_credentialissuer.go.tmpl
+++ b/apis/concierge/config/v1alpha1/types_credentialissuer.go.tmpl
@@ -76,6 +76,7 @@ type CredentialIssuer struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Status of the credential issuer.
+	// +optional
 	Status CredentialIssuerStatus `json:"status"`
 }
 

--- a/apis/concierge/config/v1alpha1/types_credentialissuer.go.tmpl
+++ b/apis/concierge/config/v1alpha1/types_credentialissuer.go.tmpl
@@ -70,6 +70,7 @@ type CredentialIssuerStrategy struct {
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped,scope=Cluster
+// +kubebuilder:subresource:status
 type CredentialIssuer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/concierge/config/v1alpha1/types_credentialissuer.go.tmpl
+++ b/apis/concierge/config/v1alpha1/types_credentialissuer.go.tmpl
@@ -69,7 +69,7 @@ type CredentialIssuerStrategy struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:categories=pinniped
+// +kubebuilder:resource:categories=pinniped,scope=Cluster
 type CredentialIssuer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/concierge/config/v1alpha1/types_credentialissuer.go.tmpl
+++ b/apis/concierge/config/v1alpha1/types_credentialissuer.go.tmpl
@@ -67,6 +67,7 @@ type CredentialIssuerStrategy struct {
 
 // Describes the configuration status of a Pinniped credential issuer.
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped
 type CredentialIssuer struct {

--- a/apis/concierge/login/types_token.go.tmpl
+++ b/apis/concierge/login/types_token.go.tmpl
@@ -27,7 +27,6 @@ type TokenCredentialRequestStatus struct {
 }
 
 // TokenCredentialRequest submits an IDP-specific credential to Pinniped in exchange for a cluster-specific credential.
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type TokenCredentialRequest struct {
 	metav1.TypeMeta

--- a/apis/concierge/login/v1alpha1/types_token.go.tmpl
+++ b/apis/concierge/login/v1alpha1/types_token.go.tmpl
@@ -30,6 +30,7 @@ type TokenCredentialRequestStatus struct {
 
 // TokenCredentialRequest submits an IDP-specific credential to Pinniped in exchange for a cluster-specific credential.
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type TokenCredentialRequest struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/supervisor/config/v1alpha1/types_federationdomain.go.tmpl
+++ b/apis/supervisor/config/v1alpha1/types_federationdomain.go.tmpl
@@ -109,6 +109,7 @@ type FederationDomainStatus struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped
+// +kubebuilder:subresource:status
 type FederationDomain struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/cmd/pinniped-supervisor/main.go
+++ b/cmd/pinniped-supervisor/main.go
@@ -175,8 +175,8 @@ func startControllers(
 						secretCache.SetTokenHMACKey(federationDomainIssuer, symmetricKey)
 					},
 				),
-				func(fd *configv1alpha1.FederationDomain) *corev1.LocalObjectReference {
-					return &fd.Status.Secrets.TokenSigningKey
+				func(fd *configv1alpha1.FederationDomainStatus) *corev1.LocalObjectReference {
+					return &fd.Secrets.TokenSigningKey
 				},
 				kubeClient,
 				pinnipedClient,
@@ -198,8 +198,8 @@ func startControllers(
 						secretCache.SetStateEncoderHashKey(federationDomainIssuer, symmetricKey)
 					},
 				),
-				func(fd *configv1alpha1.FederationDomain) *corev1.LocalObjectReference {
-					return &fd.Status.Secrets.StateSigningKey
+				func(fd *configv1alpha1.FederationDomainStatus) *corev1.LocalObjectReference {
+					return &fd.Secrets.StateSigningKey
 				},
 				kubeClient,
 				pinnipedClient,
@@ -221,8 +221,8 @@ func startControllers(
 						secretCache.SetStateEncoderBlockKey(federationDomainIssuer, symmetricKey)
 					},
 				),
-				func(fd *configv1alpha1.FederationDomain) *corev1.LocalObjectReference {
-					return &fd.Status.Secrets.StateEncryptionKey
+				func(fd *configv1alpha1.FederationDomainStatus) *corev1.LocalObjectReference {
+					return &fd.Secrets.StateEncryptionKey
 				},
 				kubeClient,
 				pinnipedClient,

--- a/cmd/pinniped/cmd/cobra_util.go
+++ b/cmd/pinniped/cmd/cobra_util.go
@@ -22,3 +22,9 @@ func mustMarkHidden(cmd *cobra.Command, flags ...string) {
 		}
 	}
 }
+
+func mustMarkDeprecated(cmd *cobra.Command, flag, usageMessage string) {
+	if err := cmd.Flags().MarkDeprecated(flag, usageMessage); err != nil {
+		panic(err)
+	}
+}

--- a/cmd/pinniped/cmd/kubeconfig_test.go
+++ b/cmd/pinniped/cmd/kubeconfig_test.go
@@ -61,7 +61,6 @@ func TestGetKubeconfig(t *testing.T) {
 				      --concierge-api-group-suffix string     Concierge API group suffix (default "pinniped.dev")
 				      --concierge-authenticator-name string   Concierge authenticator name (default: autodiscover)
 				      --concierge-authenticator-type string   Concierge authenticator type (e.g., 'webhook', 'jwt') (default: autodiscover)
-				      --concierge-namespace string            Namespace in which the concierge was installed (default "pinniped-concierge")
 				  -h, --help                                  help for kubeconfig
 				      --kubeconfig string                     Path to kubeconfig file
 				      --kubeconfig-context string             Kubeconfig context name (default: current active context)
@@ -210,34 +209,32 @@ func TestGetKubeconfig(t *testing.T) {
 			},
 			wantError: true,
 			wantStderr: here.Doc(`
-				Error: no authenticators were found in namespace "pinniped-concierge" (try setting --concierge-namespace)
+				Error: no authenticators were found
 			`),
 		},
 		{
 			name: "fail to autodetect authenticator, multiple found",
 			args: []string{
 				"--kubeconfig", "./testdata/kubeconfig.yaml",
-				"--concierge-namespace", "test-namespace",
 			},
 			conciergeObjects: []runtime.Object{
-				&conciergev1alpha1.JWTAuthenticator{ObjectMeta: metav1.ObjectMeta{Name: "test-authenticator-1", Namespace: "test-namespace"}},
-				&conciergev1alpha1.JWTAuthenticator{ObjectMeta: metav1.ObjectMeta{Name: "test-authenticator-2", Namespace: "test-namespace"}},
-				&conciergev1alpha1.WebhookAuthenticator{ObjectMeta: metav1.ObjectMeta{Name: "test-authenticator-3", Namespace: "test-namespace"}},
-				&conciergev1alpha1.WebhookAuthenticator{ObjectMeta: metav1.ObjectMeta{Name: "test-authenticator-4", Namespace: "test-namespace"}},
+				&conciergev1alpha1.JWTAuthenticator{ObjectMeta: metav1.ObjectMeta{Name: "test-authenticator-1"}},
+				&conciergev1alpha1.JWTAuthenticator{ObjectMeta: metav1.ObjectMeta{Name: "test-authenticator-2"}},
+				&conciergev1alpha1.WebhookAuthenticator{ObjectMeta: metav1.ObjectMeta{Name: "test-authenticator-3"}},
+				&conciergev1alpha1.WebhookAuthenticator{ObjectMeta: metav1.ObjectMeta{Name: "test-authenticator-4"}},
 			},
 			wantError: true,
 			wantStderr: here.Doc(`
-				Error: multiple authenticators were found in namespace "test-namespace", so the --concierge-authenticator-type/--concierge-authenticator-name flags must be specified
+				Error: multiple authenticators were found, so the --concierge-authenticator-type/--concierge-authenticator-name flags must be specified
 			`),
 		},
 		{
 			name: "autodetect webhook authenticator, missing --oidc-issuer",
 			args: []string{
 				"--kubeconfig", "./testdata/kubeconfig.yaml",
-				"--concierge-namespace", "test-namespace",
 			},
 			conciergeObjects: []runtime.Object{
-				&conciergev1alpha1.WebhookAuthenticator{ObjectMeta: metav1.ObjectMeta{Name: "test-authenticator", Namespace: "test-namespace"}},
+				&conciergev1alpha1.WebhookAuthenticator{ObjectMeta: metav1.ObjectMeta{Name: "test-authenticator"}},
 			},
 			wantError: true,
 			wantStderr: here.Doc(`
@@ -248,11 +245,10 @@ func TestGetKubeconfig(t *testing.T) {
 			name: "autodetect JWT authenticator, invalid TLS bundle",
 			args: []string{
 				"--kubeconfig", "./testdata/kubeconfig.yaml",
-				"--concierge-namespace", "test-namespace",
 			},
 			conciergeObjects: []runtime.Object{
 				&conciergev1alpha1.JWTAuthenticator{
-					ObjectMeta: metav1.ObjectMeta{Name: "test-authenticator", Namespace: "test-namespace"},
+					ObjectMeta: metav1.ObjectMeta{Name: "test-authenticator"},
 					Spec: conciergev1alpha1.JWTAuthenticatorSpec{
 						TLS: &conciergev1alpha1.TLSSpec{
 							CertificateAuthorityData: "invalid-base64",
@@ -262,19 +258,18 @@ func TestGetKubeconfig(t *testing.T) {
 			},
 			wantError: true,
 			wantStderr: here.Doc(`
-				Error: tried to autodiscover --oidc-ca-bundle, but JWTAuthenticator test-namespace/test-authenticator has invalid spec.tls.certificateAuthorityData: illegal base64 data at input byte 7
+				Error: tried to autodiscover --oidc-ca-bundle, but JWTAuthenticator test-authenticator has invalid spec.tls.certificateAuthorityData: illegal base64 data at input byte 7
 			`),
 		},
 		{
 			name: "invalid static token flags",
 			args: []string{
 				"--kubeconfig", "./testdata/kubeconfig.yaml",
-				"--concierge-namespace", "test-namespace",
 				"--static-token", "test-token",
 				"--static-token-env", "TEST_TOKEN",
 			},
 			conciergeObjects: []runtime.Object{
-				&conciergev1alpha1.WebhookAuthenticator{ObjectMeta: metav1.ObjectMeta{Name: "test-authenticator", Namespace: "test-namespace"}},
+				&conciergev1alpha1.WebhookAuthenticator{ObjectMeta: metav1.ObjectMeta{Name: "test-authenticator"}},
 			},
 			wantError: true,
 			wantStderr: here.Doc(`
@@ -295,11 +290,10 @@ func TestGetKubeconfig(t *testing.T) {
 			name: "valid static token",
 			args: []string{
 				"--kubeconfig", "./testdata/kubeconfig.yaml",
-				"--concierge-namespace", "test-namespace",
 				"--static-token", "test-token",
 			},
 			conciergeObjects: []runtime.Object{
-				&conciergev1alpha1.WebhookAuthenticator{ObjectMeta: metav1.ObjectMeta{Name: "test-authenticator", Namespace: "test-namespace"}},
+				&conciergev1alpha1.WebhookAuthenticator{ObjectMeta: metav1.ObjectMeta{Name: "test-authenticator"}},
 			},
 			wantStdout: here.Doc(`
         		apiVersion: v1
@@ -326,7 +320,6 @@ func TestGetKubeconfig(t *testing.T) {
         		      - static
         		      - --enable-concierge
         		      - --concierge-api-group-suffix=pinniped.dev
-        		      - --concierge-namespace=test-namespace
         		      - --concierge-authenticator-name=test-authenticator
         		      - --concierge-authenticator-type=webhook
         		      - --concierge-endpoint=https://fake-server-url-value
@@ -341,11 +334,10 @@ func TestGetKubeconfig(t *testing.T) {
 			name: "valid static token from env var",
 			args: []string{
 				"--kubeconfig", "./testdata/kubeconfig.yaml",
-				"--concierge-namespace", "test-namespace",
 				"--static-token-env", "TEST_TOKEN",
 			},
 			conciergeObjects: []runtime.Object{
-				&conciergev1alpha1.WebhookAuthenticator{ObjectMeta: metav1.ObjectMeta{Name: "test-authenticator", Namespace: "test-namespace"}},
+				&conciergev1alpha1.WebhookAuthenticator{ObjectMeta: metav1.ObjectMeta{Name: "test-authenticator"}},
 			},
 			wantStdout: here.Doc(`
         		apiVersion: v1
@@ -372,7 +364,6 @@ func TestGetKubeconfig(t *testing.T) {
         		      - static
         		      - --enable-concierge
         		      - --concierge-api-group-suffix=pinniped.dev
-        		      - --concierge-namespace=test-namespace
         		      - --concierge-authenticator-name=test-authenticator
         		      - --concierge-authenticator-type=webhook
         		      - --concierge-endpoint=https://fake-server-url-value
@@ -390,7 +381,7 @@ func TestGetKubeconfig(t *testing.T) {
 			},
 			conciergeObjects: []runtime.Object{
 				&conciergev1alpha1.JWTAuthenticator{
-					ObjectMeta: metav1.ObjectMeta{Name: "test-authenticator", Namespace: "pinniped-concierge"},
+					ObjectMeta: metav1.ObjectMeta{Name: "test-authenticator"},
 					Spec: conciergev1alpha1.JWTAuthenticatorSpec{
 						Issuer:   "https://example.com/issuer",
 						Audience: "test-audience",
@@ -425,7 +416,6 @@ func TestGetKubeconfig(t *testing.T) {
         		      - oidc
         		      - --enable-concierge
         		      - --concierge-api-group-suffix=pinniped.dev
-        		      - --concierge-namespace=pinniped-concierge
         		      - --concierge-authenticator-name=test-authenticator
         		      - --concierge-authenticator-type=jwt
         		      - --concierge-endpoint=https://fake-server-url-value
@@ -457,7 +447,7 @@ func TestGetKubeconfig(t *testing.T) {
 			},
 			conciergeObjects: []runtime.Object{
 				&conciergev1alpha1.WebhookAuthenticator{
-					ObjectMeta: metav1.ObjectMeta{Name: "test-authenticator", Namespace: "pinniped-concierge"},
+					ObjectMeta: metav1.ObjectMeta{Name: "test-authenticator"},
 				},
 			},
 			wantStdout: here.Docf(`
@@ -485,7 +475,6 @@ func TestGetKubeconfig(t *testing.T) {
         		      - oidc
         		      - --enable-concierge
         		      - --concierge-api-group-suffix=tuna.io
-        		      - --concierge-namespace=pinniped-concierge
         		      - --concierge-authenticator-name=test-authenticator
         		      - --concierge-authenticator-type=webhook
         		      - --concierge-endpoint=https://fake-server-url-value

--- a/cmd/pinniped/cmd/login_oidc_test.go
+++ b/cmd/pinniped/cmd/login_oidc_test.go
@@ -65,7 +65,6 @@ func TestLoginOIDCCommand(t *testing.T) {
 				      --concierge-authenticator-type string   Concierge authenticator type (e.g., 'webhook', 'jwt')
 				      --concierge-ca-bundle-data string       CA bundle to use when connecting to the concierge
 				      --concierge-endpoint string             API base for the Pinniped concierge endpoint
-				      --concierge-namespace string            Namespace in which the concierge was installed (default "pinniped-concierge")
 				      --enable-concierge                      Exchange the OIDC ID token with the Pinniped concierge during login
 				  -h, --help                                  help for oidc
 				      --issuer string                         OpenID Connect issuer URL
@@ -186,7 +185,6 @@ func TestLoginOIDCCommand(t *testing.T) {
 				"--ca-bundle-data", base64.StdEncoding.EncodeToString(testCA.Bundle()),
 				"--ca-bundle", testCABundlePath,
 				"--enable-concierge",
-				"--concierge-namespace", "test-namespace",
 				"--concierge-authenticator-type", "webhook",
 				"--concierge-authenticator-name", "test-authenticator",
 				"--concierge-endpoint", "https://127.0.0.1:1234/",

--- a/cmd/pinniped/cmd/login_static.go
+++ b/cmd/pinniped/cmd/login_static.go
@@ -41,7 +41,6 @@ type staticLoginParams struct {
 	staticToken                string
 	staticTokenEnvName         string
 	conciergeEnabled           bool
-	conciergeNamespace         string
 	conciergeAuthenticatorType string
 	conciergeAuthenticatorName string
 	conciergeEndpoint          string
@@ -51,25 +50,30 @@ type staticLoginParams struct {
 
 func staticLoginCommand(deps staticLoginDeps) *cobra.Command {
 	var (
-		cmd = cobra.Command{
+		cmd = &cobra.Command{
 			Args:         cobra.NoArgs,
 			Use:          "static [--token TOKEN] [--token-env TOKEN_NAME]",
 			Short:        "Login using a static token",
 			SilenceUsage: true,
 		}
-		flags staticLoginParams
+		flags              staticLoginParams
+		conciergeNamespace string // unused now
 	)
 	cmd.Flags().StringVar(&flags.staticToken, "token", "", "Static token to present during login")
 	cmd.Flags().StringVar(&flags.staticTokenEnvName, "token-env", "", "Environment variable containing a static token")
 	cmd.Flags().BoolVar(&flags.conciergeEnabled, "enable-concierge", false, "Exchange the token with the Pinniped concierge during login")
-	cmd.Flags().StringVar(&flags.conciergeNamespace, "concierge-namespace", "pinniped-concierge", "Namespace in which the concierge was installed")
+	cmd.Flags().StringVar(&conciergeNamespace, "concierge-namespace", "pinniped-concierge", "Namespace in which the concierge was installed")
 	cmd.Flags().StringVar(&flags.conciergeAuthenticatorType, "concierge-authenticator-type", "", "Concierge authenticator type (e.g., 'webhook', 'jwt')")
 	cmd.Flags().StringVar(&flags.conciergeAuthenticatorName, "concierge-authenticator-name", "", "Concierge authenticator name")
 	cmd.Flags().StringVar(&flags.conciergeEndpoint, "concierge-endpoint", "", "API base for the Pinniped concierge endpoint")
 	cmd.Flags().StringVar(&flags.conciergeCABundle, "concierge-ca-bundle-data", "", "CA bundle to use when connecting to the concierge")
 	cmd.Flags().StringVar(&flags.conciergeAPIGroupSuffix, "concierge-api-group-suffix", "pinniped.dev", "Concierge API group suffix")
 	cmd.RunE = func(cmd *cobra.Command, args []string) error { return runStaticLogin(cmd.OutOrStdout(), deps, flags) }
-	return &cmd
+
+	mustMarkDeprecated(cmd, "concierge-namespace", "not needed anymore")
+	mustMarkHidden(cmd, "concierge-namespace")
+
+	return cmd
 }
 
 func runStaticLogin(out io.Writer, deps staticLoginDeps, flags staticLoginParams) error {
@@ -81,7 +85,6 @@ func runStaticLogin(out io.Writer, deps staticLoginDeps, flags staticLoginParams
 	if flags.conciergeEnabled {
 		var err error
 		concierge, err = conciergeclient.New(
-			conciergeclient.WithNamespace(flags.conciergeNamespace),
 			conciergeclient.WithEndpoint(flags.conciergeEndpoint),
 			conciergeclient.WithBase64CABundle(flags.conciergeCABundle),
 			conciergeclient.WithAuthenticator(flags.conciergeAuthenticatorType, flags.conciergeAuthenticatorName),

--- a/cmd/pinniped/cmd/login_static_test.go
+++ b/cmd/pinniped/cmd/login_static_test.go
@@ -56,7 +56,6 @@ func TestLoginStaticCommand(t *testing.T) {
 				      --concierge-authenticator-type string   Concierge authenticator type (e.g., 'webhook', 'jwt')
 				      --concierge-ca-bundle-data string       CA bundle to use when connecting to the concierge
 				      --concierge-endpoint string             API base for the Pinniped concierge endpoint
-				      --concierge-namespace string            Namespace in which the concierge was installed (default "pinniped-concierge")
 				      --enable-concierge                      Exchange the token with the Pinniped concierge during login
 				  -h, --help                                  help for static
 				      --token string                          Static token to present during login

--- a/deploy/concierge/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
+++ b/deploy/concierge/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
@@ -161,7 +161,8 @@ spec:
         type: object
     served: true
     storage: true
-    subresources: {}
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/deploy/concierge/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
+++ b/deploy/concierge/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
@@ -18,7 +18,7 @@ spec:
     listKind: JWTAuthenticatorList
     plural: jwtauthenticators
     singular: jwtauthenticator
-  scope: Namespaced
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.issuer

--- a/deploy/concierge/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
+++ b/deploy/concierge/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
@@ -18,7 +18,7 @@ spec:
     listKind: JWTAuthenticatorList
     plural: jwtauthenticators
     singular: jwtauthenticator
-  scope: Cluster
+  scope: Namespaced
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.issuer

--- a/deploy/concierge/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
+++ b/deploy/concierge/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
@@ -137,7 +137,8 @@ spec:
         type: object
     served: true
     storage: true
-    subresources: {}
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/deploy/concierge/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
+++ b/deploy/concierge/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
@@ -18,7 +18,7 @@ spec:
     listKind: WebhookAuthenticatorList
     plural: webhookauthenticators
     singular: webhookauthenticator
-  scope: Namespaced
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.endpoint

--- a/deploy/concierge/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
+++ b/deploy/concierge/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
@@ -18,7 +18,7 @@ spec:
     listKind: WebhookAuthenticatorList
     plural: webhookauthenticators
     singular: webhookauthenticator
-  scope: Cluster
+  scope: Namespaced
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.endpoint

--- a/deploy/concierge/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/deploy/concierge/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -16,7 +16,7 @@ spec:
     listKind: CredentialIssuerList
     plural: credentialissuers
     singular: credentialissuer
-  scope: Namespaced
+  scope: Cluster
   versions:
   - name: v1alpha1
     schema:

--- a/deploy/concierge/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/deploy/concierge/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -16,7 +16,7 @@ spec:
     listKind: CredentialIssuerList
     plural: credentialissuers
     singular: credentialissuer
-  scope: Cluster
+  scope: Namespaced
   versions:
   - name: v1alpha1
     schema:

--- a/deploy/concierge/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/deploy/concierge/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -98,8 +98,6 @@ spec:
             required:
             - strategies
             type: object
-        required:
-        - status
         type: object
     served: true
     storage: true

--- a/deploy/concierge/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/deploy/concierge/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -103,6 +103,8 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/deploy/concierge/rbac.yaml
+++ b/deploy/concierge/rbac.yaml
@@ -17,7 +17,7 @@ rules:
     verbs: [ get, list, watch ]
   - apiGroups: [ apiregistration.k8s.io ]
     resources: [ apiservices ]
-    verbs: [ create, get, list, patch, update, watch ]
+    verbs: [ get, list, patch, update, watch ]
   - apiGroups: [ admissionregistration.k8s.io ]
     resources: [ validatingwebhookconfigurations, mutatingwebhookconfigurations ]
     verbs: [ get, list, watch ]
@@ -34,7 +34,11 @@ rules:
   - apiGroups:
       - #@ pinnipedDevAPIGroupWithPrefix("config.concierge")
     resources: [ credentialissuers ]
-    verbs: [ get, list, watch, create, update ]
+    verbs: [ get, list, watch, create ]
+  - apiGroups:
+      - #@ pinnipedDevAPIGroupWithPrefix("config.concierge")
+    resources: [ credentialissuers/status ]
+    verbs: [get, patch, update]
   - apiGroups:
       - #@ pinnipedDevAPIGroupWithPrefix("authentication.concierge")
     resources: [ jwtauthenticators, webhookauthenticators ]

--- a/deploy/concierge/rbac.yaml
+++ b/deploy/concierge/rbac.yaml
@@ -31,6 +31,14 @@ rules:
     resources: [ securitycontextconstraints ]
     verbs: [ use ]
     resourceNames: [ nonroot ]
+  - apiGroups:
+      - #@ pinnipedDevAPIGroupWithPrefix("config.concierge")
+    resources: [ credentialissuers ]
+    verbs: [ get, list, watch, create, update ]
+  - apiGroups:
+      - #@ pinnipedDevAPIGroupWithPrefix("authentication.concierge")
+    resources: [ jwtauthenticators, webhookauthenticators ]
+    verbs: [ get, list, watch ]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -69,11 +77,6 @@ rules:
   - apiGroups: [ "" ]
     resources: [ pods/exec ]
     verbs: [ create ]
-  - apiGroups:
-      - #@ pinnipedDevAPIGroupWithPrefix("config.concierge")
-      - #@ pinnipedDevAPIGroupWithPrefix("authentication.concierge")
-    resources: [ "*" ]
-    verbs: [ create, get, list, update, watch ]
   - apiGroups: [apps]
     resources: [replicasets,deployments]
     verbs: [get]

--- a/deploy/supervisor/config.supervisor.pinniped.dev_federationdomains.yaml
+++ b/deploy/supervisor/config.supervisor.pinniped.dev_federationdomains.yaml
@@ -150,6 +150,8 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/deploy/supervisor/rbac.yaml
+++ b/deploy/supervisor/rbac.yaml
@@ -19,7 +19,11 @@ rules:
   - apiGroups:
       - #@ pinnipedDevAPIGroupWithPrefix("config.supervisor")
     resources: [federationdomains]
-    verbs: [update, get, list, watch]
+    verbs: [get, list, watch]
+  - apiGroups:
+      - #@ pinnipedDevAPIGroupWithPrefix("config.supervisor")
+    resources: [federationdomains/status]
+    verbs: [get, patch, update]
   - apiGroups:
       - #@ pinnipedDevAPIGroupWithPrefix("idp.supervisor")
     resources: [oidcidentityproviders]

--- a/generated/1.17/apis/concierge/authentication/v1alpha1/types_jwt.go
+++ b/generated/1.17/apis/concierge/authentication/v1alpha1/types_jwt.go
@@ -61,6 +61,7 @@ type JWTTokenClaims struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators,scope=Cluster
 // +kubebuilder:printcolumn:name="Issuer",type=string,JSONPath=`.spec.issuer`
+// +kubebuilder:subresource:status
 type JWTAuthenticator struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/generated/1.17/apis/concierge/authentication/v1alpha1/types_jwt.go
+++ b/generated/1.17/apis/concierge/authentication/v1alpha1/types_jwt.go
@@ -57,6 +57,7 @@ type JWTTokenClaims struct {
 // signature, existence of claims, etc.) and extract the username and groups from the token.
 //
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators
 // +kubebuilder:printcolumn:name="Issuer",type=string,JSONPath=`.spec.issuer`

--- a/generated/1.17/apis/concierge/authentication/v1alpha1/types_jwt.go
+++ b/generated/1.17/apis/concierge/authentication/v1alpha1/types_jwt.go
@@ -59,7 +59,7 @@ type JWTTokenClaims struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators
+// +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators,scope=Cluster
 // +kubebuilder:printcolumn:name="Issuer",type=string,JSONPath=`.spec.issuer`
 type JWTAuthenticator struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/generated/1.17/apis/concierge/authentication/v1alpha1/types_webhook.go
+++ b/generated/1.17/apis/concierge/authentication/v1alpha1/types_webhook.go
@@ -31,7 +31,7 @@ type WebhookAuthenticatorSpec struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators
+// +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators,scope=Cluster
 // +kubebuilder:printcolumn:name="Endpoint",type=string,JSONPath=`.spec.endpoint`
 type WebhookAuthenticator struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/generated/1.17/apis/concierge/authentication/v1alpha1/types_webhook.go
+++ b/generated/1.17/apis/concierge/authentication/v1alpha1/types_webhook.go
@@ -29,6 +29,7 @@ type WebhookAuthenticatorSpec struct {
 
 // WebhookAuthenticator describes the configuration of a webhook authenticator.
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators
 // +kubebuilder:printcolumn:name="Endpoint",type=string,JSONPath=`.spec.endpoint`

--- a/generated/1.17/apis/concierge/authentication/v1alpha1/types_webhook.go
+++ b/generated/1.17/apis/concierge/authentication/v1alpha1/types_webhook.go
@@ -33,6 +33,7 @@ type WebhookAuthenticatorSpec struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators,scope=Cluster
 // +kubebuilder:printcolumn:name="Endpoint",type=string,JSONPath=`.spec.endpoint`
+// +kubebuilder:subresource:status
 type WebhookAuthenticator struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/generated/1.17/apis/concierge/config/v1alpha1/types_credentialissuer.go
+++ b/generated/1.17/apis/concierge/config/v1alpha1/types_credentialissuer.go
@@ -76,6 +76,7 @@ type CredentialIssuer struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Status of the credential issuer.
+	// +optional
 	Status CredentialIssuerStatus `json:"status"`
 }
 

--- a/generated/1.17/apis/concierge/config/v1alpha1/types_credentialissuer.go
+++ b/generated/1.17/apis/concierge/config/v1alpha1/types_credentialissuer.go
@@ -70,6 +70,7 @@ type CredentialIssuerStrategy struct {
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped,scope=Cluster
+// +kubebuilder:subresource:status
 type CredentialIssuer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/generated/1.17/apis/concierge/config/v1alpha1/types_credentialissuer.go
+++ b/generated/1.17/apis/concierge/config/v1alpha1/types_credentialissuer.go
@@ -69,7 +69,7 @@ type CredentialIssuerStrategy struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:categories=pinniped
+// +kubebuilder:resource:categories=pinniped,scope=Cluster
 type CredentialIssuer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/generated/1.17/apis/concierge/config/v1alpha1/types_credentialissuer.go
+++ b/generated/1.17/apis/concierge/config/v1alpha1/types_credentialissuer.go
@@ -67,6 +67,7 @@ type CredentialIssuerStrategy struct {
 
 // Describes the configuration status of a Pinniped credential issuer.
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped
 type CredentialIssuer struct {

--- a/generated/1.17/apis/concierge/login/types_token.go
+++ b/generated/1.17/apis/concierge/login/types_token.go
@@ -27,7 +27,6 @@ type TokenCredentialRequestStatus struct {
 }
 
 // TokenCredentialRequest submits an IDP-specific credential to Pinniped in exchange for a cluster-specific credential.
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type TokenCredentialRequest struct {
 	metav1.TypeMeta

--- a/generated/1.17/apis/concierge/login/v1alpha1/types_token.go
+++ b/generated/1.17/apis/concierge/login/v1alpha1/types_token.go
@@ -30,6 +30,7 @@ type TokenCredentialRequestStatus struct {
 
 // TokenCredentialRequest submits an IDP-specific credential to Pinniped in exchange for a cluster-specific credential.
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type TokenCredentialRequest struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/generated/1.17/apis/supervisor/config/v1alpha1/types_federationdomain.go
+++ b/generated/1.17/apis/supervisor/config/v1alpha1/types_federationdomain.go
@@ -109,6 +109,7 @@ type FederationDomainStatus struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped
+// +kubebuilder:subresource:status
 type FederationDomain struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/generated/1.17/client/concierge/clientset/versioned/typed/authentication/v1alpha1/authentication_client.go
+++ b/generated/1.17/client/concierge/clientset/versioned/typed/authentication/v1alpha1/authentication_client.go
@@ -22,12 +22,12 @@ type AuthenticationV1alpha1Client struct {
 	restClient rest.Interface
 }
 
-func (c *AuthenticationV1alpha1Client) JWTAuthenticators(namespace string) JWTAuthenticatorInterface {
-	return newJWTAuthenticators(c, namespace)
+func (c *AuthenticationV1alpha1Client) JWTAuthenticators() JWTAuthenticatorInterface {
+	return newJWTAuthenticators(c)
 }
 
-func (c *AuthenticationV1alpha1Client) WebhookAuthenticators(namespace string) WebhookAuthenticatorInterface {
-	return newWebhookAuthenticators(c, namespace)
+func (c *AuthenticationV1alpha1Client) WebhookAuthenticators() WebhookAuthenticatorInterface {
+	return newWebhookAuthenticators(c)
 }
 
 // NewForConfig creates a new AuthenticationV1alpha1Client for the given config.

--- a/generated/1.17/client/concierge/clientset/versioned/typed/authentication/v1alpha1/fake/fake_authentication_client.go
+++ b/generated/1.17/client/concierge/clientset/versioned/typed/authentication/v1alpha1/fake/fake_authentication_client.go
@@ -15,12 +15,12 @@ type FakeAuthenticationV1alpha1 struct {
 	*testing.Fake
 }
 
-func (c *FakeAuthenticationV1alpha1) JWTAuthenticators(namespace string) v1alpha1.JWTAuthenticatorInterface {
-	return &FakeJWTAuthenticators{c, namespace}
+func (c *FakeAuthenticationV1alpha1) JWTAuthenticators() v1alpha1.JWTAuthenticatorInterface {
+	return &FakeJWTAuthenticators{c}
 }
 
-func (c *FakeAuthenticationV1alpha1) WebhookAuthenticators(namespace string) v1alpha1.WebhookAuthenticatorInterface {
-	return &FakeWebhookAuthenticators{c, namespace}
+func (c *FakeAuthenticationV1alpha1) WebhookAuthenticators() v1alpha1.WebhookAuthenticatorInterface {
+	return &FakeWebhookAuthenticators{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/generated/1.17/client/concierge/clientset/versioned/typed/authentication/v1alpha1/fake/fake_jwtauthenticator.go
+++ b/generated/1.17/client/concierge/clientset/versioned/typed/authentication/v1alpha1/fake/fake_jwtauthenticator.go
@@ -18,7 +18,6 @@ import (
 // FakeJWTAuthenticators implements JWTAuthenticatorInterface
 type FakeJWTAuthenticators struct {
 	Fake *FakeAuthenticationV1alpha1
-	ns   string
 }
 
 var jwtauthenticatorsResource = schema.GroupVersionResource{Group: "authentication.concierge.pinniped.dev", Version: "v1alpha1", Resource: "jwtauthenticators"}
@@ -28,8 +27,7 @@ var jwtauthenticatorsKind = schema.GroupVersionKind{Group: "authentication.conci
 // Get takes name of the jWTAuthenticator, and returns the corresponding jWTAuthenticator object, and an error if there is any.
 func (c *FakeJWTAuthenticators) Get(name string, options v1.GetOptions) (result *v1alpha1.JWTAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(jwtauthenticatorsResource, c.ns, name), &v1alpha1.JWTAuthenticator{})
-
+		Invokes(testing.NewRootGetAction(jwtauthenticatorsResource, name), &v1alpha1.JWTAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -39,8 +37,7 @@ func (c *FakeJWTAuthenticators) Get(name string, options v1.GetOptions) (result 
 // List takes label and field selectors, and returns the list of JWTAuthenticators that match those selectors.
 func (c *FakeJWTAuthenticators) List(opts v1.ListOptions) (result *v1alpha1.JWTAuthenticatorList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(jwtauthenticatorsResource, jwtauthenticatorsKind, c.ns, opts), &v1alpha1.JWTAuthenticatorList{})
-
+		Invokes(testing.NewRootListAction(jwtauthenticatorsResource, jwtauthenticatorsKind, opts), &v1alpha1.JWTAuthenticatorList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -61,15 +58,13 @@ func (c *FakeJWTAuthenticators) List(opts v1.ListOptions) (result *v1alpha1.JWTA
 // Watch returns a watch.Interface that watches the requested jWTAuthenticators.
 func (c *FakeJWTAuthenticators) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(jwtauthenticatorsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(jwtauthenticatorsResource, opts))
 }
 
 // Create takes the representation of a jWTAuthenticator and creates it.  Returns the server's representation of the jWTAuthenticator, and an error, if there is any.
 func (c *FakeJWTAuthenticators) Create(jWTAuthenticator *v1alpha1.JWTAuthenticator) (result *v1alpha1.JWTAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(jwtauthenticatorsResource, c.ns, jWTAuthenticator), &v1alpha1.JWTAuthenticator{})
-
+		Invokes(testing.NewRootCreateAction(jwtauthenticatorsResource, jWTAuthenticator), &v1alpha1.JWTAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -79,8 +74,7 @@ func (c *FakeJWTAuthenticators) Create(jWTAuthenticator *v1alpha1.JWTAuthenticat
 // Update takes the representation of a jWTAuthenticator and updates it. Returns the server's representation of the jWTAuthenticator, and an error, if there is any.
 func (c *FakeJWTAuthenticators) Update(jWTAuthenticator *v1alpha1.JWTAuthenticator) (result *v1alpha1.JWTAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(jwtauthenticatorsResource, c.ns, jWTAuthenticator), &v1alpha1.JWTAuthenticator{})
-
+		Invokes(testing.NewRootUpdateAction(jwtauthenticatorsResource, jWTAuthenticator), &v1alpha1.JWTAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -91,8 +85,7 @@ func (c *FakeJWTAuthenticators) Update(jWTAuthenticator *v1alpha1.JWTAuthenticat
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeJWTAuthenticators) UpdateStatus(jWTAuthenticator *v1alpha1.JWTAuthenticator) (*v1alpha1.JWTAuthenticator, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(jwtauthenticatorsResource, "status", c.ns, jWTAuthenticator), &v1alpha1.JWTAuthenticator{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(jwtauthenticatorsResource, "status", jWTAuthenticator), &v1alpha1.JWTAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -102,14 +95,13 @@ func (c *FakeJWTAuthenticators) UpdateStatus(jWTAuthenticator *v1alpha1.JWTAuthe
 // Delete takes name of the jWTAuthenticator and deletes it. Returns an error if one occurs.
 func (c *FakeJWTAuthenticators) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(jwtauthenticatorsResource, c.ns, name), &v1alpha1.JWTAuthenticator{})
-
+		Invokes(testing.NewRootDeleteAction(jwtauthenticatorsResource, name), &v1alpha1.JWTAuthenticator{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeJWTAuthenticators) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(jwtauthenticatorsResource, c.ns, listOptions)
+	action := testing.NewRootDeleteCollectionAction(jwtauthenticatorsResource, listOptions)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.JWTAuthenticatorList{})
 	return err
@@ -118,8 +110,7 @@ func (c *FakeJWTAuthenticators) DeleteCollection(options *v1.DeleteOptions, list
 // Patch applies the patch and returns the patched jWTAuthenticator.
 func (c *FakeJWTAuthenticators) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.JWTAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(jwtauthenticatorsResource, c.ns, name, pt, data, subresources...), &v1alpha1.JWTAuthenticator{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(jwtauthenticatorsResource, name, pt, data, subresources...), &v1alpha1.JWTAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}

--- a/generated/1.17/client/concierge/clientset/versioned/typed/authentication/v1alpha1/fake/fake_webhookauthenticator.go
+++ b/generated/1.17/client/concierge/clientset/versioned/typed/authentication/v1alpha1/fake/fake_webhookauthenticator.go
@@ -18,7 +18,6 @@ import (
 // FakeWebhookAuthenticators implements WebhookAuthenticatorInterface
 type FakeWebhookAuthenticators struct {
 	Fake *FakeAuthenticationV1alpha1
-	ns   string
 }
 
 var webhookauthenticatorsResource = schema.GroupVersionResource{Group: "authentication.concierge.pinniped.dev", Version: "v1alpha1", Resource: "webhookauthenticators"}
@@ -28,8 +27,7 @@ var webhookauthenticatorsKind = schema.GroupVersionKind{Group: "authentication.c
 // Get takes name of the webhookAuthenticator, and returns the corresponding webhookAuthenticator object, and an error if there is any.
 func (c *FakeWebhookAuthenticators) Get(name string, options v1.GetOptions) (result *v1alpha1.WebhookAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(webhookauthenticatorsResource, c.ns, name), &v1alpha1.WebhookAuthenticator{})
-
+		Invokes(testing.NewRootGetAction(webhookauthenticatorsResource, name), &v1alpha1.WebhookAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -39,8 +37,7 @@ func (c *FakeWebhookAuthenticators) Get(name string, options v1.GetOptions) (res
 // List takes label and field selectors, and returns the list of WebhookAuthenticators that match those selectors.
 func (c *FakeWebhookAuthenticators) List(opts v1.ListOptions) (result *v1alpha1.WebhookAuthenticatorList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(webhookauthenticatorsResource, webhookauthenticatorsKind, c.ns, opts), &v1alpha1.WebhookAuthenticatorList{})
-
+		Invokes(testing.NewRootListAction(webhookauthenticatorsResource, webhookauthenticatorsKind, opts), &v1alpha1.WebhookAuthenticatorList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -61,15 +58,13 @@ func (c *FakeWebhookAuthenticators) List(opts v1.ListOptions) (result *v1alpha1.
 // Watch returns a watch.Interface that watches the requested webhookAuthenticators.
 func (c *FakeWebhookAuthenticators) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(webhookauthenticatorsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(webhookauthenticatorsResource, opts))
 }
 
 // Create takes the representation of a webhookAuthenticator and creates it.  Returns the server's representation of the webhookAuthenticator, and an error, if there is any.
 func (c *FakeWebhookAuthenticators) Create(webhookAuthenticator *v1alpha1.WebhookAuthenticator) (result *v1alpha1.WebhookAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(webhookauthenticatorsResource, c.ns, webhookAuthenticator), &v1alpha1.WebhookAuthenticator{})
-
+		Invokes(testing.NewRootCreateAction(webhookauthenticatorsResource, webhookAuthenticator), &v1alpha1.WebhookAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -79,8 +74,7 @@ func (c *FakeWebhookAuthenticators) Create(webhookAuthenticator *v1alpha1.Webhoo
 // Update takes the representation of a webhookAuthenticator and updates it. Returns the server's representation of the webhookAuthenticator, and an error, if there is any.
 func (c *FakeWebhookAuthenticators) Update(webhookAuthenticator *v1alpha1.WebhookAuthenticator) (result *v1alpha1.WebhookAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(webhookauthenticatorsResource, c.ns, webhookAuthenticator), &v1alpha1.WebhookAuthenticator{})
-
+		Invokes(testing.NewRootUpdateAction(webhookauthenticatorsResource, webhookAuthenticator), &v1alpha1.WebhookAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -91,8 +85,7 @@ func (c *FakeWebhookAuthenticators) Update(webhookAuthenticator *v1alpha1.Webhoo
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeWebhookAuthenticators) UpdateStatus(webhookAuthenticator *v1alpha1.WebhookAuthenticator) (*v1alpha1.WebhookAuthenticator, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(webhookauthenticatorsResource, "status", c.ns, webhookAuthenticator), &v1alpha1.WebhookAuthenticator{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(webhookauthenticatorsResource, "status", webhookAuthenticator), &v1alpha1.WebhookAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -102,14 +95,13 @@ func (c *FakeWebhookAuthenticators) UpdateStatus(webhookAuthenticator *v1alpha1.
 // Delete takes name of the webhookAuthenticator and deletes it. Returns an error if one occurs.
 func (c *FakeWebhookAuthenticators) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(webhookauthenticatorsResource, c.ns, name), &v1alpha1.WebhookAuthenticator{})
-
+		Invokes(testing.NewRootDeleteAction(webhookauthenticatorsResource, name), &v1alpha1.WebhookAuthenticator{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeWebhookAuthenticators) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(webhookauthenticatorsResource, c.ns, listOptions)
+	action := testing.NewRootDeleteCollectionAction(webhookauthenticatorsResource, listOptions)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.WebhookAuthenticatorList{})
 	return err
@@ -118,8 +110,7 @@ func (c *FakeWebhookAuthenticators) DeleteCollection(options *v1.DeleteOptions, 
 // Patch applies the patch and returns the patched webhookAuthenticator.
 func (c *FakeWebhookAuthenticators) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.WebhookAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(webhookauthenticatorsResource, c.ns, name, pt, data, subresources...), &v1alpha1.WebhookAuthenticator{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(webhookauthenticatorsResource, name, pt, data, subresources...), &v1alpha1.WebhookAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}

--- a/generated/1.17/client/concierge/clientset/versioned/typed/authentication/v1alpha1/jwtauthenticator.go
+++ b/generated/1.17/client/concierge/clientset/versioned/typed/authentication/v1alpha1/jwtauthenticator.go
@@ -19,7 +19,7 @@ import (
 // JWTAuthenticatorsGetter has a method to return a JWTAuthenticatorInterface.
 // A group's client should implement this interface.
 type JWTAuthenticatorsGetter interface {
-	JWTAuthenticators(namespace string) JWTAuthenticatorInterface
+	JWTAuthenticators() JWTAuthenticatorInterface
 }
 
 // JWTAuthenticatorInterface has methods to work with JWTAuthenticator resources.
@@ -39,14 +39,12 @@ type JWTAuthenticatorInterface interface {
 // jWTAuthenticators implements JWTAuthenticatorInterface
 type jWTAuthenticators struct {
 	client rest.Interface
-	ns     string
 }
 
 // newJWTAuthenticators returns a JWTAuthenticators
-func newJWTAuthenticators(c *AuthenticationV1alpha1Client, namespace string) *jWTAuthenticators {
+func newJWTAuthenticators(c *AuthenticationV1alpha1Client) *jWTAuthenticators {
 	return &jWTAuthenticators{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -54,7 +52,6 @@ func newJWTAuthenticators(c *AuthenticationV1alpha1Client, namespace string) *jW
 func (c *jWTAuthenticators) Get(name string, options v1.GetOptions) (result *v1alpha1.JWTAuthenticator, err error) {
 	result = &v1alpha1.JWTAuthenticator{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -71,7 +68,6 @@ func (c *jWTAuthenticators) List(opts v1.ListOptions) (result *v1alpha1.JWTAuthe
 	}
 	result = &v1alpha1.JWTAuthenticatorList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -88,7 +84,6 @@ func (c *jWTAuthenticators) Watch(opts v1.ListOptions) (watch.Interface, error) 
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -99,7 +94,6 @@ func (c *jWTAuthenticators) Watch(opts v1.ListOptions) (watch.Interface, error) 
 func (c *jWTAuthenticators) Create(jWTAuthenticator *v1alpha1.JWTAuthenticator) (result *v1alpha1.JWTAuthenticator, err error) {
 	result = &v1alpha1.JWTAuthenticator{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		Body(jWTAuthenticator).
 		Do().
@@ -111,7 +105,6 @@ func (c *jWTAuthenticators) Create(jWTAuthenticator *v1alpha1.JWTAuthenticator) 
 func (c *jWTAuthenticators) Update(jWTAuthenticator *v1alpha1.JWTAuthenticator) (result *v1alpha1.JWTAuthenticator, err error) {
 	result = &v1alpha1.JWTAuthenticator{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		Name(jWTAuthenticator.Name).
 		Body(jWTAuthenticator).
@@ -126,7 +119,6 @@ func (c *jWTAuthenticators) Update(jWTAuthenticator *v1alpha1.JWTAuthenticator) 
 func (c *jWTAuthenticators) UpdateStatus(jWTAuthenticator *v1alpha1.JWTAuthenticator) (result *v1alpha1.JWTAuthenticator, err error) {
 	result = &v1alpha1.JWTAuthenticator{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		Name(jWTAuthenticator.Name).
 		SubResource("status").
@@ -139,7 +131,6 @@ func (c *jWTAuthenticators) UpdateStatus(jWTAuthenticator *v1alpha1.JWTAuthentic
 // Delete takes name of the jWTAuthenticator and deletes it. Returns an error if one occurs.
 func (c *jWTAuthenticators) Delete(name string, options *v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		Name(name).
 		Body(options).
@@ -154,7 +145,6 @@ func (c *jWTAuthenticators) DeleteCollection(options *v1.DeleteOptions, listOpti
 		timeout = time.Duration(*listOptions.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -167,7 +157,6 @@ func (c *jWTAuthenticators) DeleteCollection(options *v1.DeleteOptions, listOpti
 func (c *jWTAuthenticators) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.JWTAuthenticator, err error) {
 	result = &v1alpha1.JWTAuthenticator{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		SubResource(subresources...).
 		Name(name).

--- a/generated/1.17/client/concierge/clientset/versioned/typed/authentication/v1alpha1/webhookauthenticator.go
+++ b/generated/1.17/client/concierge/clientset/versioned/typed/authentication/v1alpha1/webhookauthenticator.go
@@ -19,7 +19,7 @@ import (
 // WebhookAuthenticatorsGetter has a method to return a WebhookAuthenticatorInterface.
 // A group's client should implement this interface.
 type WebhookAuthenticatorsGetter interface {
-	WebhookAuthenticators(namespace string) WebhookAuthenticatorInterface
+	WebhookAuthenticators() WebhookAuthenticatorInterface
 }
 
 // WebhookAuthenticatorInterface has methods to work with WebhookAuthenticator resources.
@@ -39,14 +39,12 @@ type WebhookAuthenticatorInterface interface {
 // webhookAuthenticators implements WebhookAuthenticatorInterface
 type webhookAuthenticators struct {
 	client rest.Interface
-	ns     string
 }
 
 // newWebhookAuthenticators returns a WebhookAuthenticators
-func newWebhookAuthenticators(c *AuthenticationV1alpha1Client, namespace string) *webhookAuthenticators {
+func newWebhookAuthenticators(c *AuthenticationV1alpha1Client) *webhookAuthenticators {
 	return &webhookAuthenticators{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -54,7 +52,6 @@ func newWebhookAuthenticators(c *AuthenticationV1alpha1Client, namespace string)
 func (c *webhookAuthenticators) Get(name string, options v1.GetOptions) (result *v1alpha1.WebhookAuthenticator, err error) {
 	result = &v1alpha1.WebhookAuthenticator{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -71,7 +68,6 @@ func (c *webhookAuthenticators) List(opts v1.ListOptions) (result *v1alpha1.Webh
 	}
 	result = &v1alpha1.WebhookAuthenticatorList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -88,7 +84,6 @@ func (c *webhookAuthenticators) Watch(opts v1.ListOptions) (watch.Interface, err
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -99,7 +94,6 @@ func (c *webhookAuthenticators) Watch(opts v1.ListOptions) (watch.Interface, err
 func (c *webhookAuthenticators) Create(webhookAuthenticator *v1alpha1.WebhookAuthenticator) (result *v1alpha1.WebhookAuthenticator, err error) {
 	result = &v1alpha1.WebhookAuthenticator{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		Body(webhookAuthenticator).
 		Do().
@@ -111,7 +105,6 @@ func (c *webhookAuthenticators) Create(webhookAuthenticator *v1alpha1.WebhookAut
 func (c *webhookAuthenticators) Update(webhookAuthenticator *v1alpha1.WebhookAuthenticator) (result *v1alpha1.WebhookAuthenticator, err error) {
 	result = &v1alpha1.WebhookAuthenticator{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		Name(webhookAuthenticator.Name).
 		Body(webhookAuthenticator).
@@ -126,7 +119,6 @@ func (c *webhookAuthenticators) Update(webhookAuthenticator *v1alpha1.WebhookAut
 func (c *webhookAuthenticators) UpdateStatus(webhookAuthenticator *v1alpha1.WebhookAuthenticator) (result *v1alpha1.WebhookAuthenticator, err error) {
 	result = &v1alpha1.WebhookAuthenticator{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		Name(webhookAuthenticator.Name).
 		SubResource("status").
@@ -139,7 +131,6 @@ func (c *webhookAuthenticators) UpdateStatus(webhookAuthenticator *v1alpha1.Webh
 // Delete takes name of the webhookAuthenticator and deletes it. Returns an error if one occurs.
 func (c *webhookAuthenticators) Delete(name string, options *v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		Name(name).
 		Body(options).
@@ -154,7 +145,6 @@ func (c *webhookAuthenticators) DeleteCollection(options *v1.DeleteOptions, list
 		timeout = time.Duration(*listOptions.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -167,7 +157,6 @@ func (c *webhookAuthenticators) DeleteCollection(options *v1.DeleteOptions, list
 func (c *webhookAuthenticators) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.WebhookAuthenticator, err error) {
 	result = &v1alpha1.WebhookAuthenticator{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		SubResource(subresources...).
 		Name(name).

--- a/generated/1.17/client/concierge/clientset/versioned/typed/config/v1alpha1/config_client.go
+++ b/generated/1.17/client/concierge/clientset/versioned/typed/config/v1alpha1/config_client.go
@@ -21,8 +21,8 @@ type ConfigV1alpha1Client struct {
 	restClient rest.Interface
 }
 
-func (c *ConfigV1alpha1Client) CredentialIssuers(namespace string) CredentialIssuerInterface {
-	return newCredentialIssuers(c, namespace)
+func (c *ConfigV1alpha1Client) CredentialIssuers() CredentialIssuerInterface {
+	return newCredentialIssuers(c)
 }
 
 // NewForConfig creates a new ConfigV1alpha1Client for the given config.

--- a/generated/1.17/client/concierge/clientset/versioned/typed/config/v1alpha1/credentialissuer.go
+++ b/generated/1.17/client/concierge/clientset/versioned/typed/config/v1alpha1/credentialissuer.go
@@ -19,7 +19,7 @@ import (
 // CredentialIssuersGetter has a method to return a CredentialIssuerInterface.
 // A group's client should implement this interface.
 type CredentialIssuersGetter interface {
-	CredentialIssuers(namespace string) CredentialIssuerInterface
+	CredentialIssuers() CredentialIssuerInterface
 }
 
 // CredentialIssuerInterface has methods to work with CredentialIssuer resources.
@@ -39,14 +39,12 @@ type CredentialIssuerInterface interface {
 // credentialIssuers implements CredentialIssuerInterface
 type credentialIssuers struct {
 	client rest.Interface
-	ns     string
 }
 
 // newCredentialIssuers returns a CredentialIssuers
-func newCredentialIssuers(c *ConfigV1alpha1Client, namespace string) *credentialIssuers {
+func newCredentialIssuers(c *ConfigV1alpha1Client) *credentialIssuers {
 	return &credentialIssuers{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -54,7 +52,6 @@ func newCredentialIssuers(c *ConfigV1alpha1Client, namespace string) *credential
 func (c *credentialIssuers) Get(name string, options v1.GetOptions) (result *v1alpha1.CredentialIssuer, err error) {
 	result = &v1alpha1.CredentialIssuer{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -71,7 +68,6 @@ func (c *credentialIssuers) List(opts v1.ListOptions) (result *v1alpha1.Credenti
 	}
 	result = &v1alpha1.CredentialIssuerList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -88,7 +84,6 @@ func (c *credentialIssuers) Watch(opts v1.ListOptions) (watch.Interface, error) 
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -99,7 +94,6 @@ func (c *credentialIssuers) Watch(opts v1.ListOptions) (watch.Interface, error) 
 func (c *credentialIssuers) Create(credentialIssuer *v1alpha1.CredentialIssuer) (result *v1alpha1.CredentialIssuer, err error) {
 	result = &v1alpha1.CredentialIssuer{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		Body(credentialIssuer).
 		Do().
@@ -111,7 +105,6 @@ func (c *credentialIssuers) Create(credentialIssuer *v1alpha1.CredentialIssuer) 
 func (c *credentialIssuers) Update(credentialIssuer *v1alpha1.CredentialIssuer) (result *v1alpha1.CredentialIssuer, err error) {
 	result = &v1alpha1.CredentialIssuer{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		Name(credentialIssuer.Name).
 		Body(credentialIssuer).
@@ -126,7 +119,6 @@ func (c *credentialIssuers) Update(credentialIssuer *v1alpha1.CredentialIssuer) 
 func (c *credentialIssuers) UpdateStatus(credentialIssuer *v1alpha1.CredentialIssuer) (result *v1alpha1.CredentialIssuer, err error) {
 	result = &v1alpha1.CredentialIssuer{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		Name(credentialIssuer.Name).
 		SubResource("status").
@@ -139,7 +131,6 @@ func (c *credentialIssuers) UpdateStatus(credentialIssuer *v1alpha1.CredentialIs
 // Delete takes name of the credentialIssuer and deletes it. Returns an error if one occurs.
 func (c *credentialIssuers) Delete(name string, options *v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		Name(name).
 		Body(options).
@@ -154,7 +145,6 @@ func (c *credentialIssuers) DeleteCollection(options *v1.DeleteOptions, listOpti
 		timeout = time.Duration(*listOptions.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -167,7 +157,6 @@ func (c *credentialIssuers) DeleteCollection(options *v1.DeleteOptions, listOpti
 func (c *credentialIssuers) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.CredentialIssuer, err error) {
 	result = &v1alpha1.CredentialIssuer{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		SubResource(subresources...).
 		Name(name).

--- a/generated/1.17/client/concierge/clientset/versioned/typed/config/v1alpha1/fake/fake_config_client.go
+++ b/generated/1.17/client/concierge/clientset/versioned/typed/config/v1alpha1/fake/fake_config_client.go
@@ -15,8 +15,8 @@ type FakeConfigV1alpha1 struct {
 	*testing.Fake
 }
 
-func (c *FakeConfigV1alpha1) CredentialIssuers(namespace string) v1alpha1.CredentialIssuerInterface {
-	return &FakeCredentialIssuers{c, namespace}
+func (c *FakeConfigV1alpha1) CredentialIssuers() v1alpha1.CredentialIssuerInterface {
+	return &FakeCredentialIssuers{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/generated/1.17/client/concierge/clientset/versioned/typed/config/v1alpha1/fake/fake_credentialissuer.go
+++ b/generated/1.17/client/concierge/clientset/versioned/typed/config/v1alpha1/fake/fake_credentialissuer.go
@@ -18,7 +18,6 @@ import (
 // FakeCredentialIssuers implements CredentialIssuerInterface
 type FakeCredentialIssuers struct {
 	Fake *FakeConfigV1alpha1
-	ns   string
 }
 
 var credentialissuersResource = schema.GroupVersionResource{Group: "config.concierge.pinniped.dev", Version: "v1alpha1", Resource: "credentialissuers"}
@@ -28,8 +27,7 @@ var credentialissuersKind = schema.GroupVersionKind{Group: "config.concierge.pin
 // Get takes name of the credentialIssuer, and returns the corresponding credentialIssuer object, and an error if there is any.
 func (c *FakeCredentialIssuers) Get(name string, options v1.GetOptions) (result *v1alpha1.CredentialIssuer, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(credentialissuersResource, c.ns, name), &v1alpha1.CredentialIssuer{})
-
+		Invokes(testing.NewRootGetAction(credentialissuersResource, name), &v1alpha1.CredentialIssuer{})
 	if obj == nil {
 		return nil, err
 	}
@@ -39,8 +37,7 @@ func (c *FakeCredentialIssuers) Get(name string, options v1.GetOptions) (result 
 // List takes label and field selectors, and returns the list of CredentialIssuers that match those selectors.
 func (c *FakeCredentialIssuers) List(opts v1.ListOptions) (result *v1alpha1.CredentialIssuerList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(credentialissuersResource, credentialissuersKind, c.ns, opts), &v1alpha1.CredentialIssuerList{})
-
+		Invokes(testing.NewRootListAction(credentialissuersResource, credentialissuersKind, opts), &v1alpha1.CredentialIssuerList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -61,15 +58,13 @@ func (c *FakeCredentialIssuers) List(opts v1.ListOptions) (result *v1alpha1.Cred
 // Watch returns a watch.Interface that watches the requested credentialIssuers.
 func (c *FakeCredentialIssuers) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(credentialissuersResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(credentialissuersResource, opts))
 }
 
 // Create takes the representation of a credentialIssuer and creates it.  Returns the server's representation of the credentialIssuer, and an error, if there is any.
 func (c *FakeCredentialIssuers) Create(credentialIssuer *v1alpha1.CredentialIssuer) (result *v1alpha1.CredentialIssuer, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(credentialissuersResource, c.ns, credentialIssuer), &v1alpha1.CredentialIssuer{})
-
+		Invokes(testing.NewRootCreateAction(credentialissuersResource, credentialIssuer), &v1alpha1.CredentialIssuer{})
 	if obj == nil {
 		return nil, err
 	}
@@ -79,8 +74,7 @@ func (c *FakeCredentialIssuers) Create(credentialIssuer *v1alpha1.CredentialIssu
 // Update takes the representation of a credentialIssuer and updates it. Returns the server's representation of the credentialIssuer, and an error, if there is any.
 func (c *FakeCredentialIssuers) Update(credentialIssuer *v1alpha1.CredentialIssuer) (result *v1alpha1.CredentialIssuer, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(credentialissuersResource, c.ns, credentialIssuer), &v1alpha1.CredentialIssuer{})
-
+		Invokes(testing.NewRootUpdateAction(credentialissuersResource, credentialIssuer), &v1alpha1.CredentialIssuer{})
 	if obj == nil {
 		return nil, err
 	}
@@ -91,8 +85,7 @@ func (c *FakeCredentialIssuers) Update(credentialIssuer *v1alpha1.CredentialIssu
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeCredentialIssuers) UpdateStatus(credentialIssuer *v1alpha1.CredentialIssuer) (*v1alpha1.CredentialIssuer, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(credentialissuersResource, "status", c.ns, credentialIssuer), &v1alpha1.CredentialIssuer{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(credentialissuersResource, "status", credentialIssuer), &v1alpha1.CredentialIssuer{})
 	if obj == nil {
 		return nil, err
 	}
@@ -102,14 +95,13 @@ func (c *FakeCredentialIssuers) UpdateStatus(credentialIssuer *v1alpha1.Credenti
 // Delete takes name of the credentialIssuer and deletes it. Returns an error if one occurs.
 func (c *FakeCredentialIssuers) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(credentialissuersResource, c.ns, name), &v1alpha1.CredentialIssuer{})
-
+		Invokes(testing.NewRootDeleteAction(credentialissuersResource, name), &v1alpha1.CredentialIssuer{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeCredentialIssuers) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(credentialissuersResource, c.ns, listOptions)
+	action := testing.NewRootDeleteCollectionAction(credentialissuersResource, listOptions)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.CredentialIssuerList{})
 	return err
@@ -118,8 +110,7 @@ func (c *FakeCredentialIssuers) DeleteCollection(options *v1.DeleteOptions, list
 // Patch applies the patch and returns the patched credentialIssuer.
 func (c *FakeCredentialIssuers) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.CredentialIssuer, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(credentialissuersResource, c.ns, name, pt, data, subresources...), &v1alpha1.CredentialIssuer{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(credentialissuersResource, name, pt, data, subresources...), &v1alpha1.CredentialIssuer{})
 	if obj == nil {
 		return nil, err
 	}

--- a/generated/1.17/client/concierge/clientset/versioned/typed/login/v1alpha1/fake/fake_login_client.go
+++ b/generated/1.17/client/concierge/clientset/versioned/typed/login/v1alpha1/fake/fake_login_client.go
@@ -15,8 +15,8 @@ type FakeLoginV1alpha1 struct {
 	*testing.Fake
 }
 
-func (c *FakeLoginV1alpha1) TokenCredentialRequests(namespace string) v1alpha1.TokenCredentialRequestInterface {
-	return &FakeTokenCredentialRequests{c, namespace}
+func (c *FakeLoginV1alpha1) TokenCredentialRequests() v1alpha1.TokenCredentialRequestInterface {
+	return &FakeTokenCredentialRequests{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/generated/1.17/client/concierge/clientset/versioned/typed/login/v1alpha1/fake/fake_tokencredentialrequest.go
+++ b/generated/1.17/client/concierge/clientset/versioned/typed/login/v1alpha1/fake/fake_tokencredentialrequest.go
@@ -18,7 +18,6 @@ import (
 // FakeTokenCredentialRequests implements TokenCredentialRequestInterface
 type FakeTokenCredentialRequests struct {
 	Fake *FakeLoginV1alpha1
-	ns   string
 }
 
 var tokencredentialrequestsResource = schema.GroupVersionResource{Group: "login.concierge.pinniped.dev", Version: "v1alpha1", Resource: "tokencredentialrequests"}
@@ -28,8 +27,7 @@ var tokencredentialrequestsKind = schema.GroupVersionKind{Group: "login.concierg
 // Get takes name of the tokenCredentialRequest, and returns the corresponding tokenCredentialRequest object, and an error if there is any.
 func (c *FakeTokenCredentialRequests) Get(name string, options v1.GetOptions) (result *v1alpha1.TokenCredentialRequest, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(tokencredentialrequestsResource, c.ns, name), &v1alpha1.TokenCredentialRequest{})
-
+		Invokes(testing.NewRootGetAction(tokencredentialrequestsResource, name), &v1alpha1.TokenCredentialRequest{})
 	if obj == nil {
 		return nil, err
 	}
@@ -39,8 +37,7 @@ func (c *FakeTokenCredentialRequests) Get(name string, options v1.GetOptions) (r
 // List takes label and field selectors, and returns the list of TokenCredentialRequests that match those selectors.
 func (c *FakeTokenCredentialRequests) List(opts v1.ListOptions) (result *v1alpha1.TokenCredentialRequestList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(tokencredentialrequestsResource, tokencredentialrequestsKind, c.ns, opts), &v1alpha1.TokenCredentialRequestList{})
-
+		Invokes(testing.NewRootListAction(tokencredentialrequestsResource, tokencredentialrequestsKind, opts), &v1alpha1.TokenCredentialRequestList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -61,15 +58,13 @@ func (c *FakeTokenCredentialRequests) List(opts v1.ListOptions) (result *v1alpha
 // Watch returns a watch.Interface that watches the requested tokenCredentialRequests.
 func (c *FakeTokenCredentialRequests) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(tokencredentialrequestsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(tokencredentialrequestsResource, opts))
 }
 
 // Create takes the representation of a tokenCredentialRequest and creates it.  Returns the server's representation of the tokenCredentialRequest, and an error, if there is any.
 func (c *FakeTokenCredentialRequests) Create(tokenCredentialRequest *v1alpha1.TokenCredentialRequest) (result *v1alpha1.TokenCredentialRequest, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(tokencredentialrequestsResource, c.ns, tokenCredentialRequest), &v1alpha1.TokenCredentialRequest{})
-
+		Invokes(testing.NewRootCreateAction(tokencredentialrequestsResource, tokenCredentialRequest), &v1alpha1.TokenCredentialRequest{})
 	if obj == nil {
 		return nil, err
 	}
@@ -79,8 +74,7 @@ func (c *FakeTokenCredentialRequests) Create(tokenCredentialRequest *v1alpha1.To
 // Update takes the representation of a tokenCredentialRequest and updates it. Returns the server's representation of the tokenCredentialRequest, and an error, if there is any.
 func (c *FakeTokenCredentialRequests) Update(tokenCredentialRequest *v1alpha1.TokenCredentialRequest) (result *v1alpha1.TokenCredentialRequest, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(tokencredentialrequestsResource, c.ns, tokenCredentialRequest), &v1alpha1.TokenCredentialRequest{})
-
+		Invokes(testing.NewRootUpdateAction(tokencredentialrequestsResource, tokenCredentialRequest), &v1alpha1.TokenCredentialRequest{})
 	if obj == nil {
 		return nil, err
 	}
@@ -91,8 +85,7 @@ func (c *FakeTokenCredentialRequests) Update(tokenCredentialRequest *v1alpha1.To
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeTokenCredentialRequests) UpdateStatus(tokenCredentialRequest *v1alpha1.TokenCredentialRequest) (*v1alpha1.TokenCredentialRequest, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(tokencredentialrequestsResource, "status", c.ns, tokenCredentialRequest), &v1alpha1.TokenCredentialRequest{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(tokencredentialrequestsResource, "status", tokenCredentialRequest), &v1alpha1.TokenCredentialRequest{})
 	if obj == nil {
 		return nil, err
 	}
@@ -102,14 +95,13 @@ func (c *FakeTokenCredentialRequests) UpdateStatus(tokenCredentialRequest *v1alp
 // Delete takes name of the tokenCredentialRequest and deletes it. Returns an error if one occurs.
 func (c *FakeTokenCredentialRequests) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(tokencredentialrequestsResource, c.ns, name), &v1alpha1.TokenCredentialRequest{})
-
+		Invokes(testing.NewRootDeleteAction(tokencredentialrequestsResource, name), &v1alpha1.TokenCredentialRequest{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeTokenCredentialRequests) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(tokencredentialrequestsResource, c.ns, listOptions)
+	action := testing.NewRootDeleteCollectionAction(tokencredentialrequestsResource, listOptions)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.TokenCredentialRequestList{})
 	return err
@@ -118,8 +110,7 @@ func (c *FakeTokenCredentialRequests) DeleteCollection(options *v1.DeleteOptions
 // Patch applies the patch and returns the patched tokenCredentialRequest.
 func (c *FakeTokenCredentialRequests) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.TokenCredentialRequest, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(tokencredentialrequestsResource, c.ns, name, pt, data, subresources...), &v1alpha1.TokenCredentialRequest{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(tokencredentialrequestsResource, name, pt, data, subresources...), &v1alpha1.TokenCredentialRequest{})
 	if obj == nil {
 		return nil, err
 	}

--- a/generated/1.17/client/concierge/clientset/versioned/typed/login/v1alpha1/login_client.go
+++ b/generated/1.17/client/concierge/clientset/versioned/typed/login/v1alpha1/login_client.go
@@ -21,8 +21,8 @@ type LoginV1alpha1Client struct {
 	restClient rest.Interface
 }
 
-func (c *LoginV1alpha1Client) TokenCredentialRequests(namespace string) TokenCredentialRequestInterface {
-	return newTokenCredentialRequests(c, namespace)
+func (c *LoginV1alpha1Client) TokenCredentialRequests() TokenCredentialRequestInterface {
+	return newTokenCredentialRequests(c)
 }
 
 // NewForConfig creates a new LoginV1alpha1Client for the given config.

--- a/generated/1.17/client/concierge/clientset/versioned/typed/login/v1alpha1/tokencredentialrequest.go
+++ b/generated/1.17/client/concierge/clientset/versioned/typed/login/v1alpha1/tokencredentialrequest.go
@@ -19,7 +19,7 @@ import (
 // TokenCredentialRequestsGetter has a method to return a TokenCredentialRequestInterface.
 // A group's client should implement this interface.
 type TokenCredentialRequestsGetter interface {
-	TokenCredentialRequests(namespace string) TokenCredentialRequestInterface
+	TokenCredentialRequests() TokenCredentialRequestInterface
 }
 
 // TokenCredentialRequestInterface has methods to work with TokenCredentialRequest resources.
@@ -39,14 +39,12 @@ type TokenCredentialRequestInterface interface {
 // tokenCredentialRequests implements TokenCredentialRequestInterface
 type tokenCredentialRequests struct {
 	client rest.Interface
-	ns     string
 }
 
 // newTokenCredentialRequests returns a TokenCredentialRequests
-func newTokenCredentialRequests(c *LoginV1alpha1Client, namespace string) *tokenCredentialRequests {
+func newTokenCredentialRequests(c *LoginV1alpha1Client) *tokenCredentialRequests {
 	return &tokenCredentialRequests{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -54,7 +52,6 @@ func newTokenCredentialRequests(c *LoginV1alpha1Client, namespace string) *token
 func (c *tokenCredentialRequests) Get(name string, options v1.GetOptions) (result *v1alpha1.TokenCredentialRequest, err error) {
 	result = &v1alpha1.TokenCredentialRequest{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -71,7 +68,6 @@ func (c *tokenCredentialRequests) List(opts v1.ListOptions) (result *v1alpha1.To
 	}
 	result = &v1alpha1.TokenCredentialRequestList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -88,7 +84,6 @@ func (c *tokenCredentialRequests) Watch(opts v1.ListOptions) (watch.Interface, e
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -99,7 +94,6 @@ func (c *tokenCredentialRequests) Watch(opts v1.ListOptions) (watch.Interface, e
 func (c *tokenCredentialRequests) Create(tokenCredentialRequest *v1alpha1.TokenCredentialRequest) (result *v1alpha1.TokenCredentialRequest, err error) {
 	result = &v1alpha1.TokenCredentialRequest{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		Body(tokenCredentialRequest).
 		Do().
@@ -111,7 +105,6 @@ func (c *tokenCredentialRequests) Create(tokenCredentialRequest *v1alpha1.TokenC
 func (c *tokenCredentialRequests) Update(tokenCredentialRequest *v1alpha1.TokenCredentialRequest) (result *v1alpha1.TokenCredentialRequest, err error) {
 	result = &v1alpha1.TokenCredentialRequest{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		Name(tokenCredentialRequest.Name).
 		Body(tokenCredentialRequest).
@@ -126,7 +119,6 @@ func (c *tokenCredentialRequests) Update(tokenCredentialRequest *v1alpha1.TokenC
 func (c *tokenCredentialRequests) UpdateStatus(tokenCredentialRequest *v1alpha1.TokenCredentialRequest) (result *v1alpha1.TokenCredentialRequest, err error) {
 	result = &v1alpha1.TokenCredentialRequest{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		Name(tokenCredentialRequest.Name).
 		SubResource("status").
@@ -139,7 +131,6 @@ func (c *tokenCredentialRequests) UpdateStatus(tokenCredentialRequest *v1alpha1.
 // Delete takes name of the tokenCredentialRequest and deletes it. Returns an error if one occurs.
 func (c *tokenCredentialRequests) Delete(name string, options *v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		Name(name).
 		Body(options).
@@ -154,7 +145,6 @@ func (c *tokenCredentialRequests) DeleteCollection(options *v1.DeleteOptions, li
 		timeout = time.Duration(*listOptions.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -167,7 +157,6 @@ func (c *tokenCredentialRequests) DeleteCollection(options *v1.DeleteOptions, li
 func (c *tokenCredentialRequests) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.TokenCredentialRequest, err error) {
 	result = &v1alpha1.TokenCredentialRequest{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		SubResource(subresources...).
 		Name(name).

--- a/generated/1.17/client/concierge/informers/externalversions/authentication/v1alpha1/interface.go
+++ b/generated/1.17/client/concierge/informers/externalversions/authentication/v1alpha1/interface.go
@@ -30,10 +30,10 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // JWTAuthenticators returns a JWTAuthenticatorInformer.
 func (v *version) JWTAuthenticators() JWTAuthenticatorInformer {
-	return &jWTAuthenticatorInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &jWTAuthenticatorInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
 // WebhookAuthenticators returns a WebhookAuthenticatorInformer.
 func (v *version) WebhookAuthenticators() WebhookAuthenticatorInformer {
-	return &webhookAuthenticatorInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &webhookAuthenticatorInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/generated/1.17/client/concierge/informers/externalversions/authentication/v1alpha1/jwtauthenticator.go
+++ b/generated/1.17/client/concierge/informers/externalversions/authentication/v1alpha1/jwtauthenticator.go
@@ -28,33 +28,32 @@ type JWTAuthenticatorInformer interface {
 type jWTAuthenticatorInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewJWTAuthenticatorInformer constructs a new informer for JWTAuthenticator type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewJWTAuthenticatorInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredJWTAuthenticatorInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewJWTAuthenticatorInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredJWTAuthenticatorInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredJWTAuthenticatorInformer constructs a new informer for JWTAuthenticator type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredJWTAuthenticatorInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredJWTAuthenticatorInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AuthenticationV1alpha1().JWTAuthenticators(namespace).List(options)
+				return client.AuthenticationV1alpha1().JWTAuthenticators().List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AuthenticationV1alpha1().JWTAuthenticators(namespace).Watch(options)
+				return client.AuthenticationV1alpha1().JWTAuthenticators().Watch(options)
 			},
 		},
 		&authenticationv1alpha1.JWTAuthenticator{},
@@ -64,7 +63,7 @@ func NewFilteredJWTAuthenticatorInformer(client versioned.Interface, namespace s
 }
 
 func (f *jWTAuthenticatorInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredJWTAuthenticatorInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredJWTAuthenticatorInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *jWTAuthenticatorInformer) Informer() cache.SharedIndexInformer {

--- a/generated/1.17/client/concierge/informers/externalversions/authentication/v1alpha1/webhookauthenticator.go
+++ b/generated/1.17/client/concierge/informers/externalversions/authentication/v1alpha1/webhookauthenticator.go
@@ -28,33 +28,32 @@ type WebhookAuthenticatorInformer interface {
 type webhookAuthenticatorInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewWebhookAuthenticatorInformer constructs a new informer for WebhookAuthenticator type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewWebhookAuthenticatorInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredWebhookAuthenticatorInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewWebhookAuthenticatorInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredWebhookAuthenticatorInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredWebhookAuthenticatorInformer constructs a new informer for WebhookAuthenticator type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredWebhookAuthenticatorInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredWebhookAuthenticatorInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AuthenticationV1alpha1().WebhookAuthenticators(namespace).List(options)
+				return client.AuthenticationV1alpha1().WebhookAuthenticators().List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AuthenticationV1alpha1().WebhookAuthenticators(namespace).Watch(options)
+				return client.AuthenticationV1alpha1().WebhookAuthenticators().Watch(options)
 			},
 		},
 		&authenticationv1alpha1.WebhookAuthenticator{},
@@ -64,7 +63,7 @@ func NewFilteredWebhookAuthenticatorInformer(client versioned.Interface, namespa
 }
 
 func (f *webhookAuthenticatorInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredWebhookAuthenticatorInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredWebhookAuthenticatorInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *webhookAuthenticatorInformer) Informer() cache.SharedIndexInformer {

--- a/generated/1.17/client/concierge/informers/externalversions/config/v1alpha1/credentialissuer.go
+++ b/generated/1.17/client/concierge/informers/externalversions/config/v1alpha1/credentialissuer.go
@@ -28,33 +28,32 @@ type CredentialIssuerInformer interface {
 type credentialIssuerInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewCredentialIssuerInformer constructs a new informer for CredentialIssuer type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewCredentialIssuerInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredCredentialIssuerInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewCredentialIssuerInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredCredentialIssuerInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredCredentialIssuerInformer constructs a new informer for CredentialIssuer type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredCredentialIssuerInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredCredentialIssuerInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ConfigV1alpha1().CredentialIssuers(namespace).List(options)
+				return client.ConfigV1alpha1().CredentialIssuers().List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ConfigV1alpha1().CredentialIssuers(namespace).Watch(options)
+				return client.ConfigV1alpha1().CredentialIssuers().Watch(options)
 			},
 		},
 		&configv1alpha1.CredentialIssuer{},
@@ -64,7 +63,7 @@ func NewFilteredCredentialIssuerInformer(client versioned.Interface, namespace s
 }
 
 func (f *credentialIssuerInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredCredentialIssuerInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredCredentialIssuerInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *credentialIssuerInformer) Informer() cache.SharedIndexInformer {

--- a/generated/1.17/client/concierge/informers/externalversions/config/v1alpha1/interface.go
+++ b/generated/1.17/client/concierge/informers/externalversions/config/v1alpha1/interface.go
@@ -28,5 +28,5 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // CredentialIssuers returns a CredentialIssuerInformer.
 func (v *version) CredentialIssuers() CredentialIssuerInformer {
-	return &credentialIssuerInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &credentialIssuerInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/generated/1.17/client/concierge/informers/externalversions/login/v1alpha1/interface.go
+++ b/generated/1.17/client/concierge/informers/externalversions/login/v1alpha1/interface.go
@@ -28,5 +28,5 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // TokenCredentialRequests returns a TokenCredentialRequestInformer.
 func (v *version) TokenCredentialRequests() TokenCredentialRequestInformer {
-	return &tokenCredentialRequestInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &tokenCredentialRequestInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/generated/1.17/client/concierge/informers/externalversions/login/v1alpha1/tokencredentialrequest.go
+++ b/generated/1.17/client/concierge/informers/externalversions/login/v1alpha1/tokencredentialrequest.go
@@ -28,33 +28,32 @@ type TokenCredentialRequestInformer interface {
 type tokenCredentialRequestInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewTokenCredentialRequestInformer constructs a new informer for TokenCredentialRequest type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewTokenCredentialRequestInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredTokenCredentialRequestInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewTokenCredentialRequestInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredTokenCredentialRequestInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredTokenCredentialRequestInformer constructs a new informer for TokenCredentialRequest type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredTokenCredentialRequestInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredTokenCredentialRequestInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.LoginV1alpha1().TokenCredentialRequests(namespace).List(options)
+				return client.LoginV1alpha1().TokenCredentialRequests().List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.LoginV1alpha1().TokenCredentialRequests(namespace).Watch(options)
+				return client.LoginV1alpha1().TokenCredentialRequests().Watch(options)
 			},
 		},
 		&loginv1alpha1.TokenCredentialRequest{},
@@ -64,7 +63,7 @@ func NewFilteredTokenCredentialRequestInformer(client versioned.Interface, names
 }
 
 func (f *tokenCredentialRequestInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredTokenCredentialRequestInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredTokenCredentialRequestInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *tokenCredentialRequestInformer) Informer() cache.SharedIndexInformer {

--- a/generated/1.17/client/concierge/listers/authentication/v1alpha1/expansion_generated.go
+++ b/generated/1.17/client/concierge/listers/authentication/v1alpha1/expansion_generated.go
@@ -9,14 +9,6 @@ package v1alpha1
 // JWTAuthenticatorLister.
 type JWTAuthenticatorListerExpansion interface{}
 
-// JWTAuthenticatorNamespaceListerExpansion allows custom methods to be added to
-// JWTAuthenticatorNamespaceLister.
-type JWTAuthenticatorNamespaceListerExpansion interface{}
-
 // WebhookAuthenticatorListerExpansion allows custom methods to be added to
 // WebhookAuthenticatorLister.
 type WebhookAuthenticatorListerExpansion interface{}
-
-// WebhookAuthenticatorNamespaceListerExpansion allows custom methods to be added to
-// WebhookAuthenticatorNamespaceLister.
-type WebhookAuthenticatorNamespaceListerExpansion interface{}

--- a/generated/1.17/client/concierge/listers/authentication/v1alpha1/jwtauthenticator.go
+++ b/generated/1.17/client/concierge/listers/authentication/v1alpha1/jwtauthenticator.go
@@ -16,8 +16,8 @@ import (
 type JWTAuthenticatorLister interface {
 	// List lists all JWTAuthenticators in the indexer.
 	List(selector labels.Selector) (ret []*v1alpha1.JWTAuthenticator, err error)
-	// JWTAuthenticators returns an object that can list and get JWTAuthenticators.
-	JWTAuthenticators(namespace string) JWTAuthenticatorNamespaceLister
+	// Get retrieves the JWTAuthenticator from the index for a given name.
+	Get(name string) (*v1alpha1.JWTAuthenticator, error)
 	JWTAuthenticatorListerExpansion
 }
 
@@ -39,38 +39,9 @@ func (s *jWTAuthenticatorLister) List(selector labels.Selector) (ret []*v1alpha1
 	return ret, err
 }
 
-// JWTAuthenticators returns an object that can list and get JWTAuthenticators.
-func (s *jWTAuthenticatorLister) JWTAuthenticators(namespace string) JWTAuthenticatorNamespaceLister {
-	return jWTAuthenticatorNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// JWTAuthenticatorNamespaceLister helps list and get JWTAuthenticators.
-type JWTAuthenticatorNamespaceLister interface {
-	// List lists all JWTAuthenticators in the indexer for a given namespace.
-	List(selector labels.Selector) (ret []*v1alpha1.JWTAuthenticator, err error)
-	// Get retrieves the JWTAuthenticator from the indexer for a given namespace and name.
-	Get(name string) (*v1alpha1.JWTAuthenticator, error)
-	JWTAuthenticatorNamespaceListerExpansion
-}
-
-// jWTAuthenticatorNamespaceLister implements the JWTAuthenticatorNamespaceLister
-// interface.
-type jWTAuthenticatorNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all JWTAuthenticators in the indexer for a given namespace.
-func (s jWTAuthenticatorNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.JWTAuthenticator, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.JWTAuthenticator))
-	})
-	return ret, err
-}
-
-// Get retrieves the JWTAuthenticator from the indexer for a given namespace and name.
-func (s jWTAuthenticatorNamespaceLister) Get(name string) (*v1alpha1.JWTAuthenticator, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the JWTAuthenticator from the index for a given name.
+func (s *jWTAuthenticatorLister) Get(name string) (*v1alpha1.JWTAuthenticator, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/generated/1.17/client/concierge/listers/authentication/v1alpha1/webhookauthenticator.go
+++ b/generated/1.17/client/concierge/listers/authentication/v1alpha1/webhookauthenticator.go
@@ -16,8 +16,8 @@ import (
 type WebhookAuthenticatorLister interface {
 	// List lists all WebhookAuthenticators in the indexer.
 	List(selector labels.Selector) (ret []*v1alpha1.WebhookAuthenticator, err error)
-	// WebhookAuthenticators returns an object that can list and get WebhookAuthenticators.
-	WebhookAuthenticators(namespace string) WebhookAuthenticatorNamespaceLister
+	// Get retrieves the WebhookAuthenticator from the index for a given name.
+	Get(name string) (*v1alpha1.WebhookAuthenticator, error)
 	WebhookAuthenticatorListerExpansion
 }
 
@@ -39,38 +39,9 @@ func (s *webhookAuthenticatorLister) List(selector labels.Selector) (ret []*v1al
 	return ret, err
 }
 
-// WebhookAuthenticators returns an object that can list and get WebhookAuthenticators.
-func (s *webhookAuthenticatorLister) WebhookAuthenticators(namespace string) WebhookAuthenticatorNamespaceLister {
-	return webhookAuthenticatorNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// WebhookAuthenticatorNamespaceLister helps list and get WebhookAuthenticators.
-type WebhookAuthenticatorNamespaceLister interface {
-	// List lists all WebhookAuthenticators in the indexer for a given namespace.
-	List(selector labels.Selector) (ret []*v1alpha1.WebhookAuthenticator, err error)
-	// Get retrieves the WebhookAuthenticator from the indexer for a given namespace and name.
-	Get(name string) (*v1alpha1.WebhookAuthenticator, error)
-	WebhookAuthenticatorNamespaceListerExpansion
-}
-
-// webhookAuthenticatorNamespaceLister implements the WebhookAuthenticatorNamespaceLister
-// interface.
-type webhookAuthenticatorNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all WebhookAuthenticators in the indexer for a given namespace.
-func (s webhookAuthenticatorNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.WebhookAuthenticator, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.WebhookAuthenticator))
-	})
-	return ret, err
-}
-
-// Get retrieves the WebhookAuthenticator from the indexer for a given namespace and name.
-func (s webhookAuthenticatorNamespaceLister) Get(name string) (*v1alpha1.WebhookAuthenticator, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the WebhookAuthenticator from the index for a given name.
+func (s *webhookAuthenticatorLister) Get(name string) (*v1alpha1.WebhookAuthenticator, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/generated/1.17/client/concierge/listers/config/v1alpha1/credentialissuer.go
+++ b/generated/1.17/client/concierge/listers/config/v1alpha1/credentialissuer.go
@@ -16,8 +16,8 @@ import (
 type CredentialIssuerLister interface {
 	// List lists all CredentialIssuers in the indexer.
 	List(selector labels.Selector) (ret []*v1alpha1.CredentialIssuer, err error)
-	// CredentialIssuers returns an object that can list and get CredentialIssuers.
-	CredentialIssuers(namespace string) CredentialIssuerNamespaceLister
+	// Get retrieves the CredentialIssuer from the index for a given name.
+	Get(name string) (*v1alpha1.CredentialIssuer, error)
 	CredentialIssuerListerExpansion
 }
 
@@ -39,38 +39,9 @@ func (s *credentialIssuerLister) List(selector labels.Selector) (ret []*v1alpha1
 	return ret, err
 }
 
-// CredentialIssuers returns an object that can list and get CredentialIssuers.
-func (s *credentialIssuerLister) CredentialIssuers(namespace string) CredentialIssuerNamespaceLister {
-	return credentialIssuerNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// CredentialIssuerNamespaceLister helps list and get CredentialIssuers.
-type CredentialIssuerNamespaceLister interface {
-	// List lists all CredentialIssuers in the indexer for a given namespace.
-	List(selector labels.Selector) (ret []*v1alpha1.CredentialIssuer, err error)
-	// Get retrieves the CredentialIssuer from the indexer for a given namespace and name.
-	Get(name string) (*v1alpha1.CredentialIssuer, error)
-	CredentialIssuerNamespaceListerExpansion
-}
-
-// credentialIssuerNamespaceLister implements the CredentialIssuerNamespaceLister
-// interface.
-type credentialIssuerNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all CredentialIssuers in the indexer for a given namespace.
-func (s credentialIssuerNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.CredentialIssuer, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.CredentialIssuer))
-	})
-	return ret, err
-}
-
-// Get retrieves the CredentialIssuer from the indexer for a given namespace and name.
-func (s credentialIssuerNamespaceLister) Get(name string) (*v1alpha1.CredentialIssuer, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the CredentialIssuer from the index for a given name.
+func (s *credentialIssuerLister) Get(name string) (*v1alpha1.CredentialIssuer, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/generated/1.17/client/concierge/listers/config/v1alpha1/expansion_generated.go
+++ b/generated/1.17/client/concierge/listers/config/v1alpha1/expansion_generated.go
@@ -8,7 +8,3 @@ package v1alpha1
 // CredentialIssuerListerExpansion allows custom methods to be added to
 // CredentialIssuerLister.
 type CredentialIssuerListerExpansion interface{}
-
-// CredentialIssuerNamespaceListerExpansion allows custom methods to be added to
-// CredentialIssuerNamespaceLister.
-type CredentialIssuerNamespaceListerExpansion interface{}

--- a/generated/1.17/client/concierge/listers/login/v1alpha1/expansion_generated.go
+++ b/generated/1.17/client/concierge/listers/login/v1alpha1/expansion_generated.go
@@ -8,7 +8,3 @@ package v1alpha1
 // TokenCredentialRequestListerExpansion allows custom methods to be added to
 // TokenCredentialRequestLister.
 type TokenCredentialRequestListerExpansion interface{}
-
-// TokenCredentialRequestNamespaceListerExpansion allows custom methods to be added to
-// TokenCredentialRequestNamespaceLister.
-type TokenCredentialRequestNamespaceListerExpansion interface{}

--- a/generated/1.17/client/concierge/listers/login/v1alpha1/tokencredentialrequest.go
+++ b/generated/1.17/client/concierge/listers/login/v1alpha1/tokencredentialrequest.go
@@ -16,8 +16,8 @@ import (
 type TokenCredentialRequestLister interface {
 	// List lists all TokenCredentialRequests in the indexer.
 	List(selector labels.Selector) (ret []*v1alpha1.TokenCredentialRequest, err error)
-	// TokenCredentialRequests returns an object that can list and get TokenCredentialRequests.
-	TokenCredentialRequests(namespace string) TokenCredentialRequestNamespaceLister
+	// Get retrieves the TokenCredentialRequest from the index for a given name.
+	Get(name string) (*v1alpha1.TokenCredentialRequest, error)
 	TokenCredentialRequestListerExpansion
 }
 
@@ -39,38 +39,9 @@ func (s *tokenCredentialRequestLister) List(selector labels.Selector) (ret []*v1
 	return ret, err
 }
 
-// TokenCredentialRequests returns an object that can list and get TokenCredentialRequests.
-func (s *tokenCredentialRequestLister) TokenCredentialRequests(namespace string) TokenCredentialRequestNamespaceLister {
-	return tokenCredentialRequestNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// TokenCredentialRequestNamespaceLister helps list and get TokenCredentialRequests.
-type TokenCredentialRequestNamespaceLister interface {
-	// List lists all TokenCredentialRequests in the indexer for a given namespace.
-	List(selector labels.Selector) (ret []*v1alpha1.TokenCredentialRequest, err error)
-	// Get retrieves the TokenCredentialRequest from the indexer for a given namespace and name.
-	Get(name string) (*v1alpha1.TokenCredentialRequest, error)
-	TokenCredentialRequestNamespaceListerExpansion
-}
-
-// tokenCredentialRequestNamespaceLister implements the TokenCredentialRequestNamespaceLister
-// interface.
-type tokenCredentialRequestNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all TokenCredentialRequests in the indexer for a given namespace.
-func (s tokenCredentialRequestNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.TokenCredentialRequest, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.TokenCredentialRequest))
-	})
-	return ret, err
-}
-
-// Get retrieves the TokenCredentialRequest from the indexer for a given namespace and name.
-func (s tokenCredentialRequestNamespaceLister) Get(name string) (*v1alpha1.TokenCredentialRequest, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the TokenCredentialRequest from the index for a given name.
+func (s *tokenCredentialRequestLister) Get(name string) (*v1alpha1.TokenCredentialRequest, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/generated/1.17/crds/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
+++ b/generated/1.17/crds/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
@@ -161,7 +161,8 @@ spec:
         type: object
     served: true
     storage: true
-    subresources: {}
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/generated/1.17/crds/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
+++ b/generated/1.17/crds/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
@@ -18,7 +18,7 @@ spec:
     listKind: JWTAuthenticatorList
     plural: jwtauthenticators
     singular: jwtauthenticator
-  scope: Namespaced
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.issuer

--- a/generated/1.17/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
+++ b/generated/1.17/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
@@ -137,7 +137,8 @@ spec:
         type: object
     served: true
     storage: true
-    subresources: {}
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/generated/1.17/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
+++ b/generated/1.17/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
@@ -18,7 +18,7 @@ spec:
     listKind: WebhookAuthenticatorList
     plural: webhookauthenticators
     singular: webhookauthenticator
-  scope: Namespaced
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.endpoint

--- a/generated/1.17/crds/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/generated/1.17/crds/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -16,7 +16,7 @@ spec:
     listKind: CredentialIssuerList
     plural: credentialissuers
     singular: credentialissuer
-  scope: Namespaced
+  scope: Cluster
   versions:
   - name: v1alpha1
     schema:

--- a/generated/1.17/crds/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/generated/1.17/crds/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -98,8 +98,6 @@ spec:
             required:
             - strategies
             type: object
-        required:
-        - status
         type: object
     served: true
     storage: true

--- a/generated/1.17/crds/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/generated/1.17/crds/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -103,6 +103,8 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/generated/1.17/crds/config.supervisor.pinniped.dev_federationdomains.yaml
+++ b/generated/1.17/crds/config.supervisor.pinniped.dev_federationdomains.yaml
@@ -150,6 +150,8 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/generated/1.18/apis/concierge/authentication/v1alpha1/types_jwt.go
+++ b/generated/1.18/apis/concierge/authentication/v1alpha1/types_jwt.go
@@ -61,6 +61,7 @@ type JWTTokenClaims struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators,scope=Cluster
 // +kubebuilder:printcolumn:name="Issuer",type=string,JSONPath=`.spec.issuer`
+// +kubebuilder:subresource:status
 type JWTAuthenticator struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/generated/1.18/apis/concierge/authentication/v1alpha1/types_jwt.go
+++ b/generated/1.18/apis/concierge/authentication/v1alpha1/types_jwt.go
@@ -57,6 +57,7 @@ type JWTTokenClaims struct {
 // signature, existence of claims, etc.) and extract the username and groups from the token.
 //
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators
 // +kubebuilder:printcolumn:name="Issuer",type=string,JSONPath=`.spec.issuer`

--- a/generated/1.18/apis/concierge/authentication/v1alpha1/types_jwt.go
+++ b/generated/1.18/apis/concierge/authentication/v1alpha1/types_jwt.go
@@ -59,7 +59,7 @@ type JWTTokenClaims struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators
+// +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators,scope=Cluster
 // +kubebuilder:printcolumn:name="Issuer",type=string,JSONPath=`.spec.issuer`
 type JWTAuthenticator struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/generated/1.18/apis/concierge/authentication/v1alpha1/types_webhook.go
+++ b/generated/1.18/apis/concierge/authentication/v1alpha1/types_webhook.go
@@ -31,7 +31,7 @@ type WebhookAuthenticatorSpec struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators
+// +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators,scope=Cluster
 // +kubebuilder:printcolumn:name="Endpoint",type=string,JSONPath=`.spec.endpoint`
 type WebhookAuthenticator struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/generated/1.18/apis/concierge/authentication/v1alpha1/types_webhook.go
+++ b/generated/1.18/apis/concierge/authentication/v1alpha1/types_webhook.go
@@ -29,6 +29,7 @@ type WebhookAuthenticatorSpec struct {
 
 // WebhookAuthenticator describes the configuration of a webhook authenticator.
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators
 // +kubebuilder:printcolumn:name="Endpoint",type=string,JSONPath=`.spec.endpoint`

--- a/generated/1.18/apis/concierge/authentication/v1alpha1/types_webhook.go
+++ b/generated/1.18/apis/concierge/authentication/v1alpha1/types_webhook.go
@@ -33,6 +33,7 @@ type WebhookAuthenticatorSpec struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators,scope=Cluster
 // +kubebuilder:printcolumn:name="Endpoint",type=string,JSONPath=`.spec.endpoint`
+// +kubebuilder:subresource:status
 type WebhookAuthenticator struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/generated/1.18/apis/concierge/config/v1alpha1/types_credentialissuer.go
+++ b/generated/1.18/apis/concierge/config/v1alpha1/types_credentialissuer.go
@@ -76,6 +76,7 @@ type CredentialIssuer struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Status of the credential issuer.
+	// +optional
 	Status CredentialIssuerStatus `json:"status"`
 }
 

--- a/generated/1.18/apis/concierge/config/v1alpha1/types_credentialissuer.go
+++ b/generated/1.18/apis/concierge/config/v1alpha1/types_credentialissuer.go
@@ -70,6 +70,7 @@ type CredentialIssuerStrategy struct {
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped,scope=Cluster
+// +kubebuilder:subresource:status
 type CredentialIssuer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/generated/1.18/apis/concierge/config/v1alpha1/types_credentialissuer.go
+++ b/generated/1.18/apis/concierge/config/v1alpha1/types_credentialissuer.go
@@ -69,7 +69,7 @@ type CredentialIssuerStrategy struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:categories=pinniped
+// +kubebuilder:resource:categories=pinniped,scope=Cluster
 type CredentialIssuer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/generated/1.18/apis/concierge/config/v1alpha1/types_credentialissuer.go
+++ b/generated/1.18/apis/concierge/config/v1alpha1/types_credentialissuer.go
@@ -67,6 +67,7 @@ type CredentialIssuerStrategy struct {
 
 // Describes the configuration status of a Pinniped credential issuer.
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped
 type CredentialIssuer struct {

--- a/generated/1.18/apis/concierge/login/types_token.go
+++ b/generated/1.18/apis/concierge/login/types_token.go
@@ -27,7 +27,6 @@ type TokenCredentialRequestStatus struct {
 }
 
 // TokenCredentialRequest submits an IDP-specific credential to Pinniped in exchange for a cluster-specific credential.
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type TokenCredentialRequest struct {
 	metav1.TypeMeta

--- a/generated/1.18/apis/concierge/login/v1alpha1/types_token.go
+++ b/generated/1.18/apis/concierge/login/v1alpha1/types_token.go
@@ -30,6 +30,7 @@ type TokenCredentialRequestStatus struct {
 
 // TokenCredentialRequest submits an IDP-specific credential to Pinniped in exchange for a cluster-specific credential.
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type TokenCredentialRequest struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/generated/1.18/apis/supervisor/config/v1alpha1/types_federationdomain.go
+++ b/generated/1.18/apis/supervisor/config/v1alpha1/types_federationdomain.go
@@ -109,6 +109,7 @@ type FederationDomainStatus struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped
+// +kubebuilder:subresource:status
 type FederationDomain struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/generated/1.18/client/concierge/clientset/versioned/typed/authentication/v1alpha1/authentication_client.go
+++ b/generated/1.18/client/concierge/clientset/versioned/typed/authentication/v1alpha1/authentication_client.go
@@ -22,12 +22,12 @@ type AuthenticationV1alpha1Client struct {
 	restClient rest.Interface
 }
 
-func (c *AuthenticationV1alpha1Client) JWTAuthenticators(namespace string) JWTAuthenticatorInterface {
-	return newJWTAuthenticators(c, namespace)
+func (c *AuthenticationV1alpha1Client) JWTAuthenticators() JWTAuthenticatorInterface {
+	return newJWTAuthenticators(c)
 }
 
-func (c *AuthenticationV1alpha1Client) WebhookAuthenticators(namespace string) WebhookAuthenticatorInterface {
-	return newWebhookAuthenticators(c, namespace)
+func (c *AuthenticationV1alpha1Client) WebhookAuthenticators() WebhookAuthenticatorInterface {
+	return newWebhookAuthenticators(c)
 }
 
 // NewForConfig creates a new AuthenticationV1alpha1Client for the given config.

--- a/generated/1.18/client/concierge/clientset/versioned/typed/authentication/v1alpha1/fake/fake_authentication_client.go
+++ b/generated/1.18/client/concierge/clientset/versioned/typed/authentication/v1alpha1/fake/fake_authentication_client.go
@@ -15,12 +15,12 @@ type FakeAuthenticationV1alpha1 struct {
 	*testing.Fake
 }
 
-func (c *FakeAuthenticationV1alpha1) JWTAuthenticators(namespace string) v1alpha1.JWTAuthenticatorInterface {
-	return &FakeJWTAuthenticators{c, namespace}
+func (c *FakeAuthenticationV1alpha1) JWTAuthenticators() v1alpha1.JWTAuthenticatorInterface {
+	return &FakeJWTAuthenticators{c}
 }
 
-func (c *FakeAuthenticationV1alpha1) WebhookAuthenticators(namespace string) v1alpha1.WebhookAuthenticatorInterface {
-	return &FakeWebhookAuthenticators{c, namespace}
+func (c *FakeAuthenticationV1alpha1) WebhookAuthenticators() v1alpha1.WebhookAuthenticatorInterface {
+	return &FakeWebhookAuthenticators{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/generated/1.18/client/concierge/clientset/versioned/typed/authentication/v1alpha1/fake/fake_jwtauthenticator.go
+++ b/generated/1.18/client/concierge/clientset/versioned/typed/authentication/v1alpha1/fake/fake_jwtauthenticator.go
@@ -20,7 +20,6 @@ import (
 // FakeJWTAuthenticators implements JWTAuthenticatorInterface
 type FakeJWTAuthenticators struct {
 	Fake *FakeAuthenticationV1alpha1
-	ns   string
 }
 
 var jwtauthenticatorsResource = schema.GroupVersionResource{Group: "authentication.concierge.pinniped.dev", Version: "v1alpha1", Resource: "jwtauthenticators"}
@@ -30,8 +29,7 @@ var jwtauthenticatorsKind = schema.GroupVersionKind{Group: "authentication.conci
 // Get takes name of the jWTAuthenticator, and returns the corresponding jWTAuthenticator object, and an error if there is any.
 func (c *FakeJWTAuthenticators) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.JWTAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(jwtauthenticatorsResource, c.ns, name), &v1alpha1.JWTAuthenticator{})
-
+		Invokes(testing.NewRootGetAction(jwtauthenticatorsResource, name), &v1alpha1.JWTAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -41,8 +39,7 @@ func (c *FakeJWTAuthenticators) Get(ctx context.Context, name string, options v1
 // List takes label and field selectors, and returns the list of JWTAuthenticators that match those selectors.
 func (c *FakeJWTAuthenticators) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.JWTAuthenticatorList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(jwtauthenticatorsResource, jwtauthenticatorsKind, c.ns, opts), &v1alpha1.JWTAuthenticatorList{})
-
+		Invokes(testing.NewRootListAction(jwtauthenticatorsResource, jwtauthenticatorsKind, opts), &v1alpha1.JWTAuthenticatorList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -63,15 +60,13 @@ func (c *FakeJWTAuthenticators) List(ctx context.Context, opts v1.ListOptions) (
 // Watch returns a watch.Interface that watches the requested jWTAuthenticators.
 func (c *FakeJWTAuthenticators) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(jwtauthenticatorsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(jwtauthenticatorsResource, opts))
 }
 
 // Create takes the representation of a jWTAuthenticator and creates it.  Returns the server's representation of the jWTAuthenticator, and an error, if there is any.
 func (c *FakeJWTAuthenticators) Create(ctx context.Context, jWTAuthenticator *v1alpha1.JWTAuthenticator, opts v1.CreateOptions) (result *v1alpha1.JWTAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(jwtauthenticatorsResource, c.ns, jWTAuthenticator), &v1alpha1.JWTAuthenticator{})
-
+		Invokes(testing.NewRootCreateAction(jwtauthenticatorsResource, jWTAuthenticator), &v1alpha1.JWTAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -81,8 +76,7 @@ func (c *FakeJWTAuthenticators) Create(ctx context.Context, jWTAuthenticator *v1
 // Update takes the representation of a jWTAuthenticator and updates it. Returns the server's representation of the jWTAuthenticator, and an error, if there is any.
 func (c *FakeJWTAuthenticators) Update(ctx context.Context, jWTAuthenticator *v1alpha1.JWTAuthenticator, opts v1.UpdateOptions) (result *v1alpha1.JWTAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(jwtauthenticatorsResource, c.ns, jWTAuthenticator), &v1alpha1.JWTAuthenticator{})
-
+		Invokes(testing.NewRootUpdateAction(jwtauthenticatorsResource, jWTAuthenticator), &v1alpha1.JWTAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -93,8 +87,7 @@ func (c *FakeJWTAuthenticators) Update(ctx context.Context, jWTAuthenticator *v1
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeJWTAuthenticators) UpdateStatus(ctx context.Context, jWTAuthenticator *v1alpha1.JWTAuthenticator, opts v1.UpdateOptions) (*v1alpha1.JWTAuthenticator, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(jwtauthenticatorsResource, "status", c.ns, jWTAuthenticator), &v1alpha1.JWTAuthenticator{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(jwtauthenticatorsResource, "status", jWTAuthenticator), &v1alpha1.JWTAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -104,14 +97,13 @@ func (c *FakeJWTAuthenticators) UpdateStatus(ctx context.Context, jWTAuthenticat
 // Delete takes name of the jWTAuthenticator and deletes it. Returns an error if one occurs.
 func (c *FakeJWTAuthenticators) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(jwtauthenticatorsResource, c.ns, name), &v1alpha1.JWTAuthenticator{})
-
+		Invokes(testing.NewRootDeleteAction(jwtauthenticatorsResource, name), &v1alpha1.JWTAuthenticator{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeJWTAuthenticators) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(jwtauthenticatorsResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(jwtauthenticatorsResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.JWTAuthenticatorList{})
 	return err
@@ -120,8 +112,7 @@ func (c *FakeJWTAuthenticators) DeleteCollection(ctx context.Context, opts v1.De
 // Patch applies the patch and returns the patched jWTAuthenticator.
 func (c *FakeJWTAuthenticators) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.JWTAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(jwtauthenticatorsResource, c.ns, name, pt, data, subresources...), &v1alpha1.JWTAuthenticator{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(jwtauthenticatorsResource, name, pt, data, subresources...), &v1alpha1.JWTAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}

--- a/generated/1.18/client/concierge/clientset/versioned/typed/authentication/v1alpha1/fake/fake_webhookauthenticator.go
+++ b/generated/1.18/client/concierge/clientset/versioned/typed/authentication/v1alpha1/fake/fake_webhookauthenticator.go
@@ -20,7 +20,6 @@ import (
 // FakeWebhookAuthenticators implements WebhookAuthenticatorInterface
 type FakeWebhookAuthenticators struct {
 	Fake *FakeAuthenticationV1alpha1
-	ns   string
 }
 
 var webhookauthenticatorsResource = schema.GroupVersionResource{Group: "authentication.concierge.pinniped.dev", Version: "v1alpha1", Resource: "webhookauthenticators"}
@@ -30,8 +29,7 @@ var webhookauthenticatorsKind = schema.GroupVersionKind{Group: "authentication.c
 // Get takes name of the webhookAuthenticator, and returns the corresponding webhookAuthenticator object, and an error if there is any.
 func (c *FakeWebhookAuthenticators) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.WebhookAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(webhookauthenticatorsResource, c.ns, name), &v1alpha1.WebhookAuthenticator{})
-
+		Invokes(testing.NewRootGetAction(webhookauthenticatorsResource, name), &v1alpha1.WebhookAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -41,8 +39,7 @@ func (c *FakeWebhookAuthenticators) Get(ctx context.Context, name string, option
 // List takes label and field selectors, and returns the list of WebhookAuthenticators that match those selectors.
 func (c *FakeWebhookAuthenticators) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.WebhookAuthenticatorList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(webhookauthenticatorsResource, webhookauthenticatorsKind, c.ns, opts), &v1alpha1.WebhookAuthenticatorList{})
-
+		Invokes(testing.NewRootListAction(webhookauthenticatorsResource, webhookauthenticatorsKind, opts), &v1alpha1.WebhookAuthenticatorList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -63,15 +60,13 @@ func (c *FakeWebhookAuthenticators) List(ctx context.Context, opts v1.ListOption
 // Watch returns a watch.Interface that watches the requested webhookAuthenticators.
 func (c *FakeWebhookAuthenticators) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(webhookauthenticatorsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(webhookauthenticatorsResource, opts))
 }
 
 // Create takes the representation of a webhookAuthenticator and creates it.  Returns the server's representation of the webhookAuthenticator, and an error, if there is any.
 func (c *FakeWebhookAuthenticators) Create(ctx context.Context, webhookAuthenticator *v1alpha1.WebhookAuthenticator, opts v1.CreateOptions) (result *v1alpha1.WebhookAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(webhookauthenticatorsResource, c.ns, webhookAuthenticator), &v1alpha1.WebhookAuthenticator{})
-
+		Invokes(testing.NewRootCreateAction(webhookauthenticatorsResource, webhookAuthenticator), &v1alpha1.WebhookAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -81,8 +76,7 @@ func (c *FakeWebhookAuthenticators) Create(ctx context.Context, webhookAuthentic
 // Update takes the representation of a webhookAuthenticator and updates it. Returns the server's representation of the webhookAuthenticator, and an error, if there is any.
 func (c *FakeWebhookAuthenticators) Update(ctx context.Context, webhookAuthenticator *v1alpha1.WebhookAuthenticator, opts v1.UpdateOptions) (result *v1alpha1.WebhookAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(webhookauthenticatorsResource, c.ns, webhookAuthenticator), &v1alpha1.WebhookAuthenticator{})
-
+		Invokes(testing.NewRootUpdateAction(webhookauthenticatorsResource, webhookAuthenticator), &v1alpha1.WebhookAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -93,8 +87,7 @@ func (c *FakeWebhookAuthenticators) Update(ctx context.Context, webhookAuthentic
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeWebhookAuthenticators) UpdateStatus(ctx context.Context, webhookAuthenticator *v1alpha1.WebhookAuthenticator, opts v1.UpdateOptions) (*v1alpha1.WebhookAuthenticator, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(webhookauthenticatorsResource, "status", c.ns, webhookAuthenticator), &v1alpha1.WebhookAuthenticator{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(webhookauthenticatorsResource, "status", webhookAuthenticator), &v1alpha1.WebhookAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -104,14 +97,13 @@ func (c *FakeWebhookAuthenticators) UpdateStatus(ctx context.Context, webhookAut
 // Delete takes name of the webhookAuthenticator and deletes it. Returns an error if one occurs.
 func (c *FakeWebhookAuthenticators) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(webhookauthenticatorsResource, c.ns, name), &v1alpha1.WebhookAuthenticator{})
-
+		Invokes(testing.NewRootDeleteAction(webhookauthenticatorsResource, name), &v1alpha1.WebhookAuthenticator{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeWebhookAuthenticators) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(webhookauthenticatorsResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(webhookauthenticatorsResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.WebhookAuthenticatorList{})
 	return err
@@ -120,8 +112,7 @@ func (c *FakeWebhookAuthenticators) DeleteCollection(ctx context.Context, opts v
 // Patch applies the patch and returns the patched webhookAuthenticator.
 func (c *FakeWebhookAuthenticators) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.WebhookAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(webhookauthenticatorsResource, c.ns, name, pt, data, subresources...), &v1alpha1.WebhookAuthenticator{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(webhookauthenticatorsResource, name, pt, data, subresources...), &v1alpha1.WebhookAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}

--- a/generated/1.18/client/concierge/clientset/versioned/typed/authentication/v1alpha1/jwtauthenticator.go
+++ b/generated/1.18/client/concierge/clientset/versioned/typed/authentication/v1alpha1/jwtauthenticator.go
@@ -20,7 +20,7 @@ import (
 // JWTAuthenticatorsGetter has a method to return a JWTAuthenticatorInterface.
 // A group's client should implement this interface.
 type JWTAuthenticatorsGetter interface {
-	JWTAuthenticators(namespace string) JWTAuthenticatorInterface
+	JWTAuthenticators() JWTAuthenticatorInterface
 }
 
 // JWTAuthenticatorInterface has methods to work with JWTAuthenticator resources.
@@ -40,14 +40,12 @@ type JWTAuthenticatorInterface interface {
 // jWTAuthenticators implements JWTAuthenticatorInterface
 type jWTAuthenticators struct {
 	client rest.Interface
-	ns     string
 }
 
 // newJWTAuthenticators returns a JWTAuthenticators
-func newJWTAuthenticators(c *AuthenticationV1alpha1Client, namespace string) *jWTAuthenticators {
+func newJWTAuthenticators(c *AuthenticationV1alpha1Client) *jWTAuthenticators {
 	return &jWTAuthenticators{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -55,7 +53,6 @@ func newJWTAuthenticators(c *AuthenticationV1alpha1Client, namespace string) *jW
 func (c *jWTAuthenticators) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.JWTAuthenticator, err error) {
 	result = &v1alpha1.JWTAuthenticator{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -72,7 +69,6 @@ func (c *jWTAuthenticators) List(ctx context.Context, opts v1.ListOptions) (resu
 	}
 	result = &v1alpha1.JWTAuthenticatorList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -89,7 +85,6 @@ func (c *jWTAuthenticators) Watch(ctx context.Context, opts v1.ListOptions) (wat
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -100,7 +95,6 @@ func (c *jWTAuthenticators) Watch(ctx context.Context, opts v1.ListOptions) (wat
 func (c *jWTAuthenticators) Create(ctx context.Context, jWTAuthenticator *v1alpha1.JWTAuthenticator, opts v1.CreateOptions) (result *v1alpha1.JWTAuthenticator, err error) {
 	result = &v1alpha1.JWTAuthenticator{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(jWTAuthenticator).
@@ -113,7 +107,6 @@ func (c *jWTAuthenticators) Create(ctx context.Context, jWTAuthenticator *v1alph
 func (c *jWTAuthenticators) Update(ctx context.Context, jWTAuthenticator *v1alpha1.JWTAuthenticator, opts v1.UpdateOptions) (result *v1alpha1.JWTAuthenticator, err error) {
 	result = &v1alpha1.JWTAuthenticator{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		Name(jWTAuthenticator.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -128,7 +121,6 @@ func (c *jWTAuthenticators) Update(ctx context.Context, jWTAuthenticator *v1alph
 func (c *jWTAuthenticators) UpdateStatus(ctx context.Context, jWTAuthenticator *v1alpha1.JWTAuthenticator, opts v1.UpdateOptions) (result *v1alpha1.JWTAuthenticator, err error) {
 	result = &v1alpha1.JWTAuthenticator{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		Name(jWTAuthenticator.Name).
 		SubResource("status").
@@ -142,7 +134,6 @@ func (c *jWTAuthenticators) UpdateStatus(ctx context.Context, jWTAuthenticator *
 // Delete takes name of the jWTAuthenticator and deletes it. Returns an error if one occurs.
 func (c *jWTAuthenticators) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		Name(name).
 		Body(&opts).
@@ -157,7 +148,6 @@ func (c *jWTAuthenticators) DeleteCollection(ctx context.Context, opts v1.Delete
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -170,7 +160,6 @@ func (c *jWTAuthenticators) DeleteCollection(ctx context.Context, opts v1.Delete
 func (c *jWTAuthenticators) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.JWTAuthenticator, err error) {
 	result = &v1alpha1.JWTAuthenticator{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		Name(name).
 		SubResource(subresources...).

--- a/generated/1.18/client/concierge/clientset/versioned/typed/authentication/v1alpha1/webhookauthenticator.go
+++ b/generated/1.18/client/concierge/clientset/versioned/typed/authentication/v1alpha1/webhookauthenticator.go
@@ -20,7 +20,7 @@ import (
 // WebhookAuthenticatorsGetter has a method to return a WebhookAuthenticatorInterface.
 // A group's client should implement this interface.
 type WebhookAuthenticatorsGetter interface {
-	WebhookAuthenticators(namespace string) WebhookAuthenticatorInterface
+	WebhookAuthenticators() WebhookAuthenticatorInterface
 }
 
 // WebhookAuthenticatorInterface has methods to work with WebhookAuthenticator resources.
@@ -40,14 +40,12 @@ type WebhookAuthenticatorInterface interface {
 // webhookAuthenticators implements WebhookAuthenticatorInterface
 type webhookAuthenticators struct {
 	client rest.Interface
-	ns     string
 }
 
 // newWebhookAuthenticators returns a WebhookAuthenticators
-func newWebhookAuthenticators(c *AuthenticationV1alpha1Client, namespace string) *webhookAuthenticators {
+func newWebhookAuthenticators(c *AuthenticationV1alpha1Client) *webhookAuthenticators {
 	return &webhookAuthenticators{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -55,7 +53,6 @@ func newWebhookAuthenticators(c *AuthenticationV1alpha1Client, namespace string)
 func (c *webhookAuthenticators) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.WebhookAuthenticator, err error) {
 	result = &v1alpha1.WebhookAuthenticator{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -72,7 +69,6 @@ func (c *webhookAuthenticators) List(ctx context.Context, opts v1.ListOptions) (
 	}
 	result = &v1alpha1.WebhookAuthenticatorList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -89,7 +85,6 @@ func (c *webhookAuthenticators) Watch(ctx context.Context, opts v1.ListOptions) 
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -100,7 +95,6 @@ func (c *webhookAuthenticators) Watch(ctx context.Context, opts v1.ListOptions) 
 func (c *webhookAuthenticators) Create(ctx context.Context, webhookAuthenticator *v1alpha1.WebhookAuthenticator, opts v1.CreateOptions) (result *v1alpha1.WebhookAuthenticator, err error) {
 	result = &v1alpha1.WebhookAuthenticator{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(webhookAuthenticator).
@@ -113,7 +107,6 @@ func (c *webhookAuthenticators) Create(ctx context.Context, webhookAuthenticator
 func (c *webhookAuthenticators) Update(ctx context.Context, webhookAuthenticator *v1alpha1.WebhookAuthenticator, opts v1.UpdateOptions) (result *v1alpha1.WebhookAuthenticator, err error) {
 	result = &v1alpha1.WebhookAuthenticator{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		Name(webhookAuthenticator.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -128,7 +121,6 @@ func (c *webhookAuthenticators) Update(ctx context.Context, webhookAuthenticator
 func (c *webhookAuthenticators) UpdateStatus(ctx context.Context, webhookAuthenticator *v1alpha1.WebhookAuthenticator, opts v1.UpdateOptions) (result *v1alpha1.WebhookAuthenticator, err error) {
 	result = &v1alpha1.WebhookAuthenticator{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		Name(webhookAuthenticator.Name).
 		SubResource("status").
@@ -142,7 +134,6 @@ func (c *webhookAuthenticators) UpdateStatus(ctx context.Context, webhookAuthent
 // Delete takes name of the webhookAuthenticator and deletes it. Returns an error if one occurs.
 func (c *webhookAuthenticators) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		Name(name).
 		Body(&opts).
@@ -157,7 +148,6 @@ func (c *webhookAuthenticators) DeleteCollection(ctx context.Context, opts v1.De
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -170,7 +160,6 @@ func (c *webhookAuthenticators) DeleteCollection(ctx context.Context, opts v1.De
 func (c *webhookAuthenticators) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.WebhookAuthenticator, err error) {
 	result = &v1alpha1.WebhookAuthenticator{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		Name(name).
 		SubResource(subresources...).

--- a/generated/1.18/client/concierge/clientset/versioned/typed/config/v1alpha1/config_client.go
+++ b/generated/1.18/client/concierge/clientset/versioned/typed/config/v1alpha1/config_client.go
@@ -21,8 +21,8 @@ type ConfigV1alpha1Client struct {
 	restClient rest.Interface
 }
 
-func (c *ConfigV1alpha1Client) CredentialIssuers(namespace string) CredentialIssuerInterface {
-	return newCredentialIssuers(c, namespace)
+func (c *ConfigV1alpha1Client) CredentialIssuers() CredentialIssuerInterface {
+	return newCredentialIssuers(c)
 }
 
 // NewForConfig creates a new ConfigV1alpha1Client for the given config.

--- a/generated/1.18/client/concierge/clientset/versioned/typed/config/v1alpha1/credentialissuer.go
+++ b/generated/1.18/client/concierge/clientset/versioned/typed/config/v1alpha1/credentialissuer.go
@@ -20,7 +20,7 @@ import (
 // CredentialIssuersGetter has a method to return a CredentialIssuerInterface.
 // A group's client should implement this interface.
 type CredentialIssuersGetter interface {
-	CredentialIssuers(namespace string) CredentialIssuerInterface
+	CredentialIssuers() CredentialIssuerInterface
 }
 
 // CredentialIssuerInterface has methods to work with CredentialIssuer resources.
@@ -40,14 +40,12 @@ type CredentialIssuerInterface interface {
 // credentialIssuers implements CredentialIssuerInterface
 type credentialIssuers struct {
 	client rest.Interface
-	ns     string
 }
 
 // newCredentialIssuers returns a CredentialIssuers
-func newCredentialIssuers(c *ConfigV1alpha1Client, namespace string) *credentialIssuers {
+func newCredentialIssuers(c *ConfigV1alpha1Client) *credentialIssuers {
 	return &credentialIssuers{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -55,7 +53,6 @@ func newCredentialIssuers(c *ConfigV1alpha1Client, namespace string) *credential
 func (c *credentialIssuers) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.CredentialIssuer, err error) {
 	result = &v1alpha1.CredentialIssuer{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -72,7 +69,6 @@ func (c *credentialIssuers) List(ctx context.Context, opts v1.ListOptions) (resu
 	}
 	result = &v1alpha1.CredentialIssuerList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -89,7 +85,6 @@ func (c *credentialIssuers) Watch(ctx context.Context, opts v1.ListOptions) (wat
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -100,7 +95,6 @@ func (c *credentialIssuers) Watch(ctx context.Context, opts v1.ListOptions) (wat
 func (c *credentialIssuers) Create(ctx context.Context, credentialIssuer *v1alpha1.CredentialIssuer, opts v1.CreateOptions) (result *v1alpha1.CredentialIssuer, err error) {
 	result = &v1alpha1.CredentialIssuer{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(credentialIssuer).
@@ -113,7 +107,6 @@ func (c *credentialIssuers) Create(ctx context.Context, credentialIssuer *v1alph
 func (c *credentialIssuers) Update(ctx context.Context, credentialIssuer *v1alpha1.CredentialIssuer, opts v1.UpdateOptions) (result *v1alpha1.CredentialIssuer, err error) {
 	result = &v1alpha1.CredentialIssuer{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		Name(credentialIssuer.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -128,7 +121,6 @@ func (c *credentialIssuers) Update(ctx context.Context, credentialIssuer *v1alph
 func (c *credentialIssuers) UpdateStatus(ctx context.Context, credentialIssuer *v1alpha1.CredentialIssuer, opts v1.UpdateOptions) (result *v1alpha1.CredentialIssuer, err error) {
 	result = &v1alpha1.CredentialIssuer{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		Name(credentialIssuer.Name).
 		SubResource("status").
@@ -142,7 +134,6 @@ func (c *credentialIssuers) UpdateStatus(ctx context.Context, credentialIssuer *
 // Delete takes name of the credentialIssuer and deletes it. Returns an error if one occurs.
 func (c *credentialIssuers) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		Name(name).
 		Body(&opts).
@@ -157,7 +148,6 @@ func (c *credentialIssuers) DeleteCollection(ctx context.Context, opts v1.Delete
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -170,7 +160,6 @@ func (c *credentialIssuers) DeleteCollection(ctx context.Context, opts v1.Delete
 func (c *credentialIssuers) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.CredentialIssuer, err error) {
 	result = &v1alpha1.CredentialIssuer{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		Name(name).
 		SubResource(subresources...).

--- a/generated/1.18/client/concierge/clientset/versioned/typed/config/v1alpha1/fake/fake_config_client.go
+++ b/generated/1.18/client/concierge/clientset/versioned/typed/config/v1alpha1/fake/fake_config_client.go
@@ -15,8 +15,8 @@ type FakeConfigV1alpha1 struct {
 	*testing.Fake
 }
 
-func (c *FakeConfigV1alpha1) CredentialIssuers(namespace string) v1alpha1.CredentialIssuerInterface {
-	return &FakeCredentialIssuers{c, namespace}
+func (c *FakeConfigV1alpha1) CredentialIssuers() v1alpha1.CredentialIssuerInterface {
+	return &FakeCredentialIssuers{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/generated/1.18/client/concierge/clientset/versioned/typed/config/v1alpha1/fake/fake_credentialissuer.go
+++ b/generated/1.18/client/concierge/clientset/versioned/typed/config/v1alpha1/fake/fake_credentialissuer.go
@@ -20,7 +20,6 @@ import (
 // FakeCredentialIssuers implements CredentialIssuerInterface
 type FakeCredentialIssuers struct {
 	Fake *FakeConfigV1alpha1
-	ns   string
 }
 
 var credentialissuersResource = schema.GroupVersionResource{Group: "config.concierge.pinniped.dev", Version: "v1alpha1", Resource: "credentialissuers"}
@@ -30,8 +29,7 @@ var credentialissuersKind = schema.GroupVersionKind{Group: "config.concierge.pin
 // Get takes name of the credentialIssuer, and returns the corresponding credentialIssuer object, and an error if there is any.
 func (c *FakeCredentialIssuers) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.CredentialIssuer, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(credentialissuersResource, c.ns, name), &v1alpha1.CredentialIssuer{})
-
+		Invokes(testing.NewRootGetAction(credentialissuersResource, name), &v1alpha1.CredentialIssuer{})
 	if obj == nil {
 		return nil, err
 	}
@@ -41,8 +39,7 @@ func (c *FakeCredentialIssuers) Get(ctx context.Context, name string, options v1
 // List takes label and field selectors, and returns the list of CredentialIssuers that match those selectors.
 func (c *FakeCredentialIssuers) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.CredentialIssuerList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(credentialissuersResource, credentialissuersKind, c.ns, opts), &v1alpha1.CredentialIssuerList{})
-
+		Invokes(testing.NewRootListAction(credentialissuersResource, credentialissuersKind, opts), &v1alpha1.CredentialIssuerList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -63,15 +60,13 @@ func (c *FakeCredentialIssuers) List(ctx context.Context, opts v1.ListOptions) (
 // Watch returns a watch.Interface that watches the requested credentialIssuers.
 func (c *FakeCredentialIssuers) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(credentialissuersResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(credentialissuersResource, opts))
 }
 
 // Create takes the representation of a credentialIssuer and creates it.  Returns the server's representation of the credentialIssuer, and an error, if there is any.
 func (c *FakeCredentialIssuers) Create(ctx context.Context, credentialIssuer *v1alpha1.CredentialIssuer, opts v1.CreateOptions) (result *v1alpha1.CredentialIssuer, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(credentialissuersResource, c.ns, credentialIssuer), &v1alpha1.CredentialIssuer{})
-
+		Invokes(testing.NewRootCreateAction(credentialissuersResource, credentialIssuer), &v1alpha1.CredentialIssuer{})
 	if obj == nil {
 		return nil, err
 	}
@@ -81,8 +76,7 @@ func (c *FakeCredentialIssuers) Create(ctx context.Context, credentialIssuer *v1
 // Update takes the representation of a credentialIssuer and updates it. Returns the server's representation of the credentialIssuer, and an error, if there is any.
 func (c *FakeCredentialIssuers) Update(ctx context.Context, credentialIssuer *v1alpha1.CredentialIssuer, opts v1.UpdateOptions) (result *v1alpha1.CredentialIssuer, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(credentialissuersResource, c.ns, credentialIssuer), &v1alpha1.CredentialIssuer{})
-
+		Invokes(testing.NewRootUpdateAction(credentialissuersResource, credentialIssuer), &v1alpha1.CredentialIssuer{})
 	if obj == nil {
 		return nil, err
 	}
@@ -93,8 +87,7 @@ func (c *FakeCredentialIssuers) Update(ctx context.Context, credentialIssuer *v1
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeCredentialIssuers) UpdateStatus(ctx context.Context, credentialIssuer *v1alpha1.CredentialIssuer, opts v1.UpdateOptions) (*v1alpha1.CredentialIssuer, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(credentialissuersResource, "status", c.ns, credentialIssuer), &v1alpha1.CredentialIssuer{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(credentialissuersResource, "status", credentialIssuer), &v1alpha1.CredentialIssuer{})
 	if obj == nil {
 		return nil, err
 	}
@@ -104,14 +97,13 @@ func (c *FakeCredentialIssuers) UpdateStatus(ctx context.Context, credentialIssu
 // Delete takes name of the credentialIssuer and deletes it. Returns an error if one occurs.
 func (c *FakeCredentialIssuers) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(credentialissuersResource, c.ns, name), &v1alpha1.CredentialIssuer{})
-
+		Invokes(testing.NewRootDeleteAction(credentialissuersResource, name), &v1alpha1.CredentialIssuer{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeCredentialIssuers) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(credentialissuersResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(credentialissuersResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.CredentialIssuerList{})
 	return err
@@ -120,8 +112,7 @@ func (c *FakeCredentialIssuers) DeleteCollection(ctx context.Context, opts v1.De
 // Patch applies the patch and returns the patched credentialIssuer.
 func (c *FakeCredentialIssuers) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.CredentialIssuer, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(credentialissuersResource, c.ns, name, pt, data, subresources...), &v1alpha1.CredentialIssuer{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(credentialissuersResource, name, pt, data, subresources...), &v1alpha1.CredentialIssuer{})
 	if obj == nil {
 		return nil, err
 	}

--- a/generated/1.18/client/concierge/clientset/versioned/typed/login/v1alpha1/fake/fake_login_client.go
+++ b/generated/1.18/client/concierge/clientset/versioned/typed/login/v1alpha1/fake/fake_login_client.go
@@ -15,8 +15,8 @@ type FakeLoginV1alpha1 struct {
 	*testing.Fake
 }
 
-func (c *FakeLoginV1alpha1) TokenCredentialRequests(namespace string) v1alpha1.TokenCredentialRequestInterface {
-	return &FakeTokenCredentialRequests{c, namespace}
+func (c *FakeLoginV1alpha1) TokenCredentialRequests() v1alpha1.TokenCredentialRequestInterface {
+	return &FakeTokenCredentialRequests{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/generated/1.18/client/concierge/clientset/versioned/typed/login/v1alpha1/fake/fake_tokencredentialrequest.go
+++ b/generated/1.18/client/concierge/clientset/versioned/typed/login/v1alpha1/fake/fake_tokencredentialrequest.go
@@ -20,7 +20,6 @@ import (
 // FakeTokenCredentialRequests implements TokenCredentialRequestInterface
 type FakeTokenCredentialRequests struct {
 	Fake *FakeLoginV1alpha1
-	ns   string
 }
 
 var tokencredentialrequestsResource = schema.GroupVersionResource{Group: "login.concierge.pinniped.dev", Version: "v1alpha1", Resource: "tokencredentialrequests"}
@@ -30,8 +29,7 @@ var tokencredentialrequestsKind = schema.GroupVersionKind{Group: "login.concierg
 // Get takes name of the tokenCredentialRequest, and returns the corresponding tokenCredentialRequest object, and an error if there is any.
 func (c *FakeTokenCredentialRequests) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.TokenCredentialRequest, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(tokencredentialrequestsResource, c.ns, name), &v1alpha1.TokenCredentialRequest{})
-
+		Invokes(testing.NewRootGetAction(tokencredentialrequestsResource, name), &v1alpha1.TokenCredentialRequest{})
 	if obj == nil {
 		return nil, err
 	}
@@ -41,8 +39,7 @@ func (c *FakeTokenCredentialRequests) Get(ctx context.Context, name string, opti
 // List takes label and field selectors, and returns the list of TokenCredentialRequests that match those selectors.
 func (c *FakeTokenCredentialRequests) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.TokenCredentialRequestList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(tokencredentialrequestsResource, tokencredentialrequestsKind, c.ns, opts), &v1alpha1.TokenCredentialRequestList{})
-
+		Invokes(testing.NewRootListAction(tokencredentialrequestsResource, tokencredentialrequestsKind, opts), &v1alpha1.TokenCredentialRequestList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -63,15 +60,13 @@ func (c *FakeTokenCredentialRequests) List(ctx context.Context, opts v1.ListOpti
 // Watch returns a watch.Interface that watches the requested tokenCredentialRequests.
 func (c *FakeTokenCredentialRequests) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(tokencredentialrequestsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(tokencredentialrequestsResource, opts))
 }
 
 // Create takes the representation of a tokenCredentialRequest and creates it.  Returns the server's representation of the tokenCredentialRequest, and an error, if there is any.
 func (c *FakeTokenCredentialRequests) Create(ctx context.Context, tokenCredentialRequest *v1alpha1.TokenCredentialRequest, opts v1.CreateOptions) (result *v1alpha1.TokenCredentialRequest, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(tokencredentialrequestsResource, c.ns, tokenCredentialRequest), &v1alpha1.TokenCredentialRequest{})
-
+		Invokes(testing.NewRootCreateAction(tokencredentialrequestsResource, tokenCredentialRequest), &v1alpha1.TokenCredentialRequest{})
 	if obj == nil {
 		return nil, err
 	}
@@ -81,8 +76,7 @@ func (c *FakeTokenCredentialRequests) Create(ctx context.Context, tokenCredentia
 // Update takes the representation of a tokenCredentialRequest and updates it. Returns the server's representation of the tokenCredentialRequest, and an error, if there is any.
 func (c *FakeTokenCredentialRequests) Update(ctx context.Context, tokenCredentialRequest *v1alpha1.TokenCredentialRequest, opts v1.UpdateOptions) (result *v1alpha1.TokenCredentialRequest, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(tokencredentialrequestsResource, c.ns, tokenCredentialRequest), &v1alpha1.TokenCredentialRequest{})
-
+		Invokes(testing.NewRootUpdateAction(tokencredentialrequestsResource, tokenCredentialRequest), &v1alpha1.TokenCredentialRequest{})
 	if obj == nil {
 		return nil, err
 	}
@@ -93,8 +87,7 @@ func (c *FakeTokenCredentialRequests) Update(ctx context.Context, tokenCredentia
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeTokenCredentialRequests) UpdateStatus(ctx context.Context, tokenCredentialRequest *v1alpha1.TokenCredentialRequest, opts v1.UpdateOptions) (*v1alpha1.TokenCredentialRequest, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(tokencredentialrequestsResource, "status", c.ns, tokenCredentialRequest), &v1alpha1.TokenCredentialRequest{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(tokencredentialrequestsResource, "status", tokenCredentialRequest), &v1alpha1.TokenCredentialRequest{})
 	if obj == nil {
 		return nil, err
 	}
@@ -104,14 +97,13 @@ func (c *FakeTokenCredentialRequests) UpdateStatus(ctx context.Context, tokenCre
 // Delete takes name of the tokenCredentialRequest and deletes it. Returns an error if one occurs.
 func (c *FakeTokenCredentialRequests) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(tokencredentialrequestsResource, c.ns, name), &v1alpha1.TokenCredentialRequest{})
-
+		Invokes(testing.NewRootDeleteAction(tokencredentialrequestsResource, name), &v1alpha1.TokenCredentialRequest{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeTokenCredentialRequests) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(tokencredentialrequestsResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(tokencredentialrequestsResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.TokenCredentialRequestList{})
 	return err
@@ -120,8 +112,7 @@ func (c *FakeTokenCredentialRequests) DeleteCollection(ctx context.Context, opts
 // Patch applies the patch and returns the patched tokenCredentialRequest.
 func (c *FakeTokenCredentialRequests) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.TokenCredentialRequest, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(tokencredentialrequestsResource, c.ns, name, pt, data, subresources...), &v1alpha1.TokenCredentialRequest{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(tokencredentialrequestsResource, name, pt, data, subresources...), &v1alpha1.TokenCredentialRequest{})
 	if obj == nil {
 		return nil, err
 	}

--- a/generated/1.18/client/concierge/clientset/versioned/typed/login/v1alpha1/login_client.go
+++ b/generated/1.18/client/concierge/clientset/versioned/typed/login/v1alpha1/login_client.go
@@ -21,8 +21,8 @@ type LoginV1alpha1Client struct {
 	restClient rest.Interface
 }
 
-func (c *LoginV1alpha1Client) TokenCredentialRequests(namespace string) TokenCredentialRequestInterface {
-	return newTokenCredentialRequests(c, namespace)
+func (c *LoginV1alpha1Client) TokenCredentialRequests() TokenCredentialRequestInterface {
+	return newTokenCredentialRequests(c)
 }
 
 // NewForConfig creates a new LoginV1alpha1Client for the given config.

--- a/generated/1.18/client/concierge/clientset/versioned/typed/login/v1alpha1/tokencredentialrequest.go
+++ b/generated/1.18/client/concierge/clientset/versioned/typed/login/v1alpha1/tokencredentialrequest.go
@@ -20,7 +20,7 @@ import (
 // TokenCredentialRequestsGetter has a method to return a TokenCredentialRequestInterface.
 // A group's client should implement this interface.
 type TokenCredentialRequestsGetter interface {
-	TokenCredentialRequests(namespace string) TokenCredentialRequestInterface
+	TokenCredentialRequests() TokenCredentialRequestInterface
 }
 
 // TokenCredentialRequestInterface has methods to work with TokenCredentialRequest resources.
@@ -40,14 +40,12 @@ type TokenCredentialRequestInterface interface {
 // tokenCredentialRequests implements TokenCredentialRequestInterface
 type tokenCredentialRequests struct {
 	client rest.Interface
-	ns     string
 }
 
 // newTokenCredentialRequests returns a TokenCredentialRequests
-func newTokenCredentialRequests(c *LoginV1alpha1Client, namespace string) *tokenCredentialRequests {
+func newTokenCredentialRequests(c *LoginV1alpha1Client) *tokenCredentialRequests {
 	return &tokenCredentialRequests{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -55,7 +53,6 @@ func newTokenCredentialRequests(c *LoginV1alpha1Client, namespace string) *token
 func (c *tokenCredentialRequests) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.TokenCredentialRequest, err error) {
 	result = &v1alpha1.TokenCredentialRequest{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -72,7 +69,6 @@ func (c *tokenCredentialRequests) List(ctx context.Context, opts v1.ListOptions)
 	}
 	result = &v1alpha1.TokenCredentialRequestList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -89,7 +85,6 @@ func (c *tokenCredentialRequests) Watch(ctx context.Context, opts v1.ListOptions
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -100,7 +95,6 @@ func (c *tokenCredentialRequests) Watch(ctx context.Context, opts v1.ListOptions
 func (c *tokenCredentialRequests) Create(ctx context.Context, tokenCredentialRequest *v1alpha1.TokenCredentialRequest, opts v1.CreateOptions) (result *v1alpha1.TokenCredentialRequest, err error) {
 	result = &v1alpha1.TokenCredentialRequest{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(tokenCredentialRequest).
@@ -113,7 +107,6 @@ func (c *tokenCredentialRequests) Create(ctx context.Context, tokenCredentialReq
 func (c *tokenCredentialRequests) Update(ctx context.Context, tokenCredentialRequest *v1alpha1.TokenCredentialRequest, opts v1.UpdateOptions) (result *v1alpha1.TokenCredentialRequest, err error) {
 	result = &v1alpha1.TokenCredentialRequest{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		Name(tokenCredentialRequest.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -128,7 +121,6 @@ func (c *tokenCredentialRequests) Update(ctx context.Context, tokenCredentialReq
 func (c *tokenCredentialRequests) UpdateStatus(ctx context.Context, tokenCredentialRequest *v1alpha1.TokenCredentialRequest, opts v1.UpdateOptions) (result *v1alpha1.TokenCredentialRequest, err error) {
 	result = &v1alpha1.TokenCredentialRequest{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		Name(tokenCredentialRequest.Name).
 		SubResource("status").
@@ -142,7 +134,6 @@ func (c *tokenCredentialRequests) UpdateStatus(ctx context.Context, tokenCredent
 // Delete takes name of the tokenCredentialRequest and deletes it. Returns an error if one occurs.
 func (c *tokenCredentialRequests) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		Name(name).
 		Body(&opts).
@@ -157,7 +148,6 @@ func (c *tokenCredentialRequests) DeleteCollection(ctx context.Context, opts v1.
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -170,7 +160,6 @@ func (c *tokenCredentialRequests) DeleteCollection(ctx context.Context, opts v1.
 func (c *tokenCredentialRequests) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.TokenCredentialRequest, err error) {
 	result = &v1alpha1.TokenCredentialRequest{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		Name(name).
 		SubResource(subresources...).

--- a/generated/1.18/client/concierge/informers/externalversions/authentication/v1alpha1/interface.go
+++ b/generated/1.18/client/concierge/informers/externalversions/authentication/v1alpha1/interface.go
@@ -30,10 +30,10 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // JWTAuthenticators returns a JWTAuthenticatorInformer.
 func (v *version) JWTAuthenticators() JWTAuthenticatorInformer {
-	return &jWTAuthenticatorInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &jWTAuthenticatorInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
 // WebhookAuthenticators returns a WebhookAuthenticatorInformer.
 func (v *version) WebhookAuthenticators() WebhookAuthenticatorInformer {
-	return &webhookAuthenticatorInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &webhookAuthenticatorInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/generated/1.18/client/concierge/informers/externalversions/authentication/v1alpha1/jwtauthenticator.go
+++ b/generated/1.18/client/concierge/informers/externalversions/authentication/v1alpha1/jwtauthenticator.go
@@ -29,33 +29,32 @@ type JWTAuthenticatorInformer interface {
 type jWTAuthenticatorInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewJWTAuthenticatorInformer constructs a new informer for JWTAuthenticator type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewJWTAuthenticatorInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredJWTAuthenticatorInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewJWTAuthenticatorInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredJWTAuthenticatorInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredJWTAuthenticatorInformer constructs a new informer for JWTAuthenticator type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredJWTAuthenticatorInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredJWTAuthenticatorInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AuthenticationV1alpha1().JWTAuthenticators(namespace).List(context.TODO(), options)
+				return client.AuthenticationV1alpha1().JWTAuthenticators().List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AuthenticationV1alpha1().JWTAuthenticators(namespace).Watch(context.TODO(), options)
+				return client.AuthenticationV1alpha1().JWTAuthenticators().Watch(context.TODO(), options)
 			},
 		},
 		&authenticationv1alpha1.JWTAuthenticator{},
@@ -65,7 +64,7 @@ func NewFilteredJWTAuthenticatorInformer(client versioned.Interface, namespace s
 }
 
 func (f *jWTAuthenticatorInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredJWTAuthenticatorInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredJWTAuthenticatorInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *jWTAuthenticatorInformer) Informer() cache.SharedIndexInformer {

--- a/generated/1.18/client/concierge/informers/externalversions/authentication/v1alpha1/webhookauthenticator.go
+++ b/generated/1.18/client/concierge/informers/externalversions/authentication/v1alpha1/webhookauthenticator.go
@@ -29,33 +29,32 @@ type WebhookAuthenticatorInformer interface {
 type webhookAuthenticatorInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewWebhookAuthenticatorInformer constructs a new informer for WebhookAuthenticator type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewWebhookAuthenticatorInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredWebhookAuthenticatorInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewWebhookAuthenticatorInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredWebhookAuthenticatorInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredWebhookAuthenticatorInformer constructs a new informer for WebhookAuthenticator type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredWebhookAuthenticatorInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredWebhookAuthenticatorInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AuthenticationV1alpha1().WebhookAuthenticators(namespace).List(context.TODO(), options)
+				return client.AuthenticationV1alpha1().WebhookAuthenticators().List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AuthenticationV1alpha1().WebhookAuthenticators(namespace).Watch(context.TODO(), options)
+				return client.AuthenticationV1alpha1().WebhookAuthenticators().Watch(context.TODO(), options)
 			},
 		},
 		&authenticationv1alpha1.WebhookAuthenticator{},
@@ -65,7 +64,7 @@ func NewFilteredWebhookAuthenticatorInformer(client versioned.Interface, namespa
 }
 
 func (f *webhookAuthenticatorInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredWebhookAuthenticatorInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredWebhookAuthenticatorInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *webhookAuthenticatorInformer) Informer() cache.SharedIndexInformer {

--- a/generated/1.18/client/concierge/informers/externalversions/config/v1alpha1/credentialissuer.go
+++ b/generated/1.18/client/concierge/informers/externalversions/config/v1alpha1/credentialissuer.go
@@ -29,33 +29,32 @@ type CredentialIssuerInformer interface {
 type credentialIssuerInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewCredentialIssuerInformer constructs a new informer for CredentialIssuer type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewCredentialIssuerInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredCredentialIssuerInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewCredentialIssuerInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredCredentialIssuerInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredCredentialIssuerInformer constructs a new informer for CredentialIssuer type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredCredentialIssuerInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredCredentialIssuerInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ConfigV1alpha1().CredentialIssuers(namespace).List(context.TODO(), options)
+				return client.ConfigV1alpha1().CredentialIssuers().List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ConfigV1alpha1().CredentialIssuers(namespace).Watch(context.TODO(), options)
+				return client.ConfigV1alpha1().CredentialIssuers().Watch(context.TODO(), options)
 			},
 		},
 		&configv1alpha1.CredentialIssuer{},
@@ -65,7 +64,7 @@ func NewFilteredCredentialIssuerInformer(client versioned.Interface, namespace s
 }
 
 func (f *credentialIssuerInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredCredentialIssuerInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredCredentialIssuerInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *credentialIssuerInformer) Informer() cache.SharedIndexInformer {

--- a/generated/1.18/client/concierge/informers/externalversions/config/v1alpha1/interface.go
+++ b/generated/1.18/client/concierge/informers/externalversions/config/v1alpha1/interface.go
@@ -28,5 +28,5 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // CredentialIssuers returns a CredentialIssuerInformer.
 func (v *version) CredentialIssuers() CredentialIssuerInformer {
-	return &credentialIssuerInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &credentialIssuerInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/generated/1.18/client/concierge/informers/externalversions/login/v1alpha1/interface.go
+++ b/generated/1.18/client/concierge/informers/externalversions/login/v1alpha1/interface.go
@@ -28,5 +28,5 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // TokenCredentialRequests returns a TokenCredentialRequestInformer.
 func (v *version) TokenCredentialRequests() TokenCredentialRequestInformer {
-	return &tokenCredentialRequestInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &tokenCredentialRequestInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/generated/1.18/client/concierge/informers/externalversions/login/v1alpha1/tokencredentialrequest.go
+++ b/generated/1.18/client/concierge/informers/externalversions/login/v1alpha1/tokencredentialrequest.go
@@ -29,33 +29,32 @@ type TokenCredentialRequestInformer interface {
 type tokenCredentialRequestInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewTokenCredentialRequestInformer constructs a new informer for TokenCredentialRequest type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewTokenCredentialRequestInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredTokenCredentialRequestInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewTokenCredentialRequestInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredTokenCredentialRequestInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredTokenCredentialRequestInformer constructs a new informer for TokenCredentialRequest type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredTokenCredentialRequestInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredTokenCredentialRequestInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.LoginV1alpha1().TokenCredentialRequests(namespace).List(context.TODO(), options)
+				return client.LoginV1alpha1().TokenCredentialRequests().List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.LoginV1alpha1().TokenCredentialRequests(namespace).Watch(context.TODO(), options)
+				return client.LoginV1alpha1().TokenCredentialRequests().Watch(context.TODO(), options)
 			},
 		},
 		&loginv1alpha1.TokenCredentialRequest{},
@@ -65,7 +64,7 @@ func NewFilteredTokenCredentialRequestInformer(client versioned.Interface, names
 }
 
 func (f *tokenCredentialRequestInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredTokenCredentialRequestInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredTokenCredentialRequestInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *tokenCredentialRequestInformer) Informer() cache.SharedIndexInformer {

--- a/generated/1.18/client/concierge/listers/authentication/v1alpha1/expansion_generated.go
+++ b/generated/1.18/client/concierge/listers/authentication/v1alpha1/expansion_generated.go
@@ -9,14 +9,6 @@ package v1alpha1
 // JWTAuthenticatorLister.
 type JWTAuthenticatorListerExpansion interface{}
 
-// JWTAuthenticatorNamespaceListerExpansion allows custom methods to be added to
-// JWTAuthenticatorNamespaceLister.
-type JWTAuthenticatorNamespaceListerExpansion interface{}
-
 // WebhookAuthenticatorListerExpansion allows custom methods to be added to
 // WebhookAuthenticatorLister.
 type WebhookAuthenticatorListerExpansion interface{}
-
-// WebhookAuthenticatorNamespaceListerExpansion allows custom methods to be added to
-// WebhookAuthenticatorNamespaceLister.
-type WebhookAuthenticatorNamespaceListerExpansion interface{}

--- a/generated/1.18/client/concierge/listers/authentication/v1alpha1/jwtauthenticator.go
+++ b/generated/1.18/client/concierge/listers/authentication/v1alpha1/jwtauthenticator.go
@@ -16,8 +16,8 @@ import (
 type JWTAuthenticatorLister interface {
 	// List lists all JWTAuthenticators in the indexer.
 	List(selector labels.Selector) (ret []*v1alpha1.JWTAuthenticator, err error)
-	// JWTAuthenticators returns an object that can list and get JWTAuthenticators.
-	JWTAuthenticators(namespace string) JWTAuthenticatorNamespaceLister
+	// Get retrieves the JWTAuthenticator from the index for a given name.
+	Get(name string) (*v1alpha1.JWTAuthenticator, error)
 	JWTAuthenticatorListerExpansion
 }
 
@@ -39,38 +39,9 @@ func (s *jWTAuthenticatorLister) List(selector labels.Selector) (ret []*v1alpha1
 	return ret, err
 }
 
-// JWTAuthenticators returns an object that can list and get JWTAuthenticators.
-func (s *jWTAuthenticatorLister) JWTAuthenticators(namespace string) JWTAuthenticatorNamespaceLister {
-	return jWTAuthenticatorNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// JWTAuthenticatorNamespaceLister helps list and get JWTAuthenticators.
-type JWTAuthenticatorNamespaceLister interface {
-	// List lists all JWTAuthenticators in the indexer for a given namespace.
-	List(selector labels.Selector) (ret []*v1alpha1.JWTAuthenticator, err error)
-	// Get retrieves the JWTAuthenticator from the indexer for a given namespace and name.
-	Get(name string) (*v1alpha1.JWTAuthenticator, error)
-	JWTAuthenticatorNamespaceListerExpansion
-}
-
-// jWTAuthenticatorNamespaceLister implements the JWTAuthenticatorNamespaceLister
-// interface.
-type jWTAuthenticatorNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all JWTAuthenticators in the indexer for a given namespace.
-func (s jWTAuthenticatorNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.JWTAuthenticator, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.JWTAuthenticator))
-	})
-	return ret, err
-}
-
-// Get retrieves the JWTAuthenticator from the indexer for a given namespace and name.
-func (s jWTAuthenticatorNamespaceLister) Get(name string) (*v1alpha1.JWTAuthenticator, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the JWTAuthenticator from the index for a given name.
+func (s *jWTAuthenticatorLister) Get(name string) (*v1alpha1.JWTAuthenticator, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/generated/1.18/client/concierge/listers/authentication/v1alpha1/webhookauthenticator.go
+++ b/generated/1.18/client/concierge/listers/authentication/v1alpha1/webhookauthenticator.go
@@ -16,8 +16,8 @@ import (
 type WebhookAuthenticatorLister interface {
 	// List lists all WebhookAuthenticators in the indexer.
 	List(selector labels.Selector) (ret []*v1alpha1.WebhookAuthenticator, err error)
-	// WebhookAuthenticators returns an object that can list and get WebhookAuthenticators.
-	WebhookAuthenticators(namespace string) WebhookAuthenticatorNamespaceLister
+	// Get retrieves the WebhookAuthenticator from the index for a given name.
+	Get(name string) (*v1alpha1.WebhookAuthenticator, error)
 	WebhookAuthenticatorListerExpansion
 }
 
@@ -39,38 +39,9 @@ func (s *webhookAuthenticatorLister) List(selector labels.Selector) (ret []*v1al
 	return ret, err
 }
 
-// WebhookAuthenticators returns an object that can list and get WebhookAuthenticators.
-func (s *webhookAuthenticatorLister) WebhookAuthenticators(namespace string) WebhookAuthenticatorNamespaceLister {
-	return webhookAuthenticatorNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// WebhookAuthenticatorNamespaceLister helps list and get WebhookAuthenticators.
-type WebhookAuthenticatorNamespaceLister interface {
-	// List lists all WebhookAuthenticators in the indexer for a given namespace.
-	List(selector labels.Selector) (ret []*v1alpha1.WebhookAuthenticator, err error)
-	// Get retrieves the WebhookAuthenticator from the indexer for a given namespace and name.
-	Get(name string) (*v1alpha1.WebhookAuthenticator, error)
-	WebhookAuthenticatorNamespaceListerExpansion
-}
-
-// webhookAuthenticatorNamespaceLister implements the WebhookAuthenticatorNamespaceLister
-// interface.
-type webhookAuthenticatorNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all WebhookAuthenticators in the indexer for a given namespace.
-func (s webhookAuthenticatorNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.WebhookAuthenticator, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.WebhookAuthenticator))
-	})
-	return ret, err
-}
-
-// Get retrieves the WebhookAuthenticator from the indexer for a given namespace and name.
-func (s webhookAuthenticatorNamespaceLister) Get(name string) (*v1alpha1.WebhookAuthenticator, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the WebhookAuthenticator from the index for a given name.
+func (s *webhookAuthenticatorLister) Get(name string) (*v1alpha1.WebhookAuthenticator, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/generated/1.18/client/concierge/listers/config/v1alpha1/credentialissuer.go
+++ b/generated/1.18/client/concierge/listers/config/v1alpha1/credentialissuer.go
@@ -16,8 +16,8 @@ import (
 type CredentialIssuerLister interface {
 	// List lists all CredentialIssuers in the indexer.
 	List(selector labels.Selector) (ret []*v1alpha1.CredentialIssuer, err error)
-	// CredentialIssuers returns an object that can list and get CredentialIssuers.
-	CredentialIssuers(namespace string) CredentialIssuerNamespaceLister
+	// Get retrieves the CredentialIssuer from the index for a given name.
+	Get(name string) (*v1alpha1.CredentialIssuer, error)
 	CredentialIssuerListerExpansion
 }
 
@@ -39,38 +39,9 @@ func (s *credentialIssuerLister) List(selector labels.Selector) (ret []*v1alpha1
 	return ret, err
 }
 
-// CredentialIssuers returns an object that can list and get CredentialIssuers.
-func (s *credentialIssuerLister) CredentialIssuers(namespace string) CredentialIssuerNamespaceLister {
-	return credentialIssuerNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// CredentialIssuerNamespaceLister helps list and get CredentialIssuers.
-type CredentialIssuerNamespaceLister interface {
-	// List lists all CredentialIssuers in the indexer for a given namespace.
-	List(selector labels.Selector) (ret []*v1alpha1.CredentialIssuer, err error)
-	// Get retrieves the CredentialIssuer from the indexer for a given namespace and name.
-	Get(name string) (*v1alpha1.CredentialIssuer, error)
-	CredentialIssuerNamespaceListerExpansion
-}
-
-// credentialIssuerNamespaceLister implements the CredentialIssuerNamespaceLister
-// interface.
-type credentialIssuerNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all CredentialIssuers in the indexer for a given namespace.
-func (s credentialIssuerNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.CredentialIssuer, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.CredentialIssuer))
-	})
-	return ret, err
-}
-
-// Get retrieves the CredentialIssuer from the indexer for a given namespace and name.
-func (s credentialIssuerNamespaceLister) Get(name string) (*v1alpha1.CredentialIssuer, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the CredentialIssuer from the index for a given name.
+func (s *credentialIssuerLister) Get(name string) (*v1alpha1.CredentialIssuer, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/generated/1.18/client/concierge/listers/config/v1alpha1/expansion_generated.go
+++ b/generated/1.18/client/concierge/listers/config/v1alpha1/expansion_generated.go
@@ -8,7 +8,3 @@ package v1alpha1
 // CredentialIssuerListerExpansion allows custom methods to be added to
 // CredentialIssuerLister.
 type CredentialIssuerListerExpansion interface{}
-
-// CredentialIssuerNamespaceListerExpansion allows custom methods to be added to
-// CredentialIssuerNamespaceLister.
-type CredentialIssuerNamespaceListerExpansion interface{}

--- a/generated/1.18/client/concierge/listers/login/v1alpha1/expansion_generated.go
+++ b/generated/1.18/client/concierge/listers/login/v1alpha1/expansion_generated.go
@@ -8,7 +8,3 @@ package v1alpha1
 // TokenCredentialRequestListerExpansion allows custom methods to be added to
 // TokenCredentialRequestLister.
 type TokenCredentialRequestListerExpansion interface{}
-
-// TokenCredentialRequestNamespaceListerExpansion allows custom methods to be added to
-// TokenCredentialRequestNamespaceLister.
-type TokenCredentialRequestNamespaceListerExpansion interface{}

--- a/generated/1.18/client/concierge/listers/login/v1alpha1/tokencredentialrequest.go
+++ b/generated/1.18/client/concierge/listers/login/v1alpha1/tokencredentialrequest.go
@@ -16,8 +16,8 @@ import (
 type TokenCredentialRequestLister interface {
 	// List lists all TokenCredentialRequests in the indexer.
 	List(selector labels.Selector) (ret []*v1alpha1.TokenCredentialRequest, err error)
-	// TokenCredentialRequests returns an object that can list and get TokenCredentialRequests.
-	TokenCredentialRequests(namespace string) TokenCredentialRequestNamespaceLister
+	// Get retrieves the TokenCredentialRequest from the index for a given name.
+	Get(name string) (*v1alpha1.TokenCredentialRequest, error)
 	TokenCredentialRequestListerExpansion
 }
 
@@ -39,38 +39,9 @@ func (s *tokenCredentialRequestLister) List(selector labels.Selector) (ret []*v1
 	return ret, err
 }
 
-// TokenCredentialRequests returns an object that can list and get TokenCredentialRequests.
-func (s *tokenCredentialRequestLister) TokenCredentialRequests(namespace string) TokenCredentialRequestNamespaceLister {
-	return tokenCredentialRequestNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// TokenCredentialRequestNamespaceLister helps list and get TokenCredentialRequests.
-type TokenCredentialRequestNamespaceLister interface {
-	// List lists all TokenCredentialRequests in the indexer for a given namespace.
-	List(selector labels.Selector) (ret []*v1alpha1.TokenCredentialRequest, err error)
-	// Get retrieves the TokenCredentialRequest from the indexer for a given namespace and name.
-	Get(name string) (*v1alpha1.TokenCredentialRequest, error)
-	TokenCredentialRequestNamespaceListerExpansion
-}
-
-// tokenCredentialRequestNamespaceLister implements the TokenCredentialRequestNamespaceLister
-// interface.
-type tokenCredentialRequestNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all TokenCredentialRequests in the indexer for a given namespace.
-func (s tokenCredentialRequestNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.TokenCredentialRequest, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.TokenCredentialRequest))
-	})
-	return ret, err
-}
-
-// Get retrieves the TokenCredentialRequest from the indexer for a given namespace and name.
-func (s tokenCredentialRequestNamespaceLister) Get(name string) (*v1alpha1.TokenCredentialRequest, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the TokenCredentialRequest from the index for a given name.
+func (s *tokenCredentialRequestLister) Get(name string) (*v1alpha1.TokenCredentialRequest, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/generated/1.18/crds/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
+++ b/generated/1.18/crds/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
@@ -161,7 +161,8 @@ spec:
         type: object
     served: true
     storage: true
-    subresources: {}
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/generated/1.18/crds/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
+++ b/generated/1.18/crds/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
@@ -18,7 +18,7 @@ spec:
     listKind: JWTAuthenticatorList
     plural: jwtauthenticators
     singular: jwtauthenticator
-  scope: Namespaced
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.issuer

--- a/generated/1.18/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
+++ b/generated/1.18/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
@@ -137,7 +137,8 @@ spec:
         type: object
     served: true
     storage: true
-    subresources: {}
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/generated/1.18/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
+++ b/generated/1.18/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
@@ -18,7 +18,7 @@ spec:
     listKind: WebhookAuthenticatorList
     plural: webhookauthenticators
     singular: webhookauthenticator
-  scope: Namespaced
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.endpoint

--- a/generated/1.18/crds/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/generated/1.18/crds/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -16,7 +16,7 @@ spec:
     listKind: CredentialIssuerList
     plural: credentialissuers
     singular: credentialissuer
-  scope: Namespaced
+  scope: Cluster
   versions:
   - name: v1alpha1
     schema:

--- a/generated/1.18/crds/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/generated/1.18/crds/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -98,8 +98,6 @@ spec:
             required:
             - strategies
             type: object
-        required:
-        - status
         type: object
     served: true
     storage: true

--- a/generated/1.18/crds/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/generated/1.18/crds/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -103,6 +103,8 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/generated/1.18/crds/config.supervisor.pinniped.dev_federationdomains.yaml
+++ b/generated/1.18/crds/config.supervisor.pinniped.dev_federationdomains.yaml
@@ -150,6 +150,8 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/generated/1.19/apis/concierge/authentication/v1alpha1/types_jwt.go
+++ b/generated/1.19/apis/concierge/authentication/v1alpha1/types_jwt.go
@@ -61,6 +61,7 @@ type JWTTokenClaims struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators,scope=Cluster
 // +kubebuilder:printcolumn:name="Issuer",type=string,JSONPath=`.spec.issuer`
+// +kubebuilder:subresource:status
 type JWTAuthenticator struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/generated/1.19/apis/concierge/authentication/v1alpha1/types_jwt.go
+++ b/generated/1.19/apis/concierge/authentication/v1alpha1/types_jwt.go
@@ -57,6 +57,7 @@ type JWTTokenClaims struct {
 // signature, existence of claims, etc.) and extract the username and groups from the token.
 //
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators
 // +kubebuilder:printcolumn:name="Issuer",type=string,JSONPath=`.spec.issuer`

--- a/generated/1.19/apis/concierge/authentication/v1alpha1/types_jwt.go
+++ b/generated/1.19/apis/concierge/authentication/v1alpha1/types_jwt.go
@@ -59,7 +59,7 @@ type JWTTokenClaims struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators
+// +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators,scope=Cluster
 // +kubebuilder:printcolumn:name="Issuer",type=string,JSONPath=`.spec.issuer`
 type JWTAuthenticator struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/generated/1.19/apis/concierge/authentication/v1alpha1/types_webhook.go
+++ b/generated/1.19/apis/concierge/authentication/v1alpha1/types_webhook.go
@@ -31,7 +31,7 @@ type WebhookAuthenticatorSpec struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators
+// +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators,scope=Cluster
 // +kubebuilder:printcolumn:name="Endpoint",type=string,JSONPath=`.spec.endpoint`
 type WebhookAuthenticator struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/generated/1.19/apis/concierge/authentication/v1alpha1/types_webhook.go
+++ b/generated/1.19/apis/concierge/authentication/v1alpha1/types_webhook.go
@@ -29,6 +29,7 @@ type WebhookAuthenticatorSpec struct {
 
 // WebhookAuthenticator describes the configuration of a webhook authenticator.
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators
 // +kubebuilder:printcolumn:name="Endpoint",type=string,JSONPath=`.spec.endpoint`

--- a/generated/1.19/apis/concierge/authentication/v1alpha1/types_webhook.go
+++ b/generated/1.19/apis/concierge/authentication/v1alpha1/types_webhook.go
@@ -33,6 +33,7 @@ type WebhookAuthenticatorSpec struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators,scope=Cluster
 // +kubebuilder:printcolumn:name="Endpoint",type=string,JSONPath=`.spec.endpoint`
+// +kubebuilder:subresource:status
 type WebhookAuthenticator struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/generated/1.19/apis/concierge/config/v1alpha1/types_credentialissuer.go
+++ b/generated/1.19/apis/concierge/config/v1alpha1/types_credentialissuer.go
@@ -76,6 +76,7 @@ type CredentialIssuer struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Status of the credential issuer.
+	// +optional
 	Status CredentialIssuerStatus `json:"status"`
 }
 

--- a/generated/1.19/apis/concierge/config/v1alpha1/types_credentialissuer.go
+++ b/generated/1.19/apis/concierge/config/v1alpha1/types_credentialissuer.go
@@ -70,6 +70,7 @@ type CredentialIssuerStrategy struct {
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped,scope=Cluster
+// +kubebuilder:subresource:status
 type CredentialIssuer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/generated/1.19/apis/concierge/config/v1alpha1/types_credentialissuer.go
+++ b/generated/1.19/apis/concierge/config/v1alpha1/types_credentialissuer.go
@@ -69,7 +69,7 @@ type CredentialIssuerStrategy struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:categories=pinniped
+// +kubebuilder:resource:categories=pinniped,scope=Cluster
 type CredentialIssuer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/generated/1.19/apis/concierge/config/v1alpha1/types_credentialissuer.go
+++ b/generated/1.19/apis/concierge/config/v1alpha1/types_credentialissuer.go
@@ -67,6 +67,7 @@ type CredentialIssuerStrategy struct {
 
 // Describes the configuration status of a Pinniped credential issuer.
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped
 type CredentialIssuer struct {

--- a/generated/1.19/apis/concierge/login/types_token.go
+++ b/generated/1.19/apis/concierge/login/types_token.go
@@ -27,7 +27,6 @@ type TokenCredentialRequestStatus struct {
 }
 
 // TokenCredentialRequest submits an IDP-specific credential to Pinniped in exchange for a cluster-specific credential.
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type TokenCredentialRequest struct {
 	metav1.TypeMeta

--- a/generated/1.19/apis/concierge/login/v1alpha1/types_token.go
+++ b/generated/1.19/apis/concierge/login/v1alpha1/types_token.go
@@ -30,6 +30,7 @@ type TokenCredentialRequestStatus struct {
 
 // TokenCredentialRequest submits an IDP-specific credential to Pinniped in exchange for a cluster-specific credential.
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type TokenCredentialRequest struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/generated/1.19/apis/supervisor/config/v1alpha1/types_federationdomain.go
+++ b/generated/1.19/apis/supervisor/config/v1alpha1/types_federationdomain.go
@@ -109,6 +109,7 @@ type FederationDomainStatus struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped
+// +kubebuilder:subresource:status
 type FederationDomain struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/generated/1.19/client/concierge/clientset/versioned/typed/authentication/v1alpha1/authentication_client.go
+++ b/generated/1.19/client/concierge/clientset/versioned/typed/authentication/v1alpha1/authentication_client.go
@@ -22,12 +22,12 @@ type AuthenticationV1alpha1Client struct {
 	restClient rest.Interface
 }
 
-func (c *AuthenticationV1alpha1Client) JWTAuthenticators(namespace string) JWTAuthenticatorInterface {
-	return newJWTAuthenticators(c, namespace)
+func (c *AuthenticationV1alpha1Client) JWTAuthenticators() JWTAuthenticatorInterface {
+	return newJWTAuthenticators(c)
 }
 
-func (c *AuthenticationV1alpha1Client) WebhookAuthenticators(namespace string) WebhookAuthenticatorInterface {
-	return newWebhookAuthenticators(c, namespace)
+func (c *AuthenticationV1alpha1Client) WebhookAuthenticators() WebhookAuthenticatorInterface {
+	return newWebhookAuthenticators(c)
 }
 
 // NewForConfig creates a new AuthenticationV1alpha1Client for the given config.

--- a/generated/1.19/client/concierge/clientset/versioned/typed/authentication/v1alpha1/fake/fake_authentication_client.go
+++ b/generated/1.19/client/concierge/clientset/versioned/typed/authentication/v1alpha1/fake/fake_authentication_client.go
@@ -15,12 +15,12 @@ type FakeAuthenticationV1alpha1 struct {
 	*testing.Fake
 }
 
-func (c *FakeAuthenticationV1alpha1) JWTAuthenticators(namespace string) v1alpha1.JWTAuthenticatorInterface {
-	return &FakeJWTAuthenticators{c, namespace}
+func (c *FakeAuthenticationV1alpha1) JWTAuthenticators() v1alpha1.JWTAuthenticatorInterface {
+	return &FakeJWTAuthenticators{c}
 }
 
-func (c *FakeAuthenticationV1alpha1) WebhookAuthenticators(namespace string) v1alpha1.WebhookAuthenticatorInterface {
-	return &FakeWebhookAuthenticators{c, namespace}
+func (c *FakeAuthenticationV1alpha1) WebhookAuthenticators() v1alpha1.WebhookAuthenticatorInterface {
+	return &FakeWebhookAuthenticators{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/generated/1.19/client/concierge/clientset/versioned/typed/authentication/v1alpha1/fake/fake_jwtauthenticator.go
+++ b/generated/1.19/client/concierge/clientset/versioned/typed/authentication/v1alpha1/fake/fake_jwtauthenticator.go
@@ -20,7 +20,6 @@ import (
 // FakeJWTAuthenticators implements JWTAuthenticatorInterface
 type FakeJWTAuthenticators struct {
 	Fake *FakeAuthenticationV1alpha1
-	ns   string
 }
 
 var jwtauthenticatorsResource = schema.GroupVersionResource{Group: "authentication.concierge.pinniped.dev", Version: "v1alpha1", Resource: "jwtauthenticators"}
@@ -30,8 +29,7 @@ var jwtauthenticatorsKind = schema.GroupVersionKind{Group: "authentication.conci
 // Get takes name of the jWTAuthenticator, and returns the corresponding jWTAuthenticator object, and an error if there is any.
 func (c *FakeJWTAuthenticators) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.JWTAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(jwtauthenticatorsResource, c.ns, name), &v1alpha1.JWTAuthenticator{})
-
+		Invokes(testing.NewRootGetAction(jwtauthenticatorsResource, name), &v1alpha1.JWTAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -41,8 +39,7 @@ func (c *FakeJWTAuthenticators) Get(ctx context.Context, name string, options v1
 // List takes label and field selectors, and returns the list of JWTAuthenticators that match those selectors.
 func (c *FakeJWTAuthenticators) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.JWTAuthenticatorList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(jwtauthenticatorsResource, jwtauthenticatorsKind, c.ns, opts), &v1alpha1.JWTAuthenticatorList{})
-
+		Invokes(testing.NewRootListAction(jwtauthenticatorsResource, jwtauthenticatorsKind, opts), &v1alpha1.JWTAuthenticatorList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -63,15 +60,13 @@ func (c *FakeJWTAuthenticators) List(ctx context.Context, opts v1.ListOptions) (
 // Watch returns a watch.Interface that watches the requested jWTAuthenticators.
 func (c *FakeJWTAuthenticators) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(jwtauthenticatorsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(jwtauthenticatorsResource, opts))
 }
 
 // Create takes the representation of a jWTAuthenticator and creates it.  Returns the server's representation of the jWTAuthenticator, and an error, if there is any.
 func (c *FakeJWTAuthenticators) Create(ctx context.Context, jWTAuthenticator *v1alpha1.JWTAuthenticator, opts v1.CreateOptions) (result *v1alpha1.JWTAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(jwtauthenticatorsResource, c.ns, jWTAuthenticator), &v1alpha1.JWTAuthenticator{})
-
+		Invokes(testing.NewRootCreateAction(jwtauthenticatorsResource, jWTAuthenticator), &v1alpha1.JWTAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -81,8 +76,7 @@ func (c *FakeJWTAuthenticators) Create(ctx context.Context, jWTAuthenticator *v1
 // Update takes the representation of a jWTAuthenticator and updates it. Returns the server's representation of the jWTAuthenticator, and an error, if there is any.
 func (c *FakeJWTAuthenticators) Update(ctx context.Context, jWTAuthenticator *v1alpha1.JWTAuthenticator, opts v1.UpdateOptions) (result *v1alpha1.JWTAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(jwtauthenticatorsResource, c.ns, jWTAuthenticator), &v1alpha1.JWTAuthenticator{})
-
+		Invokes(testing.NewRootUpdateAction(jwtauthenticatorsResource, jWTAuthenticator), &v1alpha1.JWTAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -93,8 +87,7 @@ func (c *FakeJWTAuthenticators) Update(ctx context.Context, jWTAuthenticator *v1
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeJWTAuthenticators) UpdateStatus(ctx context.Context, jWTAuthenticator *v1alpha1.JWTAuthenticator, opts v1.UpdateOptions) (*v1alpha1.JWTAuthenticator, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(jwtauthenticatorsResource, "status", c.ns, jWTAuthenticator), &v1alpha1.JWTAuthenticator{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(jwtauthenticatorsResource, "status", jWTAuthenticator), &v1alpha1.JWTAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -104,14 +97,13 @@ func (c *FakeJWTAuthenticators) UpdateStatus(ctx context.Context, jWTAuthenticat
 // Delete takes name of the jWTAuthenticator and deletes it. Returns an error if one occurs.
 func (c *FakeJWTAuthenticators) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(jwtauthenticatorsResource, c.ns, name), &v1alpha1.JWTAuthenticator{})
-
+		Invokes(testing.NewRootDeleteAction(jwtauthenticatorsResource, name), &v1alpha1.JWTAuthenticator{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeJWTAuthenticators) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(jwtauthenticatorsResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(jwtauthenticatorsResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.JWTAuthenticatorList{})
 	return err
@@ -120,8 +112,7 @@ func (c *FakeJWTAuthenticators) DeleteCollection(ctx context.Context, opts v1.De
 // Patch applies the patch and returns the patched jWTAuthenticator.
 func (c *FakeJWTAuthenticators) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.JWTAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(jwtauthenticatorsResource, c.ns, name, pt, data, subresources...), &v1alpha1.JWTAuthenticator{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(jwtauthenticatorsResource, name, pt, data, subresources...), &v1alpha1.JWTAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}

--- a/generated/1.19/client/concierge/clientset/versioned/typed/authentication/v1alpha1/fake/fake_webhookauthenticator.go
+++ b/generated/1.19/client/concierge/clientset/versioned/typed/authentication/v1alpha1/fake/fake_webhookauthenticator.go
@@ -20,7 +20,6 @@ import (
 // FakeWebhookAuthenticators implements WebhookAuthenticatorInterface
 type FakeWebhookAuthenticators struct {
 	Fake *FakeAuthenticationV1alpha1
-	ns   string
 }
 
 var webhookauthenticatorsResource = schema.GroupVersionResource{Group: "authentication.concierge.pinniped.dev", Version: "v1alpha1", Resource: "webhookauthenticators"}
@@ -30,8 +29,7 @@ var webhookauthenticatorsKind = schema.GroupVersionKind{Group: "authentication.c
 // Get takes name of the webhookAuthenticator, and returns the corresponding webhookAuthenticator object, and an error if there is any.
 func (c *FakeWebhookAuthenticators) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.WebhookAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(webhookauthenticatorsResource, c.ns, name), &v1alpha1.WebhookAuthenticator{})
-
+		Invokes(testing.NewRootGetAction(webhookauthenticatorsResource, name), &v1alpha1.WebhookAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -41,8 +39,7 @@ func (c *FakeWebhookAuthenticators) Get(ctx context.Context, name string, option
 // List takes label and field selectors, and returns the list of WebhookAuthenticators that match those selectors.
 func (c *FakeWebhookAuthenticators) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.WebhookAuthenticatorList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(webhookauthenticatorsResource, webhookauthenticatorsKind, c.ns, opts), &v1alpha1.WebhookAuthenticatorList{})
-
+		Invokes(testing.NewRootListAction(webhookauthenticatorsResource, webhookauthenticatorsKind, opts), &v1alpha1.WebhookAuthenticatorList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -63,15 +60,13 @@ func (c *FakeWebhookAuthenticators) List(ctx context.Context, opts v1.ListOption
 // Watch returns a watch.Interface that watches the requested webhookAuthenticators.
 func (c *FakeWebhookAuthenticators) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(webhookauthenticatorsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(webhookauthenticatorsResource, opts))
 }
 
 // Create takes the representation of a webhookAuthenticator and creates it.  Returns the server's representation of the webhookAuthenticator, and an error, if there is any.
 func (c *FakeWebhookAuthenticators) Create(ctx context.Context, webhookAuthenticator *v1alpha1.WebhookAuthenticator, opts v1.CreateOptions) (result *v1alpha1.WebhookAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(webhookauthenticatorsResource, c.ns, webhookAuthenticator), &v1alpha1.WebhookAuthenticator{})
-
+		Invokes(testing.NewRootCreateAction(webhookauthenticatorsResource, webhookAuthenticator), &v1alpha1.WebhookAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -81,8 +76,7 @@ func (c *FakeWebhookAuthenticators) Create(ctx context.Context, webhookAuthentic
 // Update takes the representation of a webhookAuthenticator and updates it. Returns the server's representation of the webhookAuthenticator, and an error, if there is any.
 func (c *FakeWebhookAuthenticators) Update(ctx context.Context, webhookAuthenticator *v1alpha1.WebhookAuthenticator, opts v1.UpdateOptions) (result *v1alpha1.WebhookAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(webhookauthenticatorsResource, c.ns, webhookAuthenticator), &v1alpha1.WebhookAuthenticator{})
-
+		Invokes(testing.NewRootUpdateAction(webhookauthenticatorsResource, webhookAuthenticator), &v1alpha1.WebhookAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -93,8 +87,7 @@ func (c *FakeWebhookAuthenticators) Update(ctx context.Context, webhookAuthentic
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeWebhookAuthenticators) UpdateStatus(ctx context.Context, webhookAuthenticator *v1alpha1.WebhookAuthenticator, opts v1.UpdateOptions) (*v1alpha1.WebhookAuthenticator, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(webhookauthenticatorsResource, "status", c.ns, webhookAuthenticator), &v1alpha1.WebhookAuthenticator{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(webhookauthenticatorsResource, "status", webhookAuthenticator), &v1alpha1.WebhookAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -104,14 +97,13 @@ func (c *FakeWebhookAuthenticators) UpdateStatus(ctx context.Context, webhookAut
 // Delete takes name of the webhookAuthenticator and deletes it. Returns an error if one occurs.
 func (c *FakeWebhookAuthenticators) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(webhookauthenticatorsResource, c.ns, name), &v1alpha1.WebhookAuthenticator{})
-
+		Invokes(testing.NewRootDeleteAction(webhookauthenticatorsResource, name), &v1alpha1.WebhookAuthenticator{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeWebhookAuthenticators) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(webhookauthenticatorsResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(webhookauthenticatorsResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.WebhookAuthenticatorList{})
 	return err
@@ -120,8 +112,7 @@ func (c *FakeWebhookAuthenticators) DeleteCollection(ctx context.Context, opts v
 // Patch applies the patch and returns the patched webhookAuthenticator.
 func (c *FakeWebhookAuthenticators) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.WebhookAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(webhookauthenticatorsResource, c.ns, name, pt, data, subresources...), &v1alpha1.WebhookAuthenticator{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(webhookauthenticatorsResource, name, pt, data, subresources...), &v1alpha1.WebhookAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}

--- a/generated/1.19/client/concierge/clientset/versioned/typed/authentication/v1alpha1/jwtauthenticator.go
+++ b/generated/1.19/client/concierge/clientset/versioned/typed/authentication/v1alpha1/jwtauthenticator.go
@@ -20,7 +20,7 @@ import (
 // JWTAuthenticatorsGetter has a method to return a JWTAuthenticatorInterface.
 // A group's client should implement this interface.
 type JWTAuthenticatorsGetter interface {
-	JWTAuthenticators(namespace string) JWTAuthenticatorInterface
+	JWTAuthenticators() JWTAuthenticatorInterface
 }
 
 // JWTAuthenticatorInterface has methods to work with JWTAuthenticator resources.
@@ -40,14 +40,12 @@ type JWTAuthenticatorInterface interface {
 // jWTAuthenticators implements JWTAuthenticatorInterface
 type jWTAuthenticators struct {
 	client rest.Interface
-	ns     string
 }
 
 // newJWTAuthenticators returns a JWTAuthenticators
-func newJWTAuthenticators(c *AuthenticationV1alpha1Client, namespace string) *jWTAuthenticators {
+func newJWTAuthenticators(c *AuthenticationV1alpha1Client) *jWTAuthenticators {
 	return &jWTAuthenticators{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -55,7 +53,6 @@ func newJWTAuthenticators(c *AuthenticationV1alpha1Client, namespace string) *jW
 func (c *jWTAuthenticators) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.JWTAuthenticator, err error) {
 	result = &v1alpha1.JWTAuthenticator{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -72,7 +69,6 @@ func (c *jWTAuthenticators) List(ctx context.Context, opts v1.ListOptions) (resu
 	}
 	result = &v1alpha1.JWTAuthenticatorList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -89,7 +85,6 @@ func (c *jWTAuthenticators) Watch(ctx context.Context, opts v1.ListOptions) (wat
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -100,7 +95,6 @@ func (c *jWTAuthenticators) Watch(ctx context.Context, opts v1.ListOptions) (wat
 func (c *jWTAuthenticators) Create(ctx context.Context, jWTAuthenticator *v1alpha1.JWTAuthenticator, opts v1.CreateOptions) (result *v1alpha1.JWTAuthenticator, err error) {
 	result = &v1alpha1.JWTAuthenticator{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(jWTAuthenticator).
@@ -113,7 +107,6 @@ func (c *jWTAuthenticators) Create(ctx context.Context, jWTAuthenticator *v1alph
 func (c *jWTAuthenticators) Update(ctx context.Context, jWTAuthenticator *v1alpha1.JWTAuthenticator, opts v1.UpdateOptions) (result *v1alpha1.JWTAuthenticator, err error) {
 	result = &v1alpha1.JWTAuthenticator{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		Name(jWTAuthenticator.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -128,7 +121,6 @@ func (c *jWTAuthenticators) Update(ctx context.Context, jWTAuthenticator *v1alph
 func (c *jWTAuthenticators) UpdateStatus(ctx context.Context, jWTAuthenticator *v1alpha1.JWTAuthenticator, opts v1.UpdateOptions) (result *v1alpha1.JWTAuthenticator, err error) {
 	result = &v1alpha1.JWTAuthenticator{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		Name(jWTAuthenticator.Name).
 		SubResource("status").
@@ -142,7 +134,6 @@ func (c *jWTAuthenticators) UpdateStatus(ctx context.Context, jWTAuthenticator *
 // Delete takes name of the jWTAuthenticator and deletes it. Returns an error if one occurs.
 func (c *jWTAuthenticators) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		Name(name).
 		Body(&opts).
@@ -157,7 +148,6 @@ func (c *jWTAuthenticators) DeleteCollection(ctx context.Context, opts v1.Delete
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -170,7 +160,6 @@ func (c *jWTAuthenticators) DeleteCollection(ctx context.Context, opts v1.Delete
 func (c *jWTAuthenticators) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.JWTAuthenticator, err error) {
 	result = &v1alpha1.JWTAuthenticator{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		Name(name).
 		SubResource(subresources...).

--- a/generated/1.19/client/concierge/clientset/versioned/typed/authentication/v1alpha1/webhookauthenticator.go
+++ b/generated/1.19/client/concierge/clientset/versioned/typed/authentication/v1alpha1/webhookauthenticator.go
@@ -20,7 +20,7 @@ import (
 // WebhookAuthenticatorsGetter has a method to return a WebhookAuthenticatorInterface.
 // A group's client should implement this interface.
 type WebhookAuthenticatorsGetter interface {
-	WebhookAuthenticators(namespace string) WebhookAuthenticatorInterface
+	WebhookAuthenticators() WebhookAuthenticatorInterface
 }
 
 // WebhookAuthenticatorInterface has methods to work with WebhookAuthenticator resources.
@@ -40,14 +40,12 @@ type WebhookAuthenticatorInterface interface {
 // webhookAuthenticators implements WebhookAuthenticatorInterface
 type webhookAuthenticators struct {
 	client rest.Interface
-	ns     string
 }
 
 // newWebhookAuthenticators returns a WebhookAuthenticators
-func newWebhookAuthenticators(c *AuthenticationV1alpha1Client, namespace string) *webhookAuthenticators {
+func newWebhookAuthenticators(c *AuthenticationV1alpha1Client) *webhookAuthenticators {
 	return &webhookAuthenticators{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -55,7 +53,6 @@ func newWebhookAuthenticators(c *AuthenticationV1alpha1Client, namespace string)
 func (c *webhookAuthenticators) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.WebhookAuthenticator, err error) {
 	result = &v1alpha1.WebhookAuthenticator{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -72,7 +69,6 @@ func (c *webhookAuthenticators) List(ctx context.Context, opts v1.ListOptions) (
 	}
 	result = &v1alpha1.WebhookAuthenticatorList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -89,7 +85,6 @@ func (c *webhookAuthenticators) Watch(ctx context.Context, opts v1.ListOptions) 
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -100,7 +95,6 @@ func (c *webhookAuthenticators) Watch(ctx context.Context, opts v1.ListOptions) 
 func (c *webhookAuthenticators) Create(ctx context.Context, webhookAuthenticator *v1alpha1.WebhookAuthenticator, opts v1.CreateOptions) (result *v1alpha1.WebhookAuthenticator, err error) {
 	result = &v1alpha1.WebhookAuthenticator{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(webhookAuthenticator).
@@ -113,7 +107,6 @@ func (c *webhookAuthenticators) Create(ctx context.Context, webhookAuthenticator
 func (c *webhookAuthenticators) Update(ctx context.Context, webhookAuthenticator *v1alpha1.WebhookAuthenticator, opts v1.UpdateOptions) (result *v1alpha1.WebhookAuthenticator, err error) {
 	result = &v1alpha1.WebhookAuthenticator{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		Name(webhookAuthenticator.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -128,7 +121,6 @@ func (c *webhookAuthenticators) Update(ctx context.Context, webhookAuthenticator
 func (c *webhookAuthenticators) UpdateStatus(ctx context.Context, webhookAuthenticator *v1alpha1.WebhookAuthenticator, opts v1.UpdateOptions) (result *v1alpha1.WebhookAuthenticator, err error) {
 	result = &v1alpha1.WebhookAuthenticator{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		Name(webhookAuthenticator.Name).
 		SubResource("status").
@@ -142,7 +134,6 @@ func (c *webhookAuthenticators) UpdateStatus(ctx context.Context, webhookAuthent
 // Delete takes name of the webhookAuthenticator and deletes it. Returns an error if one occurs.
 func (c *webhookAuthenticators) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		Name(name).
 		Body(&opts).
@@ -157,7 +148,6 @@ func (c *webhookAuthenticators) DeleteCollection(ctx context.Context, opts v1.De
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -170,7 +160,6 @@ func (c *webhookAuthenticators) DeleteCollection(ctx context.Context, opts v1.De
 func (c *webhookAuthenticators) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.WebhookAuthenticator, err error) {
 	result = &v1alpha1.WebhookAuthenticator{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		Name(name).
 		SubResource(subresources...).

--- a/generated/1.19/client/concierge/clientset/versioned/typed/config/v1alpha1/config_client.go
+++ b/generated/1.19/client/concierge/clientset/versioned/typed/config/v1alpha1/config_client.go
@@ -21,8 +21,8 @@ type ConfigV1alpha1Client struct {
 	restClient rest.Interface
 }
 
-func (c *ConfigV1alpha1Client) CredentialIssuers(namespace string) CredentialIssuerInterface {
-	return newCredentialIssuers(c, namespace)
+func (c *ConfigV1alpha1Client) CredentialIssuers() CredentialIssuerInterface {
+	return newCredentialIssuers(c)
 }
 
 // NewForConfig creates a new ConfigV1alpha1Client for the given config.

--- a/generated/1.19/client/concierge/clientset/versioned/typed/config/v1alpha1/credentialissuer.go
+++ b/generated/1.19/client/concierge/clientset/versioned/typed/config/v1alpha1/credentialissuer.go
@@ -20,7 +20,7 @@ import (
 // CredentialIssuersGetter has a method to return a CredentialIssuerInterface.
 // A group's client should implement this interface.
 type CredentialIssuersGetter interface {
-	CredentialIssuers(namespace string) CredentialIssuerInterface
+	CredentialIssuers() CredentialIssuerInterface
 }
 
 // CredentialIssuerInterface has methods to work with CredentialIssuer resources.
@@ -40,14 +40,12 @@ type CredentialIssuerInterface interface {
 // credentialIssuers implements CredentialIssuerInterface
 type credentialIssuers struct {
 	client rest.Interface
-	ns     string
 }
 
 // newCredentialIssuers returns a CredentialIssuers
-func newCredentialIssuers(c *ConfigV1alpha1Client, namespace string) *credentialIssuers {
+func newCredentialIssuers(c *ConfigV1alpha1Client) *credentialIssuers {
 	return &credentialIssuers{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -55,7 +53,6 @@ func newCredentialIssuers(c *ConfigV1alpha1Client, namespace string) *credential
 func (c *credentialIssuers) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.CredentialIssuer, err error) {
 	result = &v1alpha1.CredentialIssuer{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -72,7 +69,6 @@ func (c *credentialIssuers) List(ctx context.Context, opts v1.ListOptions) (resu
 	}
 	result = &v1alpha1.CredentialIssuerList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -89,7 +85,6 @@ func (c *credentialIssuers) Watch(ctx context.Context, opts v1.ListOptions) (wat
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -100,7 +95,6 @@ func (c *credentialIssuers) Watch(ctx context.Context, opts v1.ListOptions) (wat
 func (c *credentialIssuers) Create(ctx context.Context, credentialIssuer *v1alpha1.CredentialIssuer, opts v1.CreateOptions) (result *v1alpha1.CredentialIssuer, err error) {
 	result = &v1alpha1.CredentialIssuer{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(credentialIssuer).
@@ -113,7 +107,6 @@ func (c *credentialIssuers) Create(ctx context.Context, credentialIssuer *v1alph
 func (c *credentialIssuers) Update(ctx context.Context, credentialIssuer *v1alpha1.CredentialIssuer, opts v1.UpdateOptions) (result *v1alpha1.CredentialIssuer, err error) {
 	result = &v1alpha1.CredentialIssuer{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		Name(credentialIssuer.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -128,7 +121,6 @@ func (c *credentialIssuers) Update(ctx context.Context, credentialIssuer *v1alph
 func (c *credentialIssuers) UpdateStatus(ctx context.Context, credentialIssuer *v1alpha1.CredentialIssuer, opts v1.UpdateOptions) (result *v1alpha1.CredentialIssuer, err error) {
 	result = &v1alpha1.CredentialIssuer{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		Name(credentialIssuer.Name).
 		SubResource("status").
@@ -142,7 +134,6 @@ func (c *credentialIssuers) UpdateStatus(ctx context.Context, credentialIssuer *
 // Delete takes name of the credentialIssuer and deletes it. Returns an error if one occurs.
 func (c *credentialIssuers) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		Name(name).
 		Body(&opts).
@@ -157,7 +148,6 @@ func (c *credentialIssuers) DeleteCollection(ctx context.Context, opts v1.Delete
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -170,7 +160,6 @@ func (c *credentialIssuers) DeleteCollection(ctx context.Context, opts v1.Delete
 func (c *credentialIssuers) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.CredentialIssuer, err error) {
 	result = &v1alpha1.CredentialIssuer{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		Name(name).
 		SubResource(subresources...).

--- a/generated/1.19/client/concierge/clientset/versioned/typed/config/v1alpha1/fake/fake_config_client.go
+++ b/generated/1.19/client/concierge/clientset/versioned/typed/config/v1alpha1/fake/fake_config_client.go
@@ -15,8 +15,8 @@ type FakeConfigV1alpha1 struct {
 	*testing.Fake
 }
 
-func (c *FakeConfigV1alpha1) CredentialIssuers(namespace string) v1alpha1.CredentialIssuerInterface {
-	return &FakeCredentialIssuers{c, namespace}
+func (c *FakeConfigV1alpha1) CredentialIssuers() v1alpha1.CredentialIssuerInterface {
+	return &FakeCredentialIssuers{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/generated/1.19/client/concierge/clientset/versioned/typed/config/v1alpha1/fake/fake_credentialissuer.go
+++ b/generated/1.19/client/concierge/clientset/versioned/typed/config/v1alpha1/fake/fake_credentialissuer.go
@@ -20,7 +20,6 @@ import (
 // FakeCredentialIssuers implements CredentialIssuerInterface
 type FakeCredentialIssuers struct {
 	Fake *FakeConfigV1alpha1
-	ns   string
 }
 
 var credentialissuersResource = schema.GroupVersionResource{Group: "config.concierge.pinniped.dev", Version: "v1alpha1", Resource: "credentialissuers"}
@@ -30,8 +29,7 @@ var credentialissuersKind = schema.GroupVersionKind{Group: "config.concierge.pin
 // Get takes name of the credentialIssuer, and returns the corresponding credentialIssuer object, and an error if there is any.
 func (c *FakeCredentialIssuers) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.CredentialIssuer, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(credentialissuersResource, c.ns, name), &v1alpha1.CredentialIssuer{})
-
+		Invokes(testing.NewRootGetAction(credentialissuersResource, name), &v1alpha1.CredentialIssuer{})
 	if obj == nil {
 		return nil, err
 	}
@@ -41,8 +39,7 @@ func (c *FakeCredentialIssuers) Get(ctx context.Context, name string, options v1
 // List takes label and field selectors, and returns the list of CredentialIssuers that match those selectors.
 func (c *FakeCredentialIssuers) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.CredentialIssuerList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(credentialissuersResource, credentialissuersKind, c.ns, opts), &v1alpha1.CredentialIssuerList{})
-
+		Invokes(testing.NewRootListAction(credentialissuersResource, credentialissuersKind, opts), &v1alpha1.CredentialIssuerList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -63,15 +60,13 @@ func (c *FakeCredentialIssuers) List(ctx context.Context, opts v1.ListOptions) (
 // Watch returns a watch.Interface that watches the requested credentialIssuers.
 func (c *FakeCredentialIssuers) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(credentialissuersResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(credentialissuersResource, opts))
 }
 
 // Create takes the representation of a credentialIssuer and creates it.  Returns the server's representation of the credentialIssuer, and an error, if there is any.
 func (c *FakeCredentialIssuers) Create(ctx context.Context, credentialIssuer *v1alpha1.CredentialIssuer, opts v1.CreateOptions) (result *v1alpha1.CredentialIssuer, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(credentialissuersResource, c.ns, credentialIssuer), &v1alpha1.CredentialIssuer{})
-
+		Invokes(testing.NewRootCreateAction(credentialissuersResource, credentialIssuer), &v1alpha1.CredentialIssuer{})
 	if obj == nil {
 		return nil, err
 	}
@@ -81,8 +76,7 @@ func (c *FakeCredentialIssuers) Create(ctx context.Context, credentialIssuer *v1
 // Update takes the representation of a credentialIssuer and updates it. Returns the server's representation of the credentialIssuer, and an error, if there is any.
 func (c *FakeCredentialIssuers) Update(ctx context.Context, credentialIssuer *v1alpha1.CredentialIssuer, opts v1.UpdateOptions) (result *v1alpha1.CredentialIssuer, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(credentialissuersResource, c.ns, credentialIssuer), &v1alpha1.CredentialIssuer{})
-
+		Invokes(testing.NewRootUpdateAction(credentialissuersResource, credentialIssuer), &v1alpha1.CredentialIssuer{})
 	if obj == nil {
 		return nil, err
 	}
@@ -93,8 +87,7 @@ func (c *FakeCredentialIssuers) Update(ctx context.Context, credentialIssuer *v1
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeCredentialIssuers) UpdateStatus(ctx context.Context, credentialIssuer *v1alpha1.CredentialIssuer, opts v1.UpdateOptions) (*v1alpha1.CredentialIssuer, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(credentialissuersResource, "status", c.ns, credentialIssuer), &v1alpha1.CredentialIssuer{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(credentialissuersResource, "status", credentialIssuer), &v1alpha1.CredentialIssuer{})
 	if obj == nil {
 		return nil, err
 	}
@@ -104,14 +97,13 @@ func (c *FakeCredentialIssuers) UpdateStatus(ctx context.Context, credentialIssu
 // Delete takes name of the credentialIssuer and deletes it. Returns an error if one occurs.
 func (c *FakeCredentialIssuers) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(credentialissuersResource, c.ns, name), &v1alpha1.CredentialIssuer{})
-
+		Invokes(testing.NewRootDeleteAction(credentialissuersResource, name), &v1alpha1.CredentialIssuer{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeCredentialIssuers) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(credentialissuersResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(credentialissuersResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.CredentialIssuerList{})
 	return err
@@ -120,8 +112,7 @@ func (c *FakeCredentialIssuers) DeleteCollection(ctx context.Context, opts v1.De
 // Patch applies the patch and returns the patched credentialIssuer.
 func (c *FakeCredentialIssuers) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.CredentialIssuer, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(credentialissuersResource, c.ns, name, pt, data, subresources...), &v1alpha1.CredentialIssuer{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(credentialissuersResource, name, pt, data, subresources...), &v1alpha1.CredentialIssuer{})
 	if obj == nil {
 		return nil, err
 	}

--- a/generated/1.19/client/concierge/clientset/versioned/typed/login/v1alpha1/fake/fake_login_client.go
+++ b/generated/1.19/client/concierge/clientset/versioned/typed/login/v1alpha1/fake/fake_login_client.go
@@ -15,8 +15,8 @@ type FakeLoginV1alpha1 struct {
 	*testing.Fake
 }
 
-func (c *FakeLoginV1alpha1) TokenCredentialRequests(namespace string) v1alpha1.TokenCredentialRequestInterface {
-	return &FakeTokenCredentialRequests{c, namespace}
+func (c *FakeLoginV1alpha1) TokenCredentialRequests() v1alpha1.TokenCredentialRequestInterface {
+	return &FakeTokenCredentialRequests{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/generated/1.19/client/concierge/clientset/versioned/typed/login/v1alpha1/fake/fake_tokencredentialrequest.go
+++ b/generated/1.19/client/concierge/clientset/versioned/typed/login/v1alpha1/fake/fake_tokencredentialrequest.go
@@ -20,7 +20,6 @@ import (
 // FakeTokenCredentialRequests implements TokenCredentialRequestInterface
 type FakeTokenCredentialRequests struct {
 	Fake *FakeLoginV1alpha1
-	ns   string
 }
 
 var tokencredentialrequestsResource = schema.GroupVersionResource{Group: "login.concierge.pinniped.dev", Version: "v1alpha1", Resource: "tokencredentialrequests"}
@@ -30,8 +29,7 @@ var tokencredentialrequestsKind = schema.GroupVersionKind{Group: "login.concierg
 // Get takes name of the tokenCredentialRequest, and returns the corresponding tokenCredentialRequest object, and an error if there is any.
 func (c *FakeTokenCredentialRequests) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.TokenCredentialRequest, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(tokencredentialrequestsResource, c.ns, name), &v1alpha1.TokenCredentialRequest{})
-
+		Invokes(testing.NewRootGetAction(tokencredentialrequestsResource, name), &v1alpha1.TokenCredentialRequest{})
 	if obj == nil {
 		return nil, err
 	}
@@ -41,8 +39,7 @@ func (c *FakeTokenCredentialRequests) Get(ctx context.Context, name string, opti
 // List takes label and field selectors, and returns the list of TokenCredentialRequests that match those selectors.
 func (c *FakeTokenCredentialRequests) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.TokenCredentialRequestList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(tokencredentialrequestsResource, tokencredentialrequestsKind, c.ns, opts), &v1alpha1.TokenCredentialRequestList{})
-
+		Invokes(testing.NewRootListAction(tokencredentialrequestsResource, tokencredentialrequestsKind, opts), &v1alpha1.TokenCredentialRequestList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -63,15 +60,13 @@ func (c *FakeTokenCredentialRequests) List(ctx context.Context, opts v1.ListOpti
 // Watch returns a watch.Interface that watches the requested tokenCredentialRequests.
 func (c *FakeTokenCredentialRequests) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(tokencredentialrequestsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(tokencredentialrequestsResource, opts))
 }
 
 // Create takes the representation of a tokenCredentialRequest and creates it.  Returns the server's representation of the tokenCredentialRequest, and an error, if there is any.
 func (c *FakeTokenCredentialRequests) Create(ctx context.Context, tokenCredentialRequest *v1alpha1.TokenCredentialRequest, opts v1.CreateOptions) (result *v1alpha1.TokenCredentialRequest, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(tokencredentialrequestsResource, c.ns, tokenCredentialRequest), &v1alpha1.TokenCredentialRequest{})
-
+		Invokes(testing.NewRootCreateAction(tokencredentialrequestsResource, tokenCredentialRequest), &v1alpha1.TokenCredentialRequest{})
 	if obj == nil {
 		return nil, err
 	}
@@ -81,8 +76,7 @@ func (c *FakeTokenCredentialRequests) Create(ctx context.Context, tokenCredentia
 // Update takes the representation of a tokenCredentialRequest and updates it. Returns the server's representation of the tokenCredentialRequest, and an error, if there is any.
 func (c *FakeTokenCredentialRequests) Update(ctx context.Context, tokenCredentialRequest *v1alpha1.TokenCredentialRequest, opts v1.UpdateOptions) (result *v1alpha1.TokenCredentialRequest, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(tokencredentialrequestsResource, c.ns, tokenCredentialRequest), &v1alpha1.TokenCredentialRequest{})
-
+		Invokes(testing.NewRootUpdateAction(tokencredentialrequestsResource, tokenCredentialRequest), &v1alpha1.TokenCredentialRequest{})
 	if obj == nil {
 		return nil, err
 	}
@@ -93,8 +87,7 @@ func (c *FakeTokenCredentialRequests) Update(ctx context.Context, tokenCredentia
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeTokenCredentialRequests) UpdateStatus(ctx context.Context, tokenCredentialRequest *v1alpha1.TokenCredentialRequest, opts v1.UpdateOptions) (*v1alpha1.TokenCredentialRequest, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(tokencredentialrequestsResource, "status", c.ns, tokenCredentialRequest), &v1alpha1.TokenCredentialRequest{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(tokencredentialrequestsResource, "status", tokenCredentialRequest), &v1alpha1.TokenCredentialRequest{})
 	if obj == nil {
 		return nil, err
 	}
@@ -104,14 +97,13 @@ func (c *FakeTokenCredentialRequests) UpdateStatus(ctx context.Context, tokenCre
 // Delete takes name of the tokenCredentialRequest and deletes it. Returns an error if one occurs.
 func (c *FakeTokenCredentialRequests) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(tokencredentialrequestsResource, c.ns, name), &v1alpha1.TokenCredentialRequest{})
-
+		Invokes(testing.NewRootDeleteAction(tokencredentialrequestsResource, name), &v1alpha1.TokenCredentialRequest{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeTokenCredentialRequests) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(tokencredentialrequestsResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(tokencredentialrequestsResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.TokenCredentialRequestList{})
 	return err
@@ -120,8 +112,7 @@ func (c *FakeTokenCredentialRequests) DeleteCollection(ctx context.Context, opts
 // Patch applies the patch and returns the patched tokenCredentialRequest.
 func (c *FakeTokenCredentialRequests) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.TokenCredentialRequest, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(tokencredentialrequestsResource, c.ns, name, pt, data, subresources...), &v1alpha1.TokenCredentialRequest{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(tokencredentialrequestsResource, name, pt, data, subresources...), &v1alpha1.TokenCredentialRequest{})
 	if obj == nil {
 		return nil, err
 	}

--- a/generated/1.19/client/concierge/clientset/versioned/typed/login/v1alpha1/login_client.go
+++ b/generated/1.19/client/concierge/clientset/versioned/typed/login/v1alpha1/login_client.go
@@ -21,8 +21,8 @@ type LoginV1alpha1Client struct {
 	restClient rest.Interface
 }
 
-func (c *LoginV1alpha1Client) TokenCredentialRequests(namespace string) TokenCredentialRequestInterface {
-	return newTokenCredentialRequests(c, namespace)
+func (c *LoginV1alpha1Client) TokenCredentialRequests() TokenCredentialRequestInterface {
+	return newTokenCredentialRequests(c)
 }
 
 // NewForConfig creates a new LoginV1alpha1Client for the given config.

--- a/generated/1.19/client/concierge/clientset/versioned/typed/login/v1alpha1/tokencredentialrequest.go
+++ b/generated/1.19/client/concierge/clientset/versioned/typed/login/v1alpha1/tokencredentialrequest.go
@@ -20,7 +20,7 @@ import (
 // TokenCredentialRequestsGetter has a method to return a TokenCredentialRequestInterface.
 // A group's client should implement this interface.
 type TokenCredentialRequestsGetter interface {
-	TokenCredentialRequests(namespace string) TokenCredentialRequestInterface
+	TokenCredentialRequests() TokenCredentialRequestInterface
 }
 
 // TokenCredentialRequestInterface has methods to work with TokenCredentialRequest resources.
@@ -40,14 +40,12 @@ type TokenCredentialRequestInterface interface {
 // tokenCredentialRequests implements TokenCredentialRequestInterface
 type tokenCredentialRequests struct {
 	client rest.Interface
-	ns     string
 }
 
 // newTokenCredentialRequests returns a TokenCredentialRequests
-func newTokenCredentialRequests(c *LoginV1alpha1Client, namespace string) *tokenCredentialRequests {
+func newTokenCredentialRequests(c *LoginV1alpha1Client) *tokenCredentialRequests {
 	return &tokenCredentialRequests{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -55,7 +53,6 @@ func newTokenCredentialRequests(c *LoginV1alpha1Client, namespace string) *token
 func (c *tokenCredentialRequests) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.TokenCredentialRequest, err error) {
 	result = &v1alpha1.TokenCredentialRequest{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -72,7 +69,6 @@ func (c *tokenCredentialRequests) List(ctx context.Context, opts v1.ListOptions)
 	}
 	result = &v1alpha1.TokenCredentialRequestList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -89,7 +85,6 @@ func (c *tokenCredentialRequests) Watch(ctx context.Context, opts v1.ListOptions
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -100,7 +95,6 @@ func (c *tokenCredentialRequests) Watch(ctx context.Context, opts v1.ListOptions
 func (c *tokenCredentialRequests) Create(ctx context.Context, tokenCredentialRequest *v1alpha1.TokenCredentialRequest, opts v1.CreateOptions) (result *v1alpha1.TokenCredentialRequest, err error) {
 	result = &v1alpha1.TokenCredentialRequest{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(tokenCredentialRequest).
@@ -113,7 +107,6 @@ func (c *tokenCredentialRequests) Create(ctx context.Context, tokenCredentialReq
 func (c *tokenCredentialRequests) Update(ctx context.Context, tokenCredentialRequest *v1alpha1.TokenCredentialRequest, opts v1.UpdateOptions) (result *v1alpha1.TokenCredentialRequest, err error) {
 	result = &v1alpha1.TokenCredentialRequest{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		Name(tokenCredentialRequest.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -128,7 +121,6 @@ func (c *tokenCredentialRequests) Update(ctx context.Context, tokenCredentialReq
 func (c *tokenCredentialRequests) UpdateStatus(ctx context.Context, tokenCredentialRequest *v1alpha1.TokenCredentialRequest, opts v1.UpdateOptions) (result *v1alpha1.TokenCredentialRequest, err error) {
 	result = &v1alpha1.TokenCredentialRequest{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		Name(tokenCredentialRequest.Name).
 		SubResource("status").
@@ -142,7 +134,6 @@ func (c *tokenCredentialRequests) UpdateStatus(ctx context.Context, tokenCredent
 // Delete takes name of the tokenCredentialRequest and deletes it. Returns an error if one occurs.
 func (c *tokenCredentialRequests) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		Name(name).
 		Body(&opts).
@@ -157,7 +148,6 @@ func (c *tokenCredentialRequests) DeleteCollection(ctx context.Context, opts v1.
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -170,7 +160,6 @@ func (c *tokenCredentialRequests) DeleteCollection(ctx context.Context, opts v1.
 func (c *tokenCredentialRequests) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.TokenCredentialRequest, err error) {
 	result = &v1alpha1.TokenCredentialRequest{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		Name(name).
 		SubResource(subresources...).

--- a/generated/1.19/client/concierge/informers/externalversions/authentication/v1alpha1/interface.go
+++ b/generated/1.19/client/concierge/informers/externalversions/authentication/v1alpha1/interface.go
@@ -30,10 +30,10 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // JWTAuthenticators returns a JWTAuthenticatorInformer.
 func (v *version) JWTAuthenticators() JWTAuthenticatorInformer {
-	return &jWTAuthenticatorInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &jWTAuthenticatorInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
 // WebhookAuthenticators returns a WebhookAuthenticatorInformer.
 func (v *version) WebhookAuthenticators() WebhookAuthenticatorInformer {
-	return &webhookAuthenticatorInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &webhookAuthenticatorInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/generated/1.19/client/concierge/informers/externalversions/authentication/v1alpha1/jwtauthenticator.go
+++ b/generated/1.19/client/concierge/informers/externalversions/authentication/v1alpha1/jwtauthenticator.go
@@ -29,33 +29,32 @@ type JWTAuthenticatorInformer interface {
 type jWTAuthenticatorInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewJWTAuthenticatorInformer constructs a new informer for JWTAuthenticator type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewJWTAuthenticatorInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredJWTAuthenticatorInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewJWTAuthenticatorInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredJWTAuthenticatorInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredJWTAuthenticatorInformer constructs a new informer for JWTAuthenticator type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredJWTAuthenticatorInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredJWTAuthenticatorInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AuthenticationV1alpha1().JWTAuthenticators(namespace).List(context.TODO(), options)
+				return client.AuthenticationV1alpha1().JWTAuthenticators().List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AuthenticationV1alpha1().JWTAuthenticators(namespace).Watch(context.TODO(), options)
+				return client.AuthenticationV1alpha1().JWTAuthenticators().Watch(context.TODO(), options)
 			},
 		},
 		&authenticationv1alpha1.JWTAuthenticator{},
@@ -65,7 +64,7 @@ func NewFilteredJWTAuthenticatorInformer(client versioned.Interface, namespace s
 }
 
 func (f *jWTAuthenticatorInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredJWTAuthenticatorInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredJWTAuthenticatorInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *jWTAuthenticatorInformer) Informer() cache.SharedIndexInformer {

--- a/generated/1.19/client/concierge/informers/externalversions/authentication/v1alpha1/webhookauthenticator.go
+++ b/generated/1.19/client/concierge/informers/externalversions/authentication/v1alpha1/webhookauthenticator.go
@@ -29,33 +29,32 @@ type WebhookAuthenticatorInformer interface {
 type webhookAuthenticatorInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewWebhookAuthenticatorInformer constructs a new informer for WebhookAuthenticator type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewWebhookAuthenticatorInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredWebhookAuthenticatorInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewWebhookAuthenticatorInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredWebhookAuthenticatorInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredWebhookAuthenticatorInformer constructs a new informer for WebhookAuthenticator type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredWebhookAuthenticatorInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredWebhookAuthenticatorInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AuthenticationV1alpha1().WebhookAuthenticators(namespace).List(context.TODO(), options)
+				return client.AuthenticationV1alpha1().WebhookAuthenticators().List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AuthenticationV1alpha1().WebhookAuthenticators(namespace).Watch(context.TODO(), options)
+				return client.AuthenticationV1alpha1().WebhookAuthenticators().Watch(context.TODO(), options)
 			},
 		},
 		&authenticationv1alpha1.WebhookAuthenticator{},
@@ -65,7 +64,7 @@ func NewFilteredWebhookAuthenticatorInformer(client versioned.Interface, namespa
 }
 
 func (f *webhookAuthenticatorInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredWebhookAuthenticatorInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredWebhookAuthenticatorInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *webhookAuthenticatorInformer) Informer() cache.SharedIndexInformer {

--- a/generated/1.19/client/concierge/informers/externalversions/config/v1alpha1/credentialissuer.go
+++ b/generated/1.19/client/concierge/informers/externalversions/config/v1alpha1/credentialissuer.go
@@ -29,33 +29,32 @@ type CredentialIssuerInformer interface {
 type credentialIssuerInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewCredentialIssuerInformer constructs a new informer for CredentialIssuer type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewCredentialIssuerInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredCredentialIssuerInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewCredentialIssuerInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredCredentialIssuerInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredCredentialIssuerInformer constructs a new informer for CredentialIssuer type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredCredentialIssuerInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredCredentialIssuerInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ConfigV1alpha1().CredentialIssuers(namespace).List(context.TODO(), options)
+				return client.ConfigV1alpha1().CredentialIssuers().List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ConfigV1alpha1().CredentialIssuers(namespace).Watch(context.TODO(), options)
+				return client.ConfigV1alpha1().CredentialIssuers().Watch(context.TODO(), options)
 			},
 		},
 		&configv1alpha1.CredentialIssuer{},
@@ -65,7 +64,7 @@ func NewFilteredCredentialIssuerInformer(client versioned.Interface, namespace s
 }
 
 func (f *credentialIssuerInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredCredentialIssuerInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredCredentialIssuerInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *credentialIssuerInformer) Informer() cache.SharedIndexInformer {

--- a/generated/1.19/client/concierge/informers/externalversions/config/v1alpha1/interface.go
+++ b/generated/1.19/client/concierge/informers/externalversions/config/v1alpha1/interface.go
@@ -28,5 +28,5 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // CredentialIssuers returns a CredentialIssuerInformer.
 func (v *version) CredentialIssuers() CredentialIssuerInformer {
-	return &credentialIssuerInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &credentialIssuerInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/generated/1.19/client/concierge/informers/externalversions/login/v1alpha1/interface.go
+++ b/generated/1.19/client/concierge/informers/externalversions/login/v1alpha1/interface.go
@@ -28,5 +28,5 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // TokenCredentialRequests returns a TokenCredentialRequestInformer.
 func (v *version) TokenCredentialRequests() TokenCredentialRequestInformer {
-	return &tokenCredentialRequestInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &tokenCredentialRequestInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/generated/1.19/client/concierge/informers/externalversions/login/v1alpha1/tokencredentialrequest.go
+++ b/generated/1.19/client/concierge/informers/externalversions/login/v1alpha1/tokencredentialrequest.go
@@ -29,33 +29,32 @@ type TokenCredentialRequestInformer interface {
 type tokenCredentialRequestInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewTokenCredentialRequestInformer constructs a new informer for TokenCredentialRequest type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewTokenCredentialRequestInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredTokenCredentialRequestInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewTokenCredentialRequestInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredTokenCredentialRequestInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredTokenCredentialRequestInformer constructs a new informer for TokenCredentialRequest type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredTokenCredentialRequestInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredTokenCredentialRequestInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.LoginV1alpha1().TokenCredentialRequests(namespace).List(context.TODO(), options)
+				return client.LoginV1alpha1().TokenCredentialRequests().List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.LoginV1alpha1().TokenCredentialRequests(namespace).Watch(context.TODO(), options)
+				return client.LoginV1alpha1().TokenCredentialRequests().Watch(context.TODO(), options)
 			},
 		},
 		&loginv1alpha1.TokenCredentialRequest{},
@@ -65,7 +64,7 @@ func NewFilteredTokenCredentialRequestInformer(client versioned.Interface, names
 }
 
 func (f *tokenCredentialRequestInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredTokenCredentialRequestInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredTokenCredentialRequestInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *tokenCredentialRequestInformer) Informer() cache.SharedIndexInformer {

--- a/generated/1.19/client/concierge/listers/authentication/v1alpha1/expansion_generated.go
+++ b/generated/1.19/client/concierge/listers/authentication/v1alpha1/expansion_generated.go
@@ -9,14 +9,6 @@ package v1alpha1
 // JWTAuthenticatorLister.
 type JWTAuthenticatorListerExpansion interface{}
 
-// JWTAuthenticatorNamespaceListerExpansion allows custom methods to be added to
-// JWTAuthenticatorNamespaceLister.
-type JWTAuthenticatorNamespaceListerExpansion interface{}
-
 // WebhookAuthenticatorListerExpansion allows custom methods to be added to
 // WebhookAuthenticatorLister.
 type WebhookAuthenticatorListerExpansion interface{}
-
-// WebhookAuthenticatorNamespaceListerExpansion allows custom methods to be added to
-// WebhookAuthenticatorNamespaceLister.
-type WebhookAuthenticatorNamespaceListerExpansion interface{}

--- a/generated/1.19/client/concierge/listers/authentication/v1alpha1/jwtauthenticator.go
+++ b/generated/1.19/client/concierge/listers/authentication/v1alpha1/jwtauthenticator.go
@@ -18,8 +18,9 @@ type JWTAuthenticatorLister interface {
 	// List lists all JWTAuthenticators in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.JWTAuthenticator, err error)
-	// JWTAuthenticators returns an object that can list and get JWTAuthenticators.
-	JWTAuthenticators(namespace string) JWTAuthenticatorNamespaceLister
+	// Get retrieves the JWTAuthenticator from the index for a given name.
+	// Objects returned here must be treated as read-only.
+	Get(name string) (*v1alpha1.JWTAuthenticator, error)
 	JWTAuthenticatorListerExpansion
 }
 
@@ -41,41 +42,9 @@ func (s *jWTAuthenticatorLister) List(selector labels.Selector) (ret []*v1alpha1
 	return ret, err
 }
 
-// JWTAuthenticators returns an object that can list and get JWTAuthenticators.
-func (s *jWTAuthenticatorLister) JWTAuthenticators(namespace string) JWTAuthenticatorNamespaceLister {
-	return jWTAuthenticatorNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// JWTAuthenticatorNamespaceLister helps list and get JWTAuthenticators.
-// All objects returned here must be treated as read-only.
-type JWTAuthenticatorNamespaceLister interface {
-	// List lists all JWTAuthenticators in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1alpha1.JWTAuthenticator, err error)
-	// Get retrieves the JWTAuthenticator from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1alpha1.JWTAuthenticator, error)
-	JWTAuthenticatorNamespaceListerExpansion
-}
-
-// jWTAuthenticatorNamespaceLister implements the JWTAuthenticatorNamespaceLister
-// interface.
-type jWTAuthenticatorNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all JWTAuthenticators in the indexer for a given namespace.
-func (s jWTAuthenticatorNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.JWTAuthenticator, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.JWTAuthenticator))
-	})
-	return ret, err
-}
-
-// Get retrieves the JWTAuthenticator from the indexer for a given namespace and name.
-func (s jWTAuthenticatorNamespaceLister) Get(name string) (*v1alpha1.JWTAuthenticator, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the JWTAuthenticator from the index for a given name.
+func (s *jWTAuthenticatorLister) Get(name string) (*v1alpha1.JWTAuthenticator, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/generated/1.19/client/concierge/listers/authentication/v1alpha1/webhookauthenticator.go
+++ b/generated/1.19/client/concierge/listers/authentication/v1alpha1/webhookauthenticator.go
@@ -18,8 +18,9 @@ type WebhookAuthenticatorLister interface {
 	// List lists all WebhookAuthenticators in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.WebhookAuthenticator, err error)
-	// WebhookAuthenticators returns an object that can list and get WebhookAuthenticators.
-	WebhookAuthenticators(namespace string) WebhookAuthenticatorNamespaceLister
+	// Get retrieves the WebhookAuthenticator from the index for a given name.
+	// Objects returned here must be treated as read-only.
+	Get(name string) (*v1alpha1.WebhookAuthenticator, error)
 	WebhookAuthenticatorListerExpansion
 }
 
@@ -41,41 +42,9 @@ func (s *webhookAuthenticatorLister) List(selector labels.Selector) (ret []*v1al
 	return ret, err
 }
 
-// WebhookAuthenticators returns an object that can list and get WebhookAuthenticators.
-func (s *webhookAuthenticatorLister) WebhookAuthenticators(namespace string) WebhookAuthenticatorNamespaceLister {
-	return webhookAuthenticatorNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// WebhookAuthenticatorNamespaceLister helps list and get WebhookAuthenticators.
-// All objects returned here must be treated as read-only.
-type WebhookAuthenticatorNamespaceLister interface {
-	// List lists all WebhookAuthenticators in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1alpha1.WebhookAuthenticator, err error)
-	// Get retrieves the WebhookAuthenticator from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1alpha1.WebhookAuthenticator, error)
-	WebhookAuthenticatorNamespaceListerExpansion
-}
-
-// webhookAuthenticatorNamespaceLister implements the WebhookAuthenticatorNamespaceLister
-// interface.
-type webhookAuthenticatorNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all WebhookAuthenticators in the indexer for a given namespace.
-func (s webhookAuthenticatorNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.WebhookAuthenticator, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.WebhookAuthenticator))
-	})
-	return ret, err
-}
-
-// Get retrieves the WebhookAuthenticator from the indexer for a given namespace and name.
-func (s webhookAuthenticatorNamespaceLister) Get(name string) (*v1alpha1.WebhookAuthenticator, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the WebhookAuthenticator from the index for a given name.
+func (s *webhookAuthenticatorLister) Get(name string) (*v1alpha1.WebhookAuthenticator, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/generated/1.19/client/concierge/listers/config/v1alpha1/credentialissuer.go
+++ b/generated/1.19/client/concierge/listers/config/v1alpha1/credentialissuer.go
@@ -18,8 +18,9 @@ type CredentialIssuerLister interface {
 	// List lists all CredentialIssuers in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.CredentialIssuer, err error)
-	// CredentialIssuers returns an object that can list and get CredentialIssuers.
-	CredentialIssuers(namespace string) CredentialIssuerNamespaceLister
+	// Get retrieves the CredentialIssuer from the index for a given name.
+	// Objects returned here must be treated as read-only.
+	Get(name string) (*v1alpha1.CredentialIssuer, error)
 	CredentialIssuerListerExpansion
 }
 
@@ -41,41 +42,9 @@ func (s *credentialIssuerLister) List(selector labels.Selector) (ret []*v1alpha1
 	return ret, err
 }
 
-// CredentialIssuers returns an object that can list and get CredentialIssuers.
-func (s *credentialIssuerLister) CredentialIssuers(namespace string) CredentialIssuerNamespaceLister {
-	return credentialIssuerNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// CredentialIssuerNamespaceLister helps list and get CredentialIssuers.
-// All objects returned here must be treated as read-only.
-type CredentialIssuerNamespaceLister interface {
-	// List lists all CredentialIssuers in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1alpha1.CredentialIssuer, err error)
-	// Get retrieves the CredentialIssuer from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1alpha1.CredentialIssuer, error)
-	CredentialIssuerNamespaceListerExpansion
-}
-
-// credentialIssuerNamespaceLister implements the CredentialIssuerNamespaceLister
-// interface.
-type credentialIssuerNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all CredentialIssuers in the indexer for a given namespace.
-func (s credentialIssuerNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.CredentialIssuer, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.CredentialIssuer))
-	})
-	return ret, err
-}
-
-// Get retrieves the CredentialIssuer from the indexer for a given namespace and name.
-func (s credentialIssuerNamespaceLister) Get(name string) (*v1alpha1.CredentialIssuer, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the CredentialIssuer from the index for a given name.
+func (s *credentialIssuerLister) Get(name string) (*v1alpha1.CredentialIssuer, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/generated/1.19/client/concierge/listers/config/v1alpha1/expansion_generated.go
+++ b/generated/1.19/client/concierge/listers/config/v1alpha1/expansion_generated.go
@@ -8,7 +8,3 @@ package v1alpha1
 // CredentialIssuerListerExpansion allows custom methods to be added to
 // CredentialIssuerLister.
 type CredentialIssuerListerExpansion interface{}
-
-// CredentialIssuerNamespaceListerExpansion allows custom methods to be added to
-// CredentialIssuerNamespaceLister.
-type CredentialIssuerNamespaceListerExpansion interface{}

--- a/generated/1.19/client/concierge/listers/login/v1alpha1/expansion_generated.go
+++ b/generated/1.19/client/concierge/listers/login/v1alpha1/expansion_generated.go
@@ -8,7 +8,3 @@ package v1alpha1
 // TokenCredentialRequestListerExpansion allows custom methods to be added to
 // TokenCredentialRequestLister.
 type TokenCredentialRequestListerExpansion interface{}
-
-// TokenCredentialRequestNamespaceListerExpansion allows custom methods to be added to
-// TokenCredentialRequestNamespaceLister.
-type TokenCredentialRequestNamespaceListerExpansion interface{}

--- a/generated/1.19/client/concierge/listers/login/v1alpha1/tokencredentialrequest.go
+++ b/generated/1.19/client/concierge/listers/login/v1alpha1/tokencredentialrequest.go
@@ -18,8 +18,9 @@ type TokenCredentialRequestLister interface {
 	// List lists all TokenCredentialRequests in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.TokenCredentialRequest, err error)
-	// TokenCredentialRequests returns an object that can list and get TokenCredentialRequests.
-	TokenCredentialRequests(namespace string) TokenCredentialRequestNamespaceLister
+	// Get retrieves the TokenCredentialRequest from the index for a given name.
+	// Objects returned here must be treated as read-only.
+	Get(name string) (*v1alpha1.TokenCredentialRequest, error)
 	TokenCredentialRequestListerExpansion
 }
 
@@ -41,41 +42,9 @@ func (s *tokenCredentialRequestLister) List(selector labels.Selector) (ret []*v1
 	return ret, err
 }
 
-// TokenCredentialRequests returns an object that can list and get TokenCredentialRequests.
-func (s *tokenCredentialRequestLister) TokenCredentialRequests(namespace string) TokenCredentialRequestNamespaceLister {
-	return tokenCredentialRequestNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// TokenCredentialRequestNamespaceLister helps list and get TokenCredentialRequests.
-// All objects returned here must be treated as read-only.
-type TokenCredentialRequestNamespaceLister interface {
-	// List lists all TokenCredentialRequests in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1alpha1.TokenCredentialRequest, err error)
-	// Get retrieves the TokenCredentialRequest from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1alpha1.TokenCredentialRequest, error)
-	TokenCredentialRequestNamespaceListerExpansion
-}
-
-// tokenCredentialRequestNamespaceLister implements the TokenCredentialRequestNamespaceLister
-// interface.
-type tokenCredentialRequestNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all TokenCredentialRequests in the indexer for a given namespace.
-func (s tokenCredentialRequestNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.TokenCredentialRequest, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.TokenCredentialRequest))
-	})
-	return ret, err
-}
-
-// Get retrieves the TokenCredentialRequest from the indexer for a given namespace and name.
-func (s tokenCredentialRequestNamespaceLister) Get(name string) (*v1alpha1.TokenCredentialRequest, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the TokenCredentialRequest from the index for a given name.
+func (s *tokenCredentialRequestLister) Get(name string) (*v1alpha1.TokenCredentialRequest, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/generated/1.19/crds/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
+++ b/generated/1.19/crds/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
@@ -161,7 +161,8 @@ spec:
         type: object
     served: true
     storage: true
-    subresources: {}
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/generated/1.19/crds/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
+++ b/generated/1.19/crds/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
@@ -18,7 +18,7 @@ spec:
     listKind: JWTAuthenticatorList
     plural: jwtauthenticators
     singular: jwtauthenticator
-  scope: Namespaced
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.issuer

--- a/generated/1.19/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
+++ b/generated/1.19/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
@@ -137,7 +137,8 @@ spec:
         type: object
     served: true
     storage: true
-    subresources: {}
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/generated/1.19/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
+++ b/generated/1.19/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
@@ -18,7 +18,7 @@ spec:
     listKind: WebhookAuthenticatorList
     plural: webhookauthenticators
     singular: webhookauthenticator
-  scope: Namespaced
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.endpoint

--- a/generated/1.19/crds/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/generated/1.19/crds/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -16,7 +16,7 @@ spec:
     listKind: CredentialIssuerList
     plural: credentialissuers
     singular: credentialissuer
-  scope: Namespaced
+  scope: Cluster
   versions:
   - name: v1alpha1
     schema:

--- a/generated/1.19/crds/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/generated/1.19/crds/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -98,8 +98,6 @@ spec:
             required:
             - strategies
             type: object
-        required:
-        - status
         type: object
     served: true
     storage: true

--- a/generated/1.19/crds/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/generated/1.19/crds/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -103,6 +103,8 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/generated/1.19/crds/config.supervisor.pinniped.dev_federationdomains.yaml
+++ b/generated/1.19/crds/config.supervisor.pinniped.dev_federationdomains.yaml
@@ -150,6 +150,8 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/generated/1.20/apis/concierge/authentication/v1alpha1/types_jwt.go
+++ b/generated/1.20/apis/concierge/authentication/v1alpha1/types_jwt.go
@@ -61,6 +61,7 @@ type JWTTokenClaims struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators,scope=Cluster
 // +kubebuilder:printcolumn:name="Issuer",type=string,JSONPath=`.spec.issuer`
+// +kubebuilder:subresource:status
 type JWTAuthenticator struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/generated/1.20/apis/concierge/authentication/v1alpha1/types_jwt.go
+++ b/generated/1.20/apis/concierge/authentication/v1alpha1/types_jwt.go
@@ -57,6 +57,7 @@ type JWTTokenClaims struct {
 // signature, existence of claims, etc.) and extract the username and groups from the token.
 //
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators
 // +kubebuilder:printcolumn:name="Issuer",type=string,JSONPath=`.spec.issuer`

--- a/generated/1.20/apis/concierge/authentication/v1alpha1/types_jwt.go
+++ b/generated/1.20/apis/concierge/authentication/v1alpha1/types_jwt.go
@@ -59,7 +59,7 @@ type JWTTokenClaims struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators
+// +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators,scope=Cluster
 // +kubebuilder:printcolumn:name="Issuer",type=string,JSONPath=`.spec.issuer`
 type JWTAuthenticator struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/generated/1.20/apis/concierge/authentication/v1alpha1/types_webhook.go
+++ b/generated/1.20/apis/concierge/authentication/v1alpha1/types_webhook.go
@@ -31,7 +31,7 @@ type WebhookAuthenticatorSpec struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators
+// +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators,scope=Cluster
 // +kubebuilder:printcolumn:name="Endpoint",type=string,JSONPath=`.spec.endpoint`
 type WebhookAuthenticator struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/generated/1.20/apis/concierge/authentication/v1alpha1/types_webhook.go
+++ b/generated/1.20/apis/concierge/authentication/v1alpha1/types_webhook.go
@@ -29,6 +29,7 @@ type WebhookAuthenticatorSpec struct {
 
 // WebhookAuthenticator describes the configuration of a webhook authenticator.
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators
 // +kubebuilder:printcolumn:name="Endpoint",type=string,JSONPath=`.spec.endpoint`

--- a/generated/1.20/apis/concierge/authentication/v1alpha1/types_webhook.go
+++ b/generated/1.20/apis/concierge/authentication/v1alpha1/types_webhook.go
@@ -33,6 +33,7 @@ type WebhookAuthenticatorSpec struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped;pinniped-authenticator;pinniped-authenticators,scope=Cluster
 // +kubebuilder:printcolumn:name="Endpoint",type=string,JSONPath=`.spec.endpoint`
+// +kubebuilder:subresource:status
 type WebhookAuthenticator struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/generated/1.20/apis/concierge/config/v1alpha1/types_credentialissuer.go
+++ b/generated/1.20/apis/concierge/config/v1alpha1/types_credentialissuer.go
@@ -76,6 +76,7 @@ type CredentialIssuer struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Status of the credential issuer.
+	// +optional
 	Status CredentialIssuerStatus `json:"status"`
 }
 

--- a/generated/1.20/apis/concierge/config/v1alpha1/types_credentialissuer.go
+++ b/generated/1.20/apis/concierge/config/v1alpha1/types_credentialissuer.go
@@ -70,6 +70,7 @@ type CredentialIssuerStrategy struct {
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped,scope=Cluster
+// +kubebuilder:subresource:status
 type CredentialIssuer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/generated/1.20/apis/concierge/config/v1alpha1/types_credentialissuer.go
+++ b/generated/1.20/apis/concierge/config/v1alpha1/types_credentialissuer.go
@@ -69,7 +69,7 @@ type CredentialIssuerStrategy struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:categories=pinniped
+// +kubebuilder:resource:categories=pinniped,scope=Cluster
 type CredentialIssuer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/generated/1.20/apis/concierge/config/v1alpha1/types_credentialissuer.go
+++ b/generated/1.20/apis/concierge/config/v1alpha1/types_credentialissuer.go
@@ -67,6 +67,7 @@ type CredentialIssuerStrategy struct {
 
 // Describes the configuration status of a Pinniped credential issuer.
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped
 type CredentialIssuer struct {

--- a/generated/1.20/apis/concierge/login/types_token.go
+++ b/generated/1.20/apis/concierge/login/types_token.go
@@ -27,7 +27,6 @@ type TokenCredentialRequestStatus struct {
 }
 
 // TokenCredentialRequest submits an IDP-specific credential to Pinniped in exchange for a cluster-specific credential.
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type TokenCredentialRequest struct {
 	metav1.TypeMeta

--- a/generated/1.20/apis/concierge/login/v1alpha1/types_token.go
+++ b/generated/1.20/apis/concierge/login/v1alpha1/types_token.go
@@ -30,6 +30,7 @@ type TokenCredentialRequestStatus struct {
 
 // TokenCredentialRequest submits an IDP-specific credential to Pinniped in exchange for a cluster-specific credential.
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type TokenCredentialRequest struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/generated/1.20/apis/supervisor/config/v1alpha1/types_federationdomain.go
+++ b/generated/1.20/apis/supervisor/config/v1alpha1/types_federationdomain.go
@@ -109,6 +109,7 @@ type FederationDomainStatus struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=pinniped
+// +kubebuilder:subresource:status
 type FederationDomain struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/generated/1.20/client/concierge/clientset/versioned/typed/authentication/v1alpha1/authentication_client.go
+++ b/generated/1.20/client/concierge/clientset/versioned/typed/authentication/v1alpha1/authentication_client.go
@@ -22,12 +22,12 @@ type AuthenticationV1alpha1Client struct {
 	restClient rest.Interface
 }
 
-func (c *AuthenticationV1alpha1Client) JWTAuthenticators(namespace string) JWTAuthenticatorInterface {
-	return newJWTAuthenticators(c, namespace)
+func (c *AuthenticationV1alpha1Client) JWTAuthenticators() JWTAuthenticatorInterface {
+	return newJWTAuthenticators(c)
 }
 
-func (c *AuthenticationV1alpha1Client) WebhookAuthenticators(namespace string) WebhookAuthenticatorInterface {
-	return newWebhookAuthenticators(c, namespace)
+func (c *AuthenticationV1alpha1Client) WebhookAuthenticators() WebhookAuthenticatorInterface {
+	return newWebhookAuthenticators(c)
 }
 
 // NewForConfig creates a new AuthenticationV1alpha1Client for the given config.

--- a/generated/1.20/client/concierge/clientset/versioned/typed/authentication/v1alpha1/fake/fake_authentication_client.go
+++ b/generated/1.20/client/concierge/clientset/versioned/typed/authentication/v1alpha1/fake/fake_authentication_client.go
@@ -15,12 +15,12 @@ type FakeAuthenticationV1alpha1 struct {
 	*testing.Fake
 }
 
-func (c *FakeAuthenticationV1alpha1) JWTAuthenticators(namespace string) v1alpha1.JWTAuthenticatorInterface {
-	return &FakeJWTAuthenticators{c, namespace}
+func (c *FakeAuthenticationV1alpha1) JWTAuthenticators() v1alpha1.JWTAuthenticatorInterface {
+	return &FakeJWTAuthenticators{c}
 }
 
-func (c *FakeAuthenticationV1alpha1) WebhookAuthenticators(namespace string) v1alpha1.WebhookAuthenticatorInterface {
-	return &FakeWebhookAuthenticators{c, namespace}
+func (c *FakeAuthenticationV1alpha1) WebhookAuthenticators() v1alpha1.WebhookAuthenticatorInterface {
+	return &FakeWebhookAuthenticators{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/generated/1.20/client/concierge/clientset/versioned/typed/authentication/v1alpha1/fake/fake_jwtauthenticator.go
+++ b/generated/1.20/client/concierge/clientset/versioned/typed/authentication/v1alpha1/fake/fake_jwtauthenticator.go
@@ -20,7 +20,6 @@ import (
 // FakeJWTAuthenticators implements JWTAuthenticatorInterface
 type FakeJWTAuthenticators struct {
 	Fake *FakeAuthenticationV1alpha1
-	ns   string
 }
 
 var jwtauthenticatorsResource = schema.GroupVersionResource{Group: "authentication.concierge.pinniped.dev", Version: "v1alpha1", Resource: "jwtauthenticators"}
@@ -30,8 +29,7 @@ var jwtauthenticatorsKind = schema.GroupVersionKind{Group: "authentication.conci
 // Get takes name of the jWTAuthenticator, and returns the corresponding jWTAuthenticator object, and an error if there is any.
 func (c *FakeJWTAuthenticators) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.JWTAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(jwtauthenticatorsResource, c.ns, name), &v1alpha1.JWTAuthenticator{})
-
+		Invokes(testing.NewRootGetAction(jwtauthenticatorsResource, name), &v1alpha1.JWTAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -41,8 +39,7 @@ func (c *FakeJWTAuthenticators) Get(ctx context.Context, name string, options v1
 // List takes label and field selectors, and returns the list of JWTAuthenticators that match those selectors.
 func (c *FakeJWTAuthenticators) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.JWTAuthenticatorList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(jwtauthenticatorsResource, jwtauthenticatorsKind, c.ns, opts), &v1alpha1.JWTAuthenticatorList{})
-
+		Invokes(testing.NewRootListAction(jwtauthenticatorsResource, jwtauthenticatorsKind, opts), &v1alpha1.JWTAuthenticatorList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -63,15 +60,13 @@ func (c *FakeJWTAuthenticators) List(ctx context.Context, opts v1.ListOptions) (
 // Watch returns a watch.Interface that watches the requested jWTAuthenticators.
 func (c *FakeJWTAuthenticators) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(jwtauthenticatorsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(jwtauthenticatorsResource, opts))
 }
 
 // Create takes the representation of a jWTAuthenticator and creates it.  Returns the server's representation of the jWTAuthenticator, and an error, if there is any.
 func (c *FakeJWTAuthenticators) Create(ctx context.Context, jWTAuthenticator *v1alpha1.JWTAuthenticator, opts v1.CreateOptions) (result *v1alpha1.JWTAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(jwtauthenticatorsResource, c.ns, jWTAuthenticator), &v1alpha1.JWTAuthenticator{})
-
+		Invokes(testing.NewRootCreateAction(jwtauthenticatorsResource, jWTAuthenticator), &v1alpha1.JWTAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -81,8 +76,7 @@ func (c *FakeJWTAuthenticators) Create(ctx context.Context, jWTAuthenticator *v1
 // Update takes the representation of a jWTAuthenticator and updates it. Returns the server's representation of the jWTAuthenticator, and an error, if there is any.
 func (c *FakeJWTAuthenticators) Update(ctx context.Context, jWTAuthenticator *v1alpha1.JWTAuthenticator, opts v1.UpdateOptions) (result *v1alpha1.JWTAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(jwtauthenticatorsResource, c.ns, jWTAuthenticator), &v1alpha1.JWTAuthenticator{})
-
+		Invokes(testing.NewRootUpdateAction(jwtauthenticatorsResource, jWTAuthenticator), &v1alpha1.JWTAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -93,8 +87,7 @@ func (c *FakeJWTAuthenticators) Update(ctx context.Context, jWTAuthenticator *v1
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeJWTAuthenticators) UpdateStatus(ctx context.Context, jWTAuthenticator *v1alpha1.JWTAuthenticator, opts v1.UpdateOptions) (*v1alpha1.JWTAuthenticator, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(jwtauthenticatorsResource, "status", c.ns, jWTAuthenticator), &v1alpha1.JWTAuthenticator{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(jwtauthenticatorsResource, "status", jWTAuthenticator), &v1alpha1.JWTAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -104,14 +97,13 @@ func (c *FakeJWTAuthenticators) UpdateStatus(ctx context.Context, jWTAuthenticat
 // Delete takes name of the jWTAuthenticator and deletes it. Returns an error if one occurs.
 func (c *FakeJWTAuthenticators) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(jwtauthenticatorsResource, c.ns, name), &v1alpha1.JWTAuthenticator{})
-
+		Invokes(testing.NewRootDeleteAction(jwtauthenticatorsResource, name), &v1alpha1.JWTAuthenticator{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeJWTAuthenticators) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(jwtauthenticatorsResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(jwtauthenticatorsResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.JWTAuthenticatorList{})
 	return err
@@ -120,8 +112,7 @@ func (c *FakeJWTAuthenticators) DeleteCollection(ctx context.Context, opts v1.De
 // Patch applies the patch and returns the patched jWTAuthenticator.
 func (c *FakeJWTAuthenticators) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.JWTAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(jwtauthenticatorsResource, c.ns, name, pt, data, subresources...), &v1alpha1.JWTAuthenticator{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(jwtauthenticatorsResource, name, pt, data, subresources...), &v1alpha1.JWTAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}

--- a/generated/1.20/client/concierge/clientset/versioned/typed/authentication/v1alpha1/fake/fake_webhookauthenticator.go
+++ b/generated/1.20/client/concierge/clientset/versioned/typed/authentication/v1alpha1/fake/fake_webhookauthenticator.go
@@ -20,7 +20,6 @@ import (
 // FakeWebhookAuthenticators implements WebhookAuthenticatorInterface
 type FakeWebhookAuthenticators struct {
 	Fake *FakeAuthenticationV1alpha1
-	ns   string
 }
 
 var webhookauthenticatorsResource = schema.GroupVersionResource{Group: "authentication.concierge.pinniped.dev", Version: "v1alpha1", Resource: "webhookauthenticators"}
@@ -30,8 +29,7 @@ var webhookauthenticatorsKind = schema.GroupVersionKind{Group: "authentication.c
 // Get takes name of the webhookAuthenticator, and returns the corresponding webhookAuthenticator object, and an error if there is any.
 func (c *FakeWebhookAuthenticators) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.WebhookAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(webhookauthenticatorsResource, c.ns, name), &v1alpha1.WebhookAuthenticator{})
-
+		Invokes(testing.NewRootGetAction(webhookauthenticatorsResource, name), &v1alpha1.WebhookAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -41,8 +39,7 @@ func (c *FakeWebhookAuthenticators) Get(ctx context.Context, name string, option
 // List takes label and field selectors, and returns the list of WebhookAuthenticators that match those selectors.
 func (c *FakeWebhookAuthenticators) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.WebhookAuthenticatorList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(webhookauthenticatorsResource, webhookauthenticatorsKind, c.ns, opts), &v1alpha1.WebhookAuthenticatorList{})
-
+		Invokes(testing.NewRootListAction(webhookauthenticatorsResource, webhookauthenticatorsKind, opts), &v1alpha1.WebhookAuthenticatorList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -63,15 +60,13 @@ func (c *FakeWebhookAuthenticators) List(ctx context.Context, opts v1.ListOption
 // Watch returns a watch.Interface that watches the requested webhookAuthenticators.
 func (c *FakeWebhookAuthenticators) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(webhookauthenticatorsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(webhookauthenticatorsResource, opts))
 }
 
 // Create takes the representation of a webhookAuthenticator and creates it.  Returns the server's representation of the webhookAuthenticator, and an error, if there is any.
 func (c *FakeWebhookAuthenticators) Create(ctx context.Context, webhookAuthenticator *v1alpha1.WebhookAuthenticator, opts v1.CreateOptions) (result *v1alpha1.WebhookAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(webhookauthenticatorsResource, c.ns, webhookAuthenticator), &v1alpha1.WebhookAuthenticator{})
-
+		Invokes(testing.NewRootCreateAction(webhookauthenticatorsResource, webhookAuthenticator), &v1alpha1.WebhookAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -81,8 +76,7 @@ func (c *FakeWebhookAuthenticators) Create(ctx context.Context, webhookAuthentic
 // Update takes the representation of a webhookAuthenticator and updates it. Returns the server's representation of the webhookAuthenticator, and an error, if there is any.
 func (c *FakeWebhookAuthenticators) Update(ctx context.Context, webhookAuthenticator *v1alpha1.WebhookAuthenticator, opts v1.UpdateOptions) (result *v1alpha1.WebhookAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(webhookauthenticatorsResource, c.ns, webhookAuthenticator), &v1alpha1.WebhookAuthenticator{})
-
+		Invokes(testing.NewRootUpdateAction(webhookauthenticatorsResource, webhookAuthenticator), &v1alpha1.WebhookAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -93,8 +87,7 @@ func (c *FakeWebhookAuthenticators) Update(ctx context.Context, webhookAuthentic
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeWebhookAuthenticators) UpdateStatus(ctx context.Context, webhookAuthenticator *v1alpha1.WebhookAuthenticator, opts v1.UpdateOptions) (*v1alpha1.WebhookAuthenticator, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(webhookauthenticatorsResource, "status", c.ns, webhookAuthenticator), &v1alpha1.WebhookAuthenticator{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(webhookauthenticatorsResource, "status", webhookAuthenticator), &v1alpha1.WebhookAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}
@@ -104,14 +97,13 @@ func (c *FakeWebhookAuthenticators) UpdateStatus(ctx context.Context, webhookAut
 // Delete takes name of the webhookAuthenticator and deletes it. Returns an error if one occurs.
 func (c *FakeWebhookAuthenticators) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(webhookauthenticatorsResource, c.ns, name), &v1alpha1.WebhookAuthenticator{})
-
+		Invokes(testing.NewRootDeleteAction(webhookauthenticatorsResource, name), &v1alpha1.WebhookAuthenticator{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeWebhookAuthenticators) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(webhookauthenticatorsResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(webhookauthenticatorsResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.WebhookAuthenticatorList{})
 	return err
@@ -120,8 +112,7 @@ func (c *FakeWebhookAuthenticators) DeleteCollection(ctx context.Context, opts v
 // Patch applies the patch and returns the patched webhookAuthenticator.
 func (c *FakeWebhookAuthenticators) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.WebhookAuthenticator, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(webhookauthenticatorsResource, c.ns, name, pt, data, subresources...), &v1alpha1.WebhookAuthenticator{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(webhookauthenticatorsResource, name, pt, data, subresources...), &v1alpha1.WebhookAuthenticator{})
 	if obj == nil {
 		return nil, err
 	}

--- a/generated/1.20/client/concierge/clientset/versioned/typed/authentication/v1alpha1/jwtauthenticator.go
+++ b/generated/1.20/client/concierge/clientset/versioned/typed/authentication/v1alpha1/jwtauthenticator.go
@@ -20,7 +20,7 @@ import (
 // JWTAuthenticatorsGetter has a method to return a JWTAuthenticatorInterface.
 // A group's client should implement this interface.
 type JWTAuthenticatorsGetter interface {
-	JWTAuthenticators(namespace string) JWTAuthenticatorInterface
+	JWTAuthenticators() JWTAuthenticatorInterface
 }
 
 // JWTAuthenticatorInterface has methods to work with JWTAuthenticator resources.
@@ -40,14 +40,12 @@ type JWTAuthenticatorInterface interface {
 // jWTAuthenticators implements JWTAuthenticatorInterface
 type jWTAuthenticators struct {
 	client rest.Interface
-	ns     string
 }
 
 // newJWTAuthenticators returns a JWTAuthenticators
-func newJWTAuthenticators(c *AuthenticationV1alpha1Client, namespace string) *jWTAuthenticators {
+func newJWTAuthenticators(c *AuthenticationV1alpha1Client) *jWTAuthenticators {
 	return &jWTAuthenticators{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -55,7 +53,6 @@ func newJWTAuthenticators(c *AuthenticationV1alpha1Client, namespace string) *jW
 func (c *jWTAuthenticators) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.JWTAuthenticator, err error) {
 	result = &v1alpha1.JWTAuthenticator{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -72,7 +69,6 @@ func (c *jWTAuthenticators) List(ctx context.Context, opts v1.ListOptions) (resu
 	}
 	result = &v1alpha1.JWTAuthenticatorList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -89,7 +85,6 @@ func (c *jWTAuthenticators) Watch(ctx context.Context, opts v1.ListOptions) (wat
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -100,7 +95,6 @@ func (c *jWTAuthenticators) Watch(ctx context.Context, opts v1.ListOptions) (wat
 func (c *jWTAuthenticators) Create(ctx context.Context, jWTAuthenticator *v1alpha1.JWTAuthenticator, opts v1.CreateOptions) (result *v1alpha1.JWTAuthenticator, err error) {
 	result = &v1alpha1.JWTAuthenticator{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(jWTAuthenticator).
@@ -113,7 +107,6 @@ func (c *jWTAuthenticators) Create(ctx context.Context, jWTAuthenticator *v1alph
 func (c *jWTAuthenticators) Update(ctx context.Context, jWTAuthenticator *v1alpha1.JWTAuthenticator, opts v1.UpdateOptions) (result *v1alpha1.JWTAuthenticator, err error) {
 	result = &v1alpha1.JWTAuthenticator{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		Name(jWTAuthenticator.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -128,7 +121,6 @@ func (c *jWTAuthenticators) Update(ctx context.Context, jWTAuthenticator *v1alph
 func (c *jWTAuthenticators) UpdateStatus(ctx context.Context, jWTAuthenticator *v1alpha1.JWTAuthenticator, opts v1.UpdateOptions) (result *v1alpha1.JWTAuthenticator, err error) {
 	result = &v1alpha1.JWTAuthenticator{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		Name(jWTAuthenticator.Name).
 		SubResource("status").
@@ -142,7 +134,6 @@ func (c *jWTAuthenticators) UpdateStatus(ctx context.Context, jWTAuthenticator *
 // Delete takes name of the jWTAuthenticator and deletes it. Returns an error if one occurs.
 func (c *jWTAuthenticators) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		Name(name).
 		Body(&opts).
@@ -157,7 +148,6 @@ func (c *jWTAuthenticators) DeleteCollection(ctx context.Context, opts v1.Delete
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -170,7 +160,6 @@ func (c *jWTAuthenticators) DeleteCollection(ctx context.Context, opts v1.Delete
 func (c *jWTAuthenticators) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.JWTAuthenticator, err error) {
 	result = &v1alpha1.JWTAuthenticator{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("jwtauthenticators").
 		Name(name).
 		SubResource(subresources...).

--- a/generated/1.20/client/concierge/clientset/versioned/typed/authentication/v1alpha1/webhookauthenticator.go
+++ b/generated/1.20/client/concierge/clientset/versioned/typed/authentication/v1alpha1/webhookauthenticator.go
@@ -20,7 +20,7 @@ import (
 // WebhookAuthenticatorsGetter has a method to return a WebhookAuthenticatorInterface.
 // A group's client should implement this interface.
 type WebhookAuthenticatorsGetter interface {
-	WebhookAuthenticators(namespace string) WebhookAuthenticatorInterface
+	WebhookAuthenticators() WebhookAuthenticatorInterface
 }
 
 // WebhookAuthenticatorInterface has methods to work with WebhookAuthenticator resources.
@@ -40,14 +40,12 @@ type WebhookAuthenticatorInterface interface {
 // webhookAuthenticators implements WebhookAuthenticatorInterface
 type webhookAuthenticators struct {
 	client rest.Interface
-	ns     string
 }
 
 // newWebhookAuthenticators returns a WebhookAuthenticators
-func newWebhookAuthenticators(c *AuthenticationV1alpha1Client, namespace string) *webhookAuthenticators {
+func newWebhookAuthenticators(c *AuthenticationV1alpha1Client) *webhookAuthenticators {
 	return &webhookAuthenticators{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -55,7 +53,6 @@ func newWebhookAuthenticators(c *AuthenticationV1alpha1Client, namespace string)
 func (c *webhookAuthenticators) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.WebhookAuthenticator, err error) {
 	result = &v1alpha1.WebhookAuthenticator{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -72,7 +69,6 @@ func (c *webhookAuthenticators) List(ctx context.Context, opts v1.ListOptions) (
 	}
 	result = &v1alpha1.WebhookAuthenticatorList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -89,7 +85,6 @@ func (c *webhookAuthenticators) Watch(ctx context.Context, opts v1.ListOptions) 
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -100,7 +95,6 @@ func (c *webhookAuthenticators) Watch(ctx context.Context, opts v1.ListOptions) 
 func (c *webhookAuthenticators) Create(ctx context.Context, webhookAuthenticator *v1alpha1.WebhookAuthenticator, opts v1.CreateOptions) (result *v1alpha1.WebhookAuthenticator, err error) {
 	result = &v1alpha1.WebhookAuthenticator{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(webhookAuthenticator).
@@ -113,7 +107,6 @@ func (c *webhookAuthenticators) Create(ctx context.Context, webhookAuthenticator
 func (c *webhookAuthenticators) Update(ctx context.Context, webhookAuthenticator *v1alpha1.WebhookAuthenticator, opts v1.UpdateOptions) (result *v1alpha1.WebhookAuthenticator, err error) {
 	result = &v1alpha1.WebhookAuthenticator{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		Name(webhookAuthenticator.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -128,7 +121,6 @@ func (c *webhookAuthenticators) Update(ctx context.Context, webhookAuthenticator
 func (c *webhookAuthenticators) UpdateStatus(ctx context.Context, webhookAuthenticator *v1alpha1.WebhookAuthenticator, opts v1.UpdateOptions) (result *v1alpha1.WebhookAuthenticator, err error) {
 	result = &v1alpha1.WebhookAuthenticator{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		Name(webhookAuthenticator.Name).
 		SubResource("status").
@@ -142,7 +134,6 @@ func (c *webhookAuthenticators) UpdateStatus(ctx context.Context, webhookAuthent
 // Delete takes name of the webhookAuthenticator and deletes it. Returns an error if one occurs.
 func (c *webhookAuthenticators) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		Name(name).
 		Body(&opts).
@@ -157,7 +148,6 @@ func (c *webhookAuthenticators) DeleteCollection(ctx context.Context, opts v1.De
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -170,7 +160,6 @@ func (c *webhookAuthenticators) DeleteCollection(ctx context.Context, opts v1.De
 func (c *webhookAuthenticators) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.WebhookAuthenticator, err error) {
 	result = &v1alpha1.WebhookAuthenticator{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("webhookauthenticators").
 		Name(name).
 		SubResource(subresources...).

--- a/generated/1.20/client/concierge/clientset/versioned/typed/config/v1alpha1/config_client.go
+++ b/generated/1.20/client/concierge/clientset/versioned/typed/config/v1alpha1/config_client.go
@@ -21,8 +21,8 @@ type ConfigV1alpha1Client struct {
 	restClient rest.Interface
 }
 
-func (c *ConfigV1alpha1Client) CredentialIssuers(namespace string) CredentialIssuerInterface {
-	return newCredentialIssuers(c, namespace)
+func (c *ConfigV1alpha1Client) CredentialIssuers() CredentialIssuerInterface {
+	return newCredentialIssuers(c)
 }
 
 // NewForConfig creates a new ConfigV1alpha1Client for the given config.

--- a/generated/1.20/client/concierge/clientset/versioned/typed/config/v1alpha1/credentialissuer.go
+++ b/generated/1.20/client/concierge/clientset/versioned/typed/config/v1alpha1/credentialissuer.go
@@ -20,7 +20,7 @@ import (
 // CredentialIssuersGetter has a method to return a CredentialIssuerInterface.
 // A group's client should implement this interface.
 type CredentialIssuersGetter interface {
-	CredentialIssuers(namespace string) CredentialIssuerInterface
+	CredentialIssuers() CredentialIssuerInterface
 }
 
 // CredentialIssuerInterface has methods to work with CredentialIssuer resources.
@@ -40,14 +40,12 @@ type CredentialIssuerInterface interface {
 // credentialIssuers implements CredentialIssuerInterface
 type credentialIssuers struct {
 	client rest.Interface
-	ns     string
 }
 
 // newCredentialIssuers returns a CredentialIssuers
-func newCredentialIssuers(c *ConfigV1alpha1Client, namespace string) *credentialIssuers {
+func newCredentialIssuers(c *ConfigV1alpha1Client) *credentialIssuers {
 	return &credentialIssuers{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -55,7 +53,6 @@ func newCredentialIssuers(c *ConfigV1alpha1Client, namespace string) *credential
 func (c *credentialIssuers) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.CredentialIssuer, err error) {
 	result = &v1alpha1.CredentialIssuer{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -72,7 +69,6 @@ func (c *credentialIssuers) List(ctx context.Context, opts v1.ListOptions) (resu
 	}
 	result = &v1alpha1.CredentialIssuerList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -89,7 +85,6 @@ func (c *credentialIssuers) Watch(ctx context.Context, opts v1.ListOptions) (wat
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -100,7 +95,6 @@ func (c *credentialIssuers) Watch(ctx context.Context, opts v1.ListOptions) (wat
 func (c *credentialIssuers) Create(ctx context.Context, credentialIssuer *v1alpha1.CredentialIssuer, opts v1.CreateOptions) (result *v1alpha1.CredentialIssuer, err error) {
 	result = &v1alpha1.CredentialIssuer{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(credentialIssuer).
@@ -113,7 +107,6 @@ func (c *credentialIssuers) Create(ctx context.Context, credentialIssuer *v1alph
 func (c *credentialIssuers) Update(ctx context.Context, credentialIssuer *v1alpha1.CredentialIssuer, opts v1.UpdateOptions) (result *v1alpha1.CredentialIssuer, err error) {
 	result = &v1alpha1.CredentialIssuer{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		Name(credentialIssuer.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -128,7 +121,6 @@ func (c *credentialIssuers) Update(ctx context.Context, credentialIssuer *v1alph
 func (c *credentialIssuers) UpdateStatus(ctx context.Context, credentialIssuer *v1alpha1.CredentialIssuer, opts v1.UpdateOptions) (result *v1alpha1.CredentialIssuer, err error) {
 	result = &v1alpha1.CredentialIssuer{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		Name(credentialIssuer.Name).
 		SubResource("status").
@@ -142,7 +134,6 @@ func (c *credentialIssuers) UpdateStatus(ctx context.Context, credentialIssuer *
 // Delete takes name of the credentialIssuer and deletes it. Returns an error if one occurs.
 func (c *credentialIssuers) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		Name(name).
 		Body(&opts).
@@ -157,7 +148,6 @@ func (c *credentialIssuers) DeleteCollection(ctx context.Context, opts v1.Delete
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -170,7 +160,6 @@ func (c *credentialIssuers) DeleteCollection(ctx context.Context, opts v1.Delete
 func (c *credentialIssuers) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.CredentialIssuer, err error) {
 	result = &v1alpha1.CredentialIssuer{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("credentialissuers").
 		Name(name).
 		SubResource(subresources...).

--- a/generated/1.20/client/concierge/clientset/versioned/typed/config/v1alpha1/fake/fake_config_client.go
+++ b/generated/1.20/client/concierge/clientset/versioned/typed/config/v1alpha1/fake/fake_config_client.go
@@ -15,8 +15,8 @@ type FakeConfigV1alpha1 struct {
 	*testing.Fake
 }
 
-func (c *FakeConfigV1alpha1) CredentialIssuers(namespace string) v1alpha1.CredentialIssuerInterface {
-	return &FakeCredentialIssuers{c, namespace}
+func (c *FakeConfigV1alpha1) CredentialIssuers() v1alpha1.CredentialIssuerInterface {
+	return &FakeCredentialIssuers{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/generated/1.20/client/concierge/clientset/versioned/typed/config/v1alpha1/fake/fake_credentialissuer.go
+++ b/generated/1.20/client/concierge/clientset/versioned/typed/config/v1alpha1/fake/fake_credentialissuer.go
@@ -20,7 +20,6 @@ import (
 // FakeCredentialIssuers implements CredentialIssuerInterface
 type FakeCredentialIssuers struct {
 	Fake *FakeConfigV1alpha1
-	ns   string
 }
 
 var credentialissuersResource = schema.GroupVersionResource{Group: "config.concierge.pinniped.dev", Version: "v1alpha1", Resource: "credentialissuers"}
@@ -30,8 +29,7 @@ var credentialissuersKind = schema.GroupVersionKind{Group: "config.concierge.pin
 // Get takes name of the credentialIssuer, and returns the corresponding credentialIssuer object, and an error if there is any.
 func (c *FakeCredentialIssuers) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.CredentialIssuer, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(credentialissuersResource, c.ns, name), &v1alpha1.CredentialIssuer{})
-
+		Invokes(testing.NewRootGetAction(credentialissuersResource, name), &v1alpha1.CredentialIssuer{})
 	if obj == nil {
 		return nil, err
 	}
@@ -41,8 +39,7 @@ func (c *FakeCredentialIssuers) Get(ctx context.Context, name string, options v1
 // List takes label and field selectors, and returns the list of CredentialIssuers that match those selectors.
 func (c *FakeCredentialIssuers) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.CredentialIssuerList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(credentialissuersResource, credentialissuersKind, c.ns, opts), &v1alpha1.CredentialIssuerList{})
-
+		Invokes(testing.NewRootListAction(credentialissuersResource, credentialissuersKind, opts), &v1alpha1.CredentialIssuerList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -63,15 +60,13 @@ func (c *FakeCredentialIssuers) List(ctx context.Context, opts v1.ListOptions) (
 // Watch returns a watch.Interface that watches the requested credentialIssuers.
 func (c *FakeCredentialIssuers) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(credentialissuersResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(credentialissuersResource, opts))
 }
 
 // Create takes the representation of a credentialIssuer and creates it.  Returns the server's representation of the credentialIssuer, and an error, if there is any.
 func (c *FakeCredentialIssuers) Create(ctx context.Context, credentialIssuer *v1alpha1.CredentialIssuer, opts v1.CreateOptions) (result *v1alpha1.CredentialIssuer, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(credentialissuersResource, c.ns, credentialIssuer), &v1alpha1.CredentialIssuer{})
-
+		Invokes(testing.NewRootCreateAction(credentialissuersResource, credentialIssuer), &v1alpha1.CredentialIssuer{})
 	if obj == nil {
 		return nil, err
 	}
@@ -81,8 +76,7 @@ func (c *FakeCredentialIssuers) Create(ctx context.Context, credentialIssuer *v1
 // Update takes the representation of a credentialIssuer and updates it. Returns the server's representation of the credentialIssuer, and an error, if there is any.
 func (c *FakeCredentialIssuers) Update(ctx context.Context, credentialIssuer *v1alpha1.CredentialIssuer, opts v1.UpdateOptions) (result *v1alpha1.CredentialIssuer, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(credentialissuersResource, c.ns, credentialIssuer), &v1alpha1.CredentialIssuer{})
-
+		Invokes(testing.NewRootUpdateAction(credentialissuersResource, credentialIssuer), &v1alpha1.CredentialIssuer{})
 	if obj == nil {
 		return nil, err
 	}
@@ -93,8 +87,7 @@ func (c *FakeCredentialIssuers) Update(ctx context.Context, credentialIssuer *v1
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeCredentialIssuers) UpdateStatus(ctx context.Context, credentialIssuer *v1alpha1.CredentialIssuer, opts v1.UpdateOptions) (*v1alpha1.CredentialIssuer, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(credentialissuersResource, "status", c.ns, credentialIssuer), &v1alpha1.CredentialIssuer{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(credentialissuersResource, "status", credentialIssuer), &v1alpha1.CredentialIssuer{})
 	if obj == nil {
 		return nil, err
 	}
@@ -104,14 +97,13 @@ func (c *FakeCredentialIssuers) UpdateStatus(ctx context.Context, credentialIssu
 // Delete takes name of the credentialIssuer and deletes it. Returns an error if one occurs.
 func (c *FakeCredentialIssuers) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(credentialissuersResource, c.ns, name), &v1alpha1.CredentialIssuer{})
-
+		Invokes(testing.NewRootDeleteAction(credentialissuersResource, name), &v1alpha1.CredentialIssuer{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeCredentialIssuers) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(credentialissuersResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(credentialissuersResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.CredentialIssuerList{})
 	return err
@@ -120,8 +112,7 @@ func (c *FakeCredentialIssuers) DeleteCollection(ctx context.Context, opts v1.De
 // Patch applies the patch and returns the patched credentialIssuer.
 func (c *FakeCredentialIssuers) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.CredentialIssuer, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(credentialissuersResource, c.ns, name, pt, data, subresources...), &v1alpha1.CredentialIssuer{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(credentialissuersResource, name, pt, data, subresources...), &v1alpha1.CredentialIssuer{})
 	if obj == nil {
 		return nil, err
 	}

--- a/generated/1.20/client/concierge/clientset/versioned/typed/login/v1alpha1/fake/fake_login_client.go
+++ b/generated/1.20/client/concierge/clientset/versioned/typed/login/v1alpha1/fake/fake_login_client.go
@@ -15,8 +15,8 @@ type FakeLoginV1alpha1 struct {
 	*testing.Fake
 }
 
-func (c *FakeLoginV1alpha1) TokenCredentialRequests(namespace string) v1alpha1.TokenCredentialRequestInterface {
-	return &FakeTokenCredentialRequests{c, namespace}
+func (c *FakeLoginV1alpha1) TokenCredentialRequests() v1alpha1.TokenCredentialRequestInterface {
+	return &FakeTokenCredentialRequests{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/generated/1.20/client/concierge/clientset/versioned/typed/login/v1alpha1/fake/fake_tokencredentialrequest.go
+++ b/generated/1.20/client/concierge/clientset/versioned/typed/login/v1alpha1/fake/fake_tokencredentialrequest.go
@@ -20,7 +20,6 @@ import (
 // FakeTokenCredentialRequests implements TokenCredentialRequestInterface
 type FakeTokenCredentialRequests struct {
 	Fake *FakeLoginV1alpha1
-	ns   string
 }
 
 var tokencredentialrequestsResource = schema.GroupVersionResource{Group: "login.concierge.pinniped.dev", Version: "v1alpha1", Resource: "tokencredentialrequests"}
@@ -30,8 +29,7 @@ var tokencredentialrequestsKind = schema.GroupVersionKind{Group: "login.concierg
 // Get takes name of the tokenCredentialRequest, and returns the corresponding tokenCredentialRequest object, and an error if there is any.
 func (c *FakeTokenCredentialRequests) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.TokenCredentialRequest, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(tokencredentialrequestsResource, c.ns, name), &v1alpha1.TokenCredentialRequest{})
-
+		Invokes(testing.NewRootGetAction(tokencredentialrequestsResource, name), &v1alpha1.TokenCredentialRequest{})
 	if obj == nil {
 		return nil, err
 	}
@@ -41,8 +39,7 @@ func (c *FakeTokenCredentialRequests) Get(ctx context.Context, name string, opti
 // List takes label and field selectors, and returns the list of TokenCredentialRequests that match those selectors.
 func (c *FakeTokenCredentialRequests) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.TokenCredentialRequestList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(tokencredentialrequestsResource, tokencredentialrequestsKind, c.ns, opts), &v1alpha1.TokenCredentialRequestList{})
-
+		Invokes(testing.NewRootListAction(tokencredentialrequestsResource, tokencredentialrequestsKind, opts), &v1alpha1.TokenCredentialRequestList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -63,15 +60,13 @@ func (c *FakeTokenCredentialRequests) List(ctx context.Context, opts v1.ListOpti
 // Watch returns a watch.Interface that watches the requested tokenCredentialRequests.
 func (c *FakeTokenCredentialRequests) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(tokencredentialrequestsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(tokencredentialrequestsResource, opts))
 }
 
 // Create takes the representation of a tokenCredentialRequest and creates it.  Returns the server's representation of the tokenCredentialRequest, and an error, if there is any.
 func (c *FakeTokenCredentialRequests) Create(ctx context.Context, tokenCredentialRequest *v1alpha1.TokenCredentialRequest, opts v1.CreateOptions) (result *v1alpha1.TokenCredentialRequest, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(tokencredentialrequestsResource, c.ns, tokenCredentialRequest), &v1alpha1.TokenCredentialRequest{})
-
+		Invokes(testing.NewRootCreateAction(tokencredentialrequestsResource, tokenCredentialRequest), &v1alpha1.TokenCredentialRequest{})
 	if obj == nil {
 		return nil, err
 	}
@@ -81,8 +76,7 @@ func (c *FakeTokenCredentialRequests) Create(ctx context.Context, tokenCredentia
 // Update takes the representation of a tokenCredentialRequest and updates it. Returns the server's representation of the tokenCredentialRequest, and an error, if there is any.
 func (c *FakeTokenCredentialRequests) Update(ctx context.Context, tokenCredentialRequest *v1alpha1.TokenCredentialRequest, opts v1.UpdateOptions) (result *v1alpha1.TokenCredentialRequest, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(tokencredentialrequestsResource, c.ns, tokenCredentialRequest), &v1alpha1.TokenCredentialRequest{})
-
+		Invokes(testing.NewRootUpdateAction(tokencredentialrequestsResource, tokenCredentialRequest), &v1alpha1.TokenCredentialRequest{})
 	if obj == nil {
 		return nil, err
 	}
@@ -93,8 +87,7 @@ func (c *FakeTokenCredentialRequests) Update(ctx context.Context, tokenCredentia
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeTokenCredentialRequests) UpdateStatus(ctx context.Context, tokenCredentialRequest *v1alpha1.TokenCredentialRequest, opts v1.UpdateOptions) (*v1alpha1.TokenCredentialRequest, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(tokencredentialrequestsResource, "status", c.ns, tokenCredentialRequest), &v1alpha1.TokenCredentialRequest{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(tokencredentialrequestsResource, "status", tokenCredentialRequest), &v1alpha1.TokenCredentialRequest{})
 	if obj == nil {
 		return nil, err
 	}
@@ -104,14 +97,13 @@ func (c *FakeTokenCredentialRequests) UpdateStatus(ctx context.Context, tokenCre
 // Delete takes name of the tokenCredentialRequest and deletes it. Returns an error if one occurs.
 func (c *FakeTokenCredentialRequests) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(tokencredentialrequestsResource, c.ns, name), &v1alpha1.TokenCredentialRequest{})
-
+		Invokes(testing.NewRootDeleteAction(tokencredentialrequestsResource, name), &v1alpha1.TokenCredentialRequest{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeTokenCredentialRequests) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(tokencredentialrequestsResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(tokencredentialrequestsResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.TokenCredentialRequestList{})
 	return err
@@ -120,8 +112,7 @@ func (c *FakeTokenCredentialRequests) DeleteCollection(ctx context.Context, opts
 // Patch applies the patch and returns the patched tokenCredentialRequest.
 func (c *FakeTokenCredentialRequests) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.TokenCredentialRequest, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(tokencredentialrequestsResource, c.ns, name, pt, data, subresources...), &v1alpha1.TokenCredentialRequest{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(tokencredentialrequestsResource, name, pt, data, subresources...), &v1alpha1.TokenCredentialRequest{})
 	if obj == nil {
 		return nil, err
 	}

--- a/generated/1.20/client/concierge/clientset/versioned/typed/login/v1alpha1/login_client.go
+++ b/generated/1.20/client/concierge/clientset/versioned/typed/login/v1alpha1/login_client.go
@@ -21,8 +21,8 @@ type LoginV1alpha1Client struct {
 	restClient rest.Interface
 }
 
-func (c *LoginV1alpha1Client) TokenCredentialRequests(namespace string) TokenCredentialRequestInterface {
-	return newTokenCredentialRequests(c, namespace)
+func (c *LoginV1alpha1Client) TokenCredentialRequests() TokenCredentialRequestInterface {
+	return newTokenCredentialRequests(c)
 }
 
 // NewForConfig creates a new LoginV1alpha1Client for the given config.

--- a/generated/1.20/client/concierge/clientset/versioned/typed/login/v1alpha1/tokencredentialrequest.go
+++ b/generated/1.20/client/concierge/clientset/versioned/typed/login/v1alpha1/tokencredentialrequest.go
@@ -20,7 +20,7 @@ import (
 // TokenCredentialRequestsGetter has a method to return a TokenCredentialRequestInterface.
 // A group's client should implement this interface.
 type TokenCredentialRequestsGetter interface {
-	TokenCredentialRequests(namespace string) TokenCredentialRequestInterface
+	TokenCredentialRequests() TokenCredentialRequestInterface
 }
 
 // TokenCredentialRequestInterface has methods to work with TokenCredentialRequest resources.
@@ -40,14 +40,12 @@ type TokenCredentialRequestInterface interface {
 // tokenCredentialRequests implements TokenCredentialRequestInterface
 type tokenCredentialRequests struct {
 	client rest.Interface
-	ns     string
 }
 
 // newTokenCredentialRequests returns a TokenCredentialRequests
-func newTokenCredentialRequests(c *LoginV1alpha1Client, namespace string) *tokenCredentialRequests {
+func newTokenCredentialRequests(c *LoginV1alpha1Client) *tokenCredentialRequests {
 	return &tokenCredentialRequests{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -55,7 +53,6 @@ func newTokenCredentialRequests(c *LoginV1alpha1Client, namespace string) *token
 func (c *tokenCredentialRequests) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.TokenCredentialRequest, err error) {
 	result = &v1alpha1.TokenCredentialRequest{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -72,7 +69,6 @@ func (c *tokenCredentialRequests) List(ctx context.Context, opts v1.ListOptions)
 	}
 	result = &v1alpha1.TokenCredentialRequestList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -89,7 +85,6 @@ func (c *tokenCredentialRequests) Watch(ctx context.Context, opts v1.ListOptions
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -100,7 +95,6 @@ func (c *tokenCredentialRequests) Watch(ctx context.Context, opts v1.ListOptions
 func (c *tokenCredentialRequests) Create(ctx context.Context, tokenCredentialRequest *v1alpha1.TokenCredentialRequest, opts v1.CreateOptions) (result *v1alpha1.TokenCredentialRequest, err error) {
 	result = &v1alpha1.TokenCredentialRequest{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(tokenCredentialRequest).
@@ -113,7 +107,6 @@ func (c *tokenCredentialRequests) Create(ctx context.Context, tokenCredentialReq
 func (c *tokenCredentialRequests) Update(ctx context.Context, tokenCredentialRequest *v1alpha1.TokenCredentialRequest, opts v1.UpdateOptions) (result *v1alpha1.TokenCredentialRequest, err error) {
 	result = &v1alpha1.TokenCredentialRequest{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		Name(tokenCredentialRequest.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -128,7 +121,6 @@ func (c *tokenCredentialRequests) Update(ctx context.Context, tokenCredentialReq
 func (c *tokenCredentialRequests) UpdateStatus(ctx context.Context, tokenCredentialRequest *v1alpha1.TokenCredentialRequest, opts v1.UpdateOptions) (result *v1alpha1.TokenCredentialRequest, err error) {
 	result = &v1alpha1.TokenCredentialRequest{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		Name(tokenCredentialRequest.Name).
 		SubResource("status").
@@ -142,7 +134,6 @@ func (c *tokenCredentialRequests) UpdateStatus(ctx context.Context, tokenCredent
 // Delete takes name of the tokenCredentialRequest and deletes it. Returns an error if one occurs.
 func (c *tokenCredentialRequests) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		Name(name).
 		Body(&opts).
@@ -157,7 +148,6 @@ func (c *tokenCredentialRequests) DeleteCollection(ctx context.Context, opts v1.
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -170,7 +160,6 @@ func (c *tokenCredentialRequests) DeleteCollection(ctx context.Context, opts v1.
 func (c *tokenCredentialRequests) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.TokenCredentialRequest, err error) {
 	result = &v1alpha1.TokenCredentialRequest{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("tokencredentialrequests").
 		Name(name).
 		SubResource(subresources...).

--- a/generated/1.20/client/concierge/informers/externalversions/authentication/v1alpha1/interface.go
+++ b/generated/1.20/client/concierge/informers/externalversions/authentication/v1alpha1/interface.go
@@ -30,10 +30,10 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // JWTAuthenticators returns a JWTAuthenticatorInformer.
 func (v *version) JWTAuthenticators() JWTAuthenticatorInformer {
-	return &jWTAuthenticatorInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &jWTAuthenticatorInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
 // WebhookAuthenticators returns a WebhookAuthenticatorInformer.
 func (v *version) WebhookAuthenticators() WebhookAuthenticatorInformer {
-	return &webhookAuthenticatorInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &webhookAuthenticatorInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/generated/1.20/client/concierge/informers/externalversions/authentication/v1alpha1/jwtauthenticator.go
+++ b/generated/1.20/client/concierge/informers/externalversions/authentication/v1alpha1/jwtauthenticator.go
@@ -29,33 +29,32 @@ type JWTAuthenticatorInformer interface {
 type jWTAuthenticatorInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewJWTAuthenticatorInformer constructs a new informer for JWTAuthenticator type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewJWTAuthenticatorInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredJWTAuthenticatorInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewJWTAuthenticatorInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredJWTAuthenticatorInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredJWTAuthenticatorInformer constructs a new informer for JWTAuthenticator type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredJWTAuthenticatorInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredJWTAuthenticatorInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AuthenticationV1alpha1().JWTAuthenticators(namespace).List(context.TODO(), options)
+				return client.AuthenticationV1alpha1().JWTAuthenticators().List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AuthenticationV1alpha1().JWTAuthenticators(namespace).Watch(context.TODO(), options)
+				return client.AuthenticationV1alpha1().JWTAuthenticators().Watch(context.TODO(), options)
 			},
 		},
 		&authenticationv1alpha1.JWTAuthenticator{},
@@ -65,7 +64,7 @@ func NewFilteredJWTAuthenticatorInformer(client versioned.Interface, namespace s
 }
 
 func (f *jWTAuthenticatorInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredJWTAuthenticatorInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredJWTAuthenticatorInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *jWTAuthenticatorInformer) Informer() cache.SharedIndexInformer {

--- a/generated/1.20/client/concierge/informers/externalversions/authentication/v1alpha1/webhookauthenticator.go
+++ b/generated/1.20/client/concierge/informers/externalversions/authentication/v1alpha1/webhookauthenticator.go
@@ -29,33 +29,32 @@ type WebhookAuthenticatorInformer interface {
 type webhookAuthenticatorInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewWebhookAuthenticatorInformer constructs a new informer for WebhookAuthenticator type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewWebhookAuthenticatorInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredWebhookAuthenticatorInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewWebhookAuthenticatorInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredWebhookAuthenticatorInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredWebhookAuthenticatorInformer constructs a new informer for WebhookAuthenticator type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredWebhookAuthenticatorInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredWebhookAuthenticatorInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AuthenticationV1alpha1().WebhookAuthenticators(namespace).List(context.TODO(), options)
+				return client.AuthenticationV1alpha1().WebhookAuthenticators().List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AuthenticationV1alpha1().WebhookAuthenticators(namespace).Watch(context.TODO(), options)
+				return client.AuthenticationV1alpha1().WebhookAuthenticators().Watch(context.TODO(), options)
 			},
 		},
 		&authenticationv1alpha1.WebhookAuthenticator{},
@@ -65,7 +64,7 @@ func NewFilteredWebhookAuthenticatorInformer(client versioned.Interface, namespa
 }
 
 func (f *webhookAuthenticatorInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredWebhookAuthenticatorInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredWebhookAuthenticatorInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *webhookAuthenticatorInformer) Informer() cache.SharedIndexInformer {

--- a/generated/1.20/client/concierge/informers/externalversions/config/v1alpha1/credentialissuer.go
+++ b/generated/1.20/client/concierge/informers/externalversions/config/v1alpha1/credentialissuer.go
@@ -29,33 +29,32 @@ type CredentialIssuerInformer interface {
 type credentialIssuerInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewCredentialIssuerInformer constructs a new informer for CredentialIssuer type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewCredentialIssuerInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredCredentialIssuerInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewCredentialIssuerInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredCredentialIssuerInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredCredentialIssuerInformer constructs a new informer for CredentialIssuer type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredCredentialIssuerInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredCredentialIssuerInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ConfigV1alpha1().CredentialIssuers(namespace).List(context.TODO(), options)
+				return client.ConfigV1alpha1().CredentialIssuers().List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ConfigV1alpha1().CredentialIssuers(namespace).Watch(context.TODO(), options)
+				return client.ConfigV1alpha1().CredentialIssuers().Watch(context.TODO(), options)
 			},
 		},
 		&configv1alpha1.CredentialIssuer{},
@@ -65,7 +64,7 @@ func NewFilteredCredentialIssuerInformer(client versioned.Interface, namespace s
 }
 
 func (f *credentialIssuerInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredCredentialIssuerInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredCredentialIssuerInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *credentialIssuerInformer) Informer() cache.SharedIndexInformer {

--- a/generated/1.20/client/concierge/informers/externalversions/config/v1alpha1/interface.go
+++ b/generated/1.20/client/concierge/informers/externalversions/config/v1alpha1/interface.go
@@ -28,5 +28,5 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // CredentialIssuers returns a CredentialIssuerInformer.
 func (v *version) CredentialIssuers() CredentialIssuerInformer {
-	return &credentialIssuerInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &credentialIssuerInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/generated/1.20/client/concierge/informers/externalversions/login/v1alpha1/interface.go
+++ b/generated/1.20/client/concierge/informers/externalversions/login/v1alpha1/interface.go
@@ -28,5 +28,5 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // TokenCredentialRequests returns a TokenCredentialRequestInformer.
 func (v *version) TokenCredentialRequests() TokenCredentialRequestInformer {
-	return &tokenCredentialRequestInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &tokenCredentialRequestInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/generated/1.20/client/concierge/informers/externalversions/login/v1alpha1/tokencredentialrequest.go
+++ b/generated/1.20/client/concierge/informers/externalversions/login/v1alpha1/tokencredentialrequest.go
@@ -29,33 +29,32 @@ type TokenCredentialRequestInformer interface {
 type tokenCredentialRequestInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewTokenCredentialRequestInformer constructs a new informer for TokenCredentialRequest type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewTokenCredentialRequestInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredTokenCredentialRequestInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewTokenCredentialRequestInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredTokenCredentialRequestInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredTokenCredentialRequestInformer constructs a new informer for TokenCredentialRequest type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredTokenCredentialRequestInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredTokenCredentialRequestInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.LoginV1alpha1().TokenCredentialRequests(namespace).List(context.TODO(), options)
+				return client.LoginV1alpha1().TokenCredentialRequests().List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.LoginV1alpha1().TokenCredentialRequests(namespace).Watch(context.TODO(), options)
+				return client.LoginV1alpha1().TokenCredentialRequests().Watch(context.TODO(), options)
 			},
 		},
 		&loginv1alpha1.TokenCredentialRequest{},
@@ -65,7 +64,7 @@ func NewFilteredTokenCredentialRequestInformer(client versioned.Interface, names
 }
 
 func (f *tokenCredentialRequestInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredTokenCredentialRequestInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredTokenCredentialRequestInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *tokenCredentialRequestInformer) Informer() cache.SharedIndexInformer {

--- a/generated/1.20/client/concierge/listers/authentication/v1alpha1/expansion_generated.go
+++ b/generated/1.20/client/concierge/listers/authentication/v1alpha1/expansion_generated.go
@@ -9,14 +9,6 @@ package v1alpha1
 // JWTAuthenticatorLister.
 type JWTAuthenticatorListerExpansion interface{}
 
-// JWTAuthenticatorNamespaceListerExpansion allows custom methods to be added to
-// JWTAuthenticatorNamespaceLister.
-type JWTAuthenticatorNamespaceListerExpansion interface{}
-
 // WebhookAuthenticatorListerExpansion allows custom methods to be added to
 // WebhookAuthenticatorLister.
 type WebhookAuthenticatorListerExpansion interface{}
-
-// WebhookAuthenticatorNamespaceListerExpansion allows custom methods to be added to
-// WebhookAuthenticatorNamespaceLister.
-type WebhookAuthenticatorNamespaceListerExpansion interface{}

--- a/generated/1.20/client/concierge/listers/authentication/v1alpha1/jwtauthenticator.go
+++ b/generated/1.20/client/concierge/listers/authentication/v1alpha1/jwtauthenticator.go
@@ -18,8 +18,9 @@ type JWTAuthenticatorLister interface {
 	// List lists all JWTAuthenticators in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.JWTAuthenticator, err error)
-	// JWTAuthenticators returns an object that can list and get JWTAuthenticators.
-	JWTAuthenticators(namespace string) JWTAuthenticatorNamespaceLister
+	// Get retrieves the JWTAuthenticator from the index for a given name.
+	// Objects returned here must be treated as read-only.
+	Get(name string) (*v1alpha1.JWTAuthenticator, error)
 	JWTAuthenticatorListerExpansion
 }
 
@@ -41,41 +42,9 @@ func (s *jWTAuthenticatorLister) List(selector labels.Selector) (ret []*v1alpha1
 	return ret, err
 }
 
-// JWTAuthenticators returns an object that can list and get JWTAuthenticators.
-func (s *jWTAuthenticatorLister) JWTAuthenticators(namespace string) JWTAuthenticatorNamespaceLister {
-	return jWTAuthenticatorNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// JWTAuthenticatorNamespaceLister helps list and get JWTAuthenticators.
-// All objects returned here must be treated as read-only.
-type JWTAuthenticatorNamespaceLister interface {
-	// List lists all JWTAuthenticators in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1alpha1.JWTAuthenticator, err error)
-	// Get retrieves the JWTAuthenticator from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1alpha1.JWTAuthenticator, error)
-	JWTAuthenticatorNamespaceListerExpansion
-}
-
-// jWTAuthenticatorNamespaceLister implements the JWTAuthenticatorNamespaceLister
-// interface.
-type jWTAuthenticatorNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all JWTAuthenticators in the indexer for a given namespace.
-func (s jWTAuthenticatorNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.JWTAuthenticator, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.JWTAuthenticator))
-	})
-	return ret, err
-}
-
-// Get retrieves the JWTAuthenticator from the indexer for a given namespace and name.
-func (s jWTAuthenticatorNamespaceLister) Get(name string) (*v1alpha1.JWTAuthenticator, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the JWTAuthenticator from the index for a given name.
+func (s *jWTAuthenticatorLister) Get(name string) (*v1alpha1.JWTAuthenticator, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/generated/1.20/client/concierge/listers/authentication/v1alpha1/webhookauthenticator.go
+++ b/generated/1.20/client/concierge/listers/authentication/v1alpha1/webhookauthenticator.go
@@ -18,8 +18,9 @@ type WebhookAuthenticatorLister interface {
 	// List lists all WebhookAuthenticators in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.WebhookAuthenticator, err error)
-	// WebhookAuthenticators returns an object that can list and get WebhookAuthenticators.
-	WebhookAuthenticators(namespace string) WebhookAuthenticatorNamespaceLister
+	// Get retrieves the WebhookAuthenticator from the index for a given name.
+	// Objects returned here must be treated as read-only.
+	Get(name string) (*v1alpha1.WebhookAuthenticator, error)
 	WebhookAuthenticatorListerExpansion
 }
 
@@ -41,41 +42,9 @@ func (s *webhookAuthenticatorLister) List(selector labels.Selector) (ret []*v1al
 	return ret, err
 }
 
-// WebhookAuthenticators returns an object that can list and get WebhookAuthenticators.
-func (s *webhookAuthenticatorLister) WebhookAuthenticators(namespace string) WebhookAuthenticatorNamespaceLister {
-	return webhookAuthenticatorNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// WebhookAuthenticatorNamespaceLister helps list and get WebhookAuthenticators.
-// All objects returned here must be treated as read-only.
-type WebhookAuthenticatorNamespaceLister interface {
-	// List lists all WebhookAuthenticators in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1alpha1.WebhookAuthenticator, err error)
-	// Get retrieves the WebhookAuthenticator from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1alpha1.WebhookAuthenticator, error)
-	WebhookAuthenticatorNamespaceListerExpansion
-}
-
-// webhookAuthenticatorNamespaceLister implements the WebhookAuthenticatorNamespaceLister
-// interface.
-type webhookAuthenticatorNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all WebhookAuthenticators in the indexer for a given namespace.
-func (s webhookAuthenticatorNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.WebhookAuthenticator, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.WebhookAuthenticator))
-	})
-	return ret, err
-}
-
-// Get retrieves the WebhookAuthenticator from the indexer for a given namespace and name.
-func (s webhookAuthenticatorNamespaceLister) Get(name string) (*v1alpha1.WebhookAuthenticator, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the WebhookAuthenticator from the index for a given name.
+func (s *webhookAuthenticatorLister) Get(name string) (*v1alpha1.WebhookAuthenticator, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/generated/1.20/client/concierge/listers/config/v1alpha1/credentialissuer.go
+++ b/generated/1.20/client/concierge/listers/config/v1alpha1/credentialissuer.go
@@ -18,8 +18,9 @@ type CredentialIssuerLister interface {
 	// List lists all CredentialIssuers in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.CredentialIssuer, err error)
-	// CredentialIssuers returns an object that can list and get CredentialIssuers.
-	CredentialIssuers(namespace string) CredentialIssuerNamespaceLister
+	// Get retrieves the CredentialIssuer from the index for a given name.
+	// Objects returned here must be treated as read-only.
+	Get(name string) (*v1alpha1.CredentialIssuer, error)
 	CredentialIssuerListerExpansion
 }
 
@@ -41,41 +42,9 @@ func (s *credentialIssuerLister) List(selector labels.Selector) (ret []*v1alpha1
 	return ret, err
 }
 
-// CredentialIssuers returns an object that can list and get CredentialIssuers.
-func (s *credentialIssuerLister) CredentialIssuers(namespace string) CredentialIssuerNamespaceLister {
-	return credentialIssuerNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// CredentialIssuerNamespaceLister helps list and get CredentialIssuers.
-// All objects returned here must be treated as read-only.
-type CredentialIssuerNamespaceLister interface {
-	// List lists all CredentialIssuers in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1alpha1.CredentialIssuer, err error)
-	// Get retrieves the CredentialIssuer from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1alpha1.CredentialIssuer, error)
-	CredentialIssuerNamespaceListerExpansion
-}
-
-// credentialIssuerNamespaceLister implements the CredentialIssuerNamespaceLister
-// interface.
-type credentialIssuerNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all CredentialIssuers in the indexer for a given namespace.
-func (s credentialIssuerNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.CredentialIssuer, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.CredentialIssuer))
-	})
-	return ret, err
-}
-
-// Get retrieves the CredentialIssuer from the indexer for a given namespace and name.
-func (s credentialIssuerNamespaceLister) Get(name string) (*v1alpha1.CredentialIssuer, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the CredentialIssuer from the index for a given name.
+func (s *credentialIssuerLister) Get(name string) (*v1alpha1.CredentialIssuer, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/generated/1.20/client/concierge/listers/config/v1alpha1/expansion_generated.go
+++ b/generated/1.20/client/concierge/listers/config/v1alpha1/expansion_generated.go
@@ -8,7 +8,3 @@ package v1alpha1
 // CredentialIssuerListerExpansion allows custom methods to be added to
 // CredentialIssuerLister.
 type CredentialIssuerListerExpansion interface{}
-
-// CredentialIssuerNamespaceListerExpansion allows custom methods to be added to
-// CredentialIssuerNamespaceLister.
-type CredentialIssuerNamespaceListerExpansion interface{}

--- a/generated/1.20/client/concierge/listers/login/v1alpha1/expansion_generated.go
+++ b/generated/1.20/client/concierge/listers/login/v1alpha1/expansion_generated.go
@@ -8,7 +8,3 @@ package v1alpha1
 // TokenCredentialRequestListerExpansion allows custom methods to be added to
 // TokenCredentialRequestLister.
 type TokenCredentialRequestListerExpansion interface{}
-
-// TokenCredentialRequestNamespaceListerExpansion allows custom methods to be added to
-// TokenCredentialRequestNamespaceLister.
-type TokenCredentialRequestNamespaceListerExpansion interface{}

--- a/generated/1.20/client/concierge/listers/login/v1alpha1/tokencredentialrequest.go
+++ b/generated/1.20/client/concierge/listers/login/v1alpha1/tokencredentialrequest.go
@@ -18,8 +18,9 @@ type TokenCredentialRequestLister interface {
 	// List lists all TokenCredentialRequests in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.TokenCredentialRequest, err error)
-	// TokenCredentialRequests returns an object that can list and get TokenCredentialRequests.
-	TokenCredentialRequests(namespace string) TokenCredentialRequestNamespaceLister
+	// Get retrieves the TokenCredentialRequest from the index for a given name.
+	// Objects returned here must be treated as read-only.
+	Get(name string) (*v1alpha1.TokenCredentialRequest, error)
 	TokenCredentialRequestListerExpansion
 }
 
@@ -41,41 +42,9 @@ func (s *tokenCredentialRequestLister) List(selector labels.Selector) (ret []*v1
 	return ret, err
 }
 
-// TokenCredentialRequests returns an object that can list and get TokenCredentialRequests.
-func (s *tokenCredentialRequestLister) TokenCredentialRequests(namespace string) TokenCredentialRequestNamespaceLister {
-	return tokenCredentialRequestNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// TokenCredentialRequestNamespaceLister helps list and get TokenCredentialRequests.
-// All objects returned here must be treated as read-only.
-type TokenCredentialRequestNamespaceLister interface {
-	// List lists all TokenCredentialRequests in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1alpha1.TokenCredentialRequest, err error)
-	// Get retrieves the TokenCredentialRequest from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1alpha1.TokenCredentialRequest, error)
-	TokenCredentialRequestNamespaceListerExpansion
-}
-
-// tokenCredentialRequestNamespaceLister implements the TokenCredentialRequestNamespaceLister
-// interface.
-type tokenCredentialRequestNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all TokenCredentialRequests in the indexer for a given namespace.
-func (s tokenCredentialRequestNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.TokenCredentialRequest, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.TokenCredentialRequest))
-	})
-	return ret, err
-}
-
-// Get retrieves the TokenCredentialRequest from the indexer for a given namespace and name.
-func (s tokenCredentialRequestNamespaceLister) Get(name string) (*v1alpha1.TokenCredentialRequest, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the TokenCredentialRequest from the index for a given name.
+func (s *tokenCredentialRequestLister) Get(name string) (*v1alpha1.TokenCredentialRequest, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/generated/1.20/crds/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
+++ b/generated/1.20/crds/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
@@ -161,7 +161,8 @@ spec:
         type: object
     served: true
     storage: true
-    subresources: {}
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/generated/1.20/crds/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
+++ b/generated/1.20/crds/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
@@ -18,7 +18,7 @@ spec:
     listKind: JWTAuthenticatorList
     plural: jwtauthenticators
     singular: jwtauthenticator
-  scope: Namespaced
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.issuer

--- a/generated/1.20/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
+++ b/generated/1.20/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
@@ -137,7 +137,8 @@ spec:
         type: object
     served: true
     storage: true
-    subresources: {}
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/generated/1.20/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
+++ b/generated/1.20/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
@@ -18,7 +18,7 @@ spec:
     listKind: WebhookAuthenticatorList
     plural: webhookauthenticators
     singular: webhookauthenticator
-  scope: Namespaced
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.endpoint

--- a/generated/1.20/crds/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/generated/1.20/crds/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -16,7 +16,7 @@ spec:
     listKind: CredentialIssuerList
     plural: credentialissuers
     singular: credentialissuer
-  scope: Namespaced
+  scope: Cluster
   versions:
   - name: v1alpha1
     schema:

--- a/generated/1.20/crds/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/generated/1.20/crds/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -98,8 +98,6 @@ spec:
             required:
             - strategies
             type: object
-        required:
-        - status
         type: object
     served: true
     storage: true

--- a/generated/1.20/crds/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/generated/1.20/crds/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -103,6 +103,8 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/generated/1.20/crds/config.supervisor.pinniped.dev_federationdomains.yaml
+++ b/generated/1.20/crds/config.supervisor.pinniped.dev_federationdomains.yaml
@@ -150,6 +150,8 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/internal/apiserviceref/apiserviceref.go
+++ b/internal/apiserviceref/apiserviceref.go
@@ -1,0 +1,36 @@
+// Copyright 2021 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package apiserviceref
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+
+	"go.pinniped.dev/internal/kubeclient"
+	"go.pinniped.dev/internal/ownerref"
+)
+
+func New(apiServiceName string, opts ...kubeclient.Option) (kubeclient.Option, error) {
+	tempClient, err := kubeclient.New(opts...)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create temp client: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	apiService, err := tempClient.Aggregation.ApiregistrationV1().APIServices().Get(ctx, apiServiceName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("cannot get api service %s: %w", apiServiceName, err)
+	}
+
+	// work around stupid behavior of WithoutVersionDecoder.Decode
+	apiService.APIVersion, apiService.Kind = apiregistrationv1.SchemeGroupVersion.WithKind("APIService").ToAPIVersionAndKind()
+
+	return kubeclient.WithMiddleware(ownerref.New(apiService)), nil
+}

--- a/internal/controller/authenticator/authncache/cache.go
+++ b/internal/controller/authenticator/authncache/cache.go
@@ -28,10 +28,9 @@ type Cache struct {
 }
 
 type Key struct {
-	APIGroup  string
-	Kind      string
-	Namespace string
-	Name      string
+	APIGroup string
+	Kind     string
+	Name     string
 }
 
 type Value interface {
@@ -74,7 +73,6 @@ func (c *Cache) Keys() []Key {
 	sort.Slice(result, func(i, j int) bool {
 		return result[i].APIGroup < result[j].APIGroup ||
 			result[i].Kind < result[j].Kind ||
-			result[i].Namespace < result[j].Namespace ||
 			result[i].Name < result[j].Name
 	})
 	return result
@@ -83,9 +81,8 @@ func (c *Cache) Keys() []Key {
 func (c *Cache) AuthenticateTokenCredentialRequest(ctx context.Context, req *loginapi.TokenCredentialRequest) (user.Info, error) {
 	// Map the incoming request to a cache key.
 	key := Key{
-		Namespace: req.Namespace,
-		Name:      req.Spec.Authenticator.Name,
-		Kind:      req.Spec.Authenticator.Kind,
+		Name: req.Spec.Authenticator.Name,
+		Kind: req.Spec.Authenticator.Kind,
 	}
 	if req.Spec.Authenticator.APIGroup != nil {
 		key.APIGroup = *req.Spec.Authenticator.APIGroup
@@ -95,7 +92,7 @@ func (c *Cache) AuthenticateTokenCredentialRequest(ctx context.Context, req *log
 	if val == nil {
 		plog.Debug(
 			"authenticator does not exist",
-			"authenticator", klog.KRef(key.Namespace, key.Name),
+			"authenticator", klog.KRef("", key.Name),
 			"kind", key.Kind,
 			"apiGroup", key.APIGroup,
 		)

--- a/internal/controller/authenticator/authncache/cache_test.go
+++ b/internal/controller/authenticator/authncache/cache_test.go
@@ -31,13 +31,13 @@ func TestCache(t *testing.T) {
 	cache := New()
 	require.NotNil(t, cache)
 
-	key1 := Key{Namespace: "foo", Name: "authenticator-one"}
+	key1 := Key{Name: "authenticator-one"}
 	mockToken1 := mocktokenauthenticator.NewMockToken(ctrl)
 	cache.Store(key1, mockToken1)
 	require.Equal(t, mockToken1, cache.Get(key1))
 	require.Equal(t, 1, len(cache.Keys()))
 
-	key2 := Key{Namespace: "foo", Name: "authenticator-two"}
+	key2 := Key{Name: "authenticator-two"}
 	mockToken2 := mocktokenauthenticator.NewMockToken(ctrl)
 	cache.Store(key2, mockToken2)
 	require.Equal(t, mockToken2, cache.Get(key2))
@@ -50,11 +50,10 @@ func TestCache(t *testing.T) {
 
 	// Fill the cache back up with a fixed set of keys, but inserted in shuffled order.
 	keysInExpectedOrder := []Key{
-		{APIGroup: "a", Kind: "a", Namespace: "a", Name: "a"},
-		{APIGroup: "b", Kind: "a", Namespace: "a", Name: "a"},
-		{APIGroup: "b", Kind: "b", Namespace: "a", Name: "a"},
-		{APIGroup: "b", Kind: "b", Namespace: "b", Name: "a"},
-		{APIGroup: "b", Kind: "b", Namespace: "b", Name: "b"},
+		{APIGroup: "a", Kind: "a", Name: "a"},
+		{APIGroup: "b", Kind: "a", Name: "a"},
+		{APIGroup: "b", Kind: "b", Name: "a"},
+		{APIGroup: "b", Kind: "b", Name: "b"},
 	}
 	for tries := 0; tries < 10; tries++ {
 		cache := New()
@@ -85,10 +84,9 @@ func TestAuthenticateTokenCredentialRequest(t *testing.T) {
 		Status: loginapi.TokenCredentialRequestStatus{},
 	}
 	validRequestKey := Key{
-		APIGroup:  *validRequest.Spec.Authenticator.APIGroup,
-		Kind:      validRequest.Spec.Authenticator.Kind,
-		Namespace: validRequest.Namespace,
-		Name:      validRequest.Spec.Authenticator.Name,
+		APIGroup: *validRequest.Spec.Authenticator.APIGroup,
+		Kind:     validRequest.Spec.Authenticator.Kind,
+		Name:     validRequest.Spec.Authenticator.Name,
 	}
 
 	mockCache := func(t *testing.T, res *authenticator.Response, authenticated bool, err error) *Cache {

--- a/internal/controller/authenticator/cachecleaner/cachecleaner.go
+++ b/internal/controller/authenticator/cachecleaner/cachecleaner.go
@@ -72,19 +72,17 @@ func (c *controller) Sync(_ controllerlib.Context) error {
 	authenticatorSet := map[authncache.Key]bool{}
 	for _, webhook := range webhooks {
 		key := authncache.Key{
-			Namespace: webhook.Namespace,
-			Name:      webhook.Name,
-			Kind:      "WebhookAuthenticator",
-			APIGroup:  auth1alpha1.SchemeGroupVersion.Group,
+			Name:     webhook.Name,
+			Kind:     "WebhookAuthenticator",
+			APIGroup: auth1alpha1.SchemeGroupVersion.Group,
 		}
 		authenticatorSet[key] = true
 	}
 	for _, jwtAuthenticator := range jwtAuthenticators {
 		key := authncache.Key{
-			Namespace: jwtAuthenticator.Namespace,
-			Name:      jwtAuthenticator.Name,
-			Kind:      "JWTAuthenticator",
-			APIGroup:  auth1alpha1.SchemeGroupVersion.Group,
+			Name:     jwtAuthenticator.Name,
+			Kind:     "JWTAuthenticator",
+			APIGroup: auth1alpha1.SchemeGroupVersion.Group,
 		}
 		authenticatorSet[key] = true
 	}
@@ -97,7 +95,7 @@ func (c *controller) Sync(_ controllerlib.Context) error {
 		if _, exists := authenticatorSet[key]; !exists {
 			c.log.WithValues(
 				"authenticator",
-				klog.KRef(key.Namespace, key.Name),
+				klog.KRef("", key.Name),
 				"kind",
 				key.Kind,
 			).Info("deleting authenticator from cache")

--- a/internal/controller/authenticator/cachecleaner/cachecleaner_test.go
+++ b/internal/controller/authenticator/cachecleaner/cachecleaner_test.go
@@ -26,34 +26,29 @@ func TestController(t *testing.T) {
 	t.Parallel()
 
 	testWebhookKey1 := authncache.Key{
-		APIGroup:  "authentication.concierge.pinniped.dev",
-		Kind:      "WebhookAuthenticator",
-		Namespace: "test-namespace",
-		Name:      "test-webhook-name-one",
+		APIGroup: "authentication.concierge.pinniped.dev",
+		Kind:     "WebhookAuthenticator",
+		Name:     "test-webhook-name-one",
 	}
 	testWebhookKey2 := authncache.Key{
-		APIGroup:  "authentication.concierge.pinniped.dev",
-		Kind:      "WebhookAuthenticator",
-		Namespace: "test-namespace",
-		Name:      "test-webhook-name-two",
+		APIGroup: "authentication.concierge.pinniped.dev",
+		Kind:     "WebhookAuthenticator",
+		Name:     "test-webhook-name-two",
 	}
 	testJWTAuthenticatorKey1 := authncache.Key{
-		APIGroup:  "authentication.concierge.pinniped.dev",
-		Kind:      "JWTAuthenticator",
-		Namespace: "test-namespace",
-		Name:      "test-jwt-authenticator-name-one",
+		APIGroup: "authentication.concierge.pinniped.dev",
+		Kind:     "JWTAuthenticator",
+		Name:     "test-jwt-authenticator-name-one",
 	}
 	testJWTAuthenticatorKey2 := authncache.Key{
-		APIGroup:  "authentication.concierge.pinniped.dev",
-		Kind:      "JWTAuthenticator",
-		Namespace: "test-namespace",
-		Name:      "test-jwt-authenticator-name-two",
+		APIGroup: "authentication.concierge.pinniped.dev",
+		Kind:     "JWTAuthenticator",
+		Name:     "test-jwt-authenticator-name-two",
 	}
 	testKeyUnknownType := authncache.Key{
-		APIGroup:  "authentication.concierge.pinniped.dev",
-		Kind:      "SomeOtherAuthenticator",
-		Namespace: "test-namespace",
-		Name:      "test-name-one",
+		APIGroup: "authentication.concierge.pinniped.dev",
+		Kind:     "SomeOtherAuthenticator",
+		Name:     "test-name-one",
 	}
 
 	tests := []struct {
@@ -73,14 +68,12 @@ func TestController(t *testing.T) {
 			objects: []runtime.Object{
 				&authv1alpha.WebhookAuthenticator{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: testWebhookKey1.Namespace,
-						Name:      testWebhookKey1.Name,
+						Name: testWebhookKey1.Name,
 					},
 				},
 				&authv1alpha.JWTAuthenticator{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: testJWTAuthenticatorKey1.Namespace,
-						Name:      testJWTAuthenticatorKey1.Name,
+						Name: testJWTAuthenticatorKey1.Name,
 					},
 				},
 			},
@@ -91,26 +84,22 @@ func TestController(t *testing.T) {
 			objects: []runtime.Object{
 				&authv1alpha.WebhookAuthenticator{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: testWebhookKey1.Namespace,
-						Name:      testWebhookKey1.Name,
+						Name: testWebhookKey1.Name,
 					},
 				},
 				&authv1alpha.WebhookAuthenticator{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: testWebhookKey2.Namespace,
-						Name:      testWebhookKey2.Name,
+						Name: testWebhookKey2.Name,
 					},
 				},
 				&authv1alpha.JWTAuthenticator{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: testJWTAuthenticatorKey1.Namespace,
-						Name:      testJWTAuthenticatorKey1.Name,
+						Name: testJWTAuthenticatorKey1.Name,
 					},
 				},
 				&authv1alpha.JWTAuthenticator{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: testJWTAuthenticatorKey2.Namespace,
-						Name:      testJWTAuthenticatorKey2.Name,
+						Name: testJWTAuthenticatorKey2.Name,
 					},
 				},
 			},
@@ -128,20 +117,18 @@ func TestController(t *testing.T) {
 			objects: []runtime.Object{
 				&authv1alpha.WebhookAuthenticator{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: testWebhookKey1.Namespace,
-						Name:      testWebhookKey1.Name,
+						Name: testWebhookKey1.Name,
 					},
 				},
 				&authv1alpha.JWTAuthenticator{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: testJWTAuthenticatorKey1.Namespace,
-						Name:      testJWTAuthenticatorKey1.Name,
+						Name: testJWTAuthenticatorKey1.Name,
 					},
 				},
 			},
 			wantLogs: []string{
-				`cachecleaner-controller "level"=0 "msg"="deleting authenticator from cache" "authenticator"={"name":"test-jwt-authenticator-name-two","namespace":"test-namespace"} "kind"="JWTAuthenticator"`,
-				`cachecleaner-controller "level"=0 "msg"="deleting authenticator from cache" "authenticator"={"name":"test-webhook-name-two","namespace":"test-namespace"} "kind"="WebhookAuthenticator"`,
+				`cachecleaner-controller "level"=0 "msg"="deleting authenticator from cache" "authenticator"={"name":"test-jwt-authenticator-name-two"} "kind"="JWTAuthenticator"`,
+				`cachecleaner-controller "level"=0 "msg"="deleting authenticator from cache" "authenticator"={"name":"test-webhook-name-two"} "kind"="WebhookAuthenticator"`,
 			},
 			wantCacheKeys: []authncache.Key{testWebhookKey1, testJWTAuthenticatorKey1, testKeyUnknownType},
 		},
@@ -173,8 +160,7 @@ func TestController(t *testing.T) {
 			syncCtx := controllerlib.Context{
 				Context: ctx,
 				Key: controllerlib.Key{
-					Namespace: "test-namespace",
-					Name:      "test-webhook-name-one",
+					Name: "test-webhook-name-one",
 				},
 			}
 

--- a/internal/controller/authenticator/jwtcachefiller/jwtcachefiller.go
+++ b/internal/controller/authenticator/jwtcachefiller/jwtcachefiller.go
@@ -88,7 +88,7 @@ type controller struct {
 
 // Sync implements controllerlib.Syncer.
 func (c *controller) Sync(ctx controllerlib.Context) error {
-	obj, err := c.jwtAuthenticators.Lister().JWTAuthenticators(ctx.Key.Namespace).Get(ctx.Key.Name)
+	obj, err := c.jwtAuthenticators.Lister().Get(ctx.Key.Name)
 	if err != nil && errors.IsNotFound(err) {
 		c.log.Info("Sync() found that the JWTAuthenticator does not exist yet or was deleted")
 		return nil

--- a/internal/controller/authenticator/jwtcachefiller/jwtcachefiller.go
+++ b/internal/controller/authenticator/jwtcachefiller/jwtcachefiller.go
@@ -98,10 +98,9 @@ func (c *controller) Sync(ctx controllerlib.Context) error {
 	}
 
 	cacheKey := authncache.Key{
-		APIGroup:  auth1alpha1.GroupName,
-		Kind:      "JWTAuthenticator",
-		Namespace: ctx.Key.Namespace,
-		Name:      ctx.Key.Name,
+		APIGroup: auth1alpha1.GroupName,
+		Kind:     "JWTAuthenticator",
+		Name:     ctx.Key.Name,
 	}
 
 	// If this authenticator already exists, then only recreate it if is different from the desired

--- a/internal/controller/authenticator/jwtcachefiller/jwtcachefiller_test.go
+++ b/internal/controller/authenticator/jwtcachefiller/jwtcachefiller_test.go
@@ -356,10 +356,9 @@ func TestController(t *testing.T) {
 
 			// We expected the cache to have an entry, so pull that entry from the cache and test it.
 			expectedCacheKey := authncache.Key{
-				APIGroup:  auth1alpha1.GroupName,
-				Kind:      "JWTAuthenticator",
-				Namespace: syncCtx.Key.Namespace,
-				Name:      syncCtx.Key.Name,
+				APIGroup: auth1alpha1.GroupName,
+				Kind:     "JWTAuthenticator",
+				Name:     syncCtx.Key.Name,
 			}
 			cachedAuthenticator := cache.Get(expectedCacheKey)
 			require.NotNil(t, cachedAuthenticator)

--- a/internal/controller/authenticator/jwtcachefiller/jwtcachefiller_test.go
+++ b/internal/controller/authenticator/jwtcachefiller/jwtcachefiller_test.go
@@ -135,43 +135,41 @@ func TestController(t *testing.T) {
 	}{
 		{
 			name:    "not found",
-			syncKey: controllerlib.Key{Namespace: "test-namespace", Name: "test-name"},
+			syncKey: controllerlib.Key{Name: "test-name"},
 			wantLogs: []string{
 				`jwtcachefiller-controller "level"=0 "msg"="Sync() found that the JWTAuthenticator does not exist yet or was deleted"`,
 			},
 		},
 		{
 			name:    "valid jwt authenticator with CA",
-			syncKey: controllerlib.Key{Namespace: "test-namespace", Name: "test-name"},
+			syncKey: controllerlib.Key{Name: "test-name"},
 			jwtAuthenticators: []runtime.Object{
 				&auth1alpha1.JWTAuthenticator{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "test-namespace",
-						Name:      "test-name",
+						Name: "test-name",
 					},
 					Spec: *someJWTAuthenticatorSpec,
 				},
 			},
 			wantLogs: []string{
-				`jwtcachefiller-controller "level"=0 "msg"="added new jwt authenticator" "issuer"="` + goodIssuer + `" "jwtAuthenticator"={"name":"test-name","namespace":"test-namespace"}`,
+				`jwtcachefiller-controller "level"=0 "msg"="added new jwt authenticator" "issuer"="` + goodIssuer + `" "jwtAuthenticator"={"name":"test-name"}`,
 			},
 			wantCacheEntries:                 1,
 			runTestsOnResultingAuthenticator: true,
 		},
 		{
 			name:    "valid jwt authenticator with custom username claim",
-			syncKey: controllerlib.Key{Namespace: "test-namespace", Name: "test-name"},
+			syncKey: controllerlib.Key{Name: "test-name"},
 			jwtAuthenticators: []runtime.Object{
 				&auth1alpha1.JWTAuthenticator{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "test-namespace",
-						Name:      "test-name",
+						Name: "test-name",
 					},
 					Spec: *someJWTAuthenticatorSpecWithUsernameClaim,
 				},
 			},
 			wantLogs: []string{
-				`jwtcachefiller-controller "level"=0 "msg"="added new jwt authenticator" "issuer"="` + goodIssuer + `" "jwtAuthenticator"={"name":"test-name","namespace":"test-namespace"}`,
+				`jwtcachefiller-controller "level"=0 "msg"="added new jwt authenticator" "issuer"="` + goodIssuer + `" "jwtAuthenticator"={"name":"test-name"}`,
 			},
 			wantCacheEntries:                 1,
 			wantUsernameClaim:                someJWTAuthenticatorSpecWithUsernameClaim.Claims.Username,
@@ -179,18 +177,17 @@ func TestController(t *testing.T) {
 		},
 		{
 			name:    "valid jwt authenticator with custom groups claim",
-			syncKey: controllerlib.Key{Namespace: "test-namespace", Name: "test-name"},
+			syncKey: controllerlib.Key{Name: "test-name"},
 			jwtAuthenticators: []runtime.Object{
 				&auth1alpha1.JWTAuthenticator{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "test-namespace",
-						Name:      "test-name",
+						Name: "test-name",
 					},
 					Spec: *someJWTAuthenticatorSpecWithGroupsClaim,
 				},
 			},
 			wantLogs: []string{
-				`jwtcachefiller-controller "level"=0 "msg"="added new jwt authenticator" "issuer"="` + goodIssuer + `" "jwtAuthenticator"={"name":"test-name","namespace":"test-namespace"}`,
+				`jwtcachefiller-controller "level"=0 "msg"="added new jwt authenticator" "issuer"="` + goodIssuer + `" "jwtAuthenticator"={"name":"test-name"}`,
 			},
 			wantCacheEntries:                 1,
 			wantGroupsClaim:                  someJWTAuthenticatorSpecWithGroupsClaim.Claims.Groups,
@@ -201,27 +198,25 @@ func TestController(t *testing.T) {
 			cache: func(t *testing.T, cache *authncache.Cache, wantClose bool) {
 				cache.Store(
 					authncache.Key{
-						Name:      "test-name",
-						Namespace: "test-namespace",
-						Kind:      "JWTAuthenticator",
-						APIGroup:  auth1alpha1.SchemeGroupVersion.Group,
+						Name:     "test-name",
+						Kind:     "JWTAuthenticator",
+						APIGroup: auth1alpha1.SchemeGroupVersion.Group,
 					},
 					newCacheValue(t, *otherJWTAuthenticatorSpec, wantClose),
 				)
 			},
 			wantClose: true,
-			syncKey:   controllerlib.Key{Namespace: "test-namespace", Name: "test-name"},
+			syncKey:   controllerlib.Key{Name: "test-name"},
 			jwtAuthenticators: []runtime.Object{
 				&auth1alpha1.JWTAuthenticator{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "test-namespace",
-						Name:      "test-name",
+						Name: "test-name",
 					},
 					Spec: *someJWTAuthenticatorSpec,
 				},
 			},
 			wantLogs: []string{
-				`jwtcachefiller-controller "level"=0 "msg"="added new jwt authenticator" "issuer"="` + goodIssuer + `" "jwtAuthenticator"={"name":"test-name","namespace":"test-namespace"}`,
+				`jwtcachefiller-controller "level"=0 "msg"="added new jwt authenticator" "issuer"="` + goodIssuer + `" "jwtAuthenticator"={"name":"test-name"}`,
 			},
 			wantCacheEntries:                 1,
 			runTestsOnResultingAuthenticator: true,
@@ -231,27 +226,25 @@ func TestController(t *testing.T) {
 			cache: func(t *testing.T, cache *authncache.Cache, wantClose bool) {
 				cache.Store(
 					authncache.Key{
-						Name:      "test-name",
-						Namespace: "test-namespace",
-						Kind:      "JWTAuthenticator",
-						APIGroup:  auth1alpha1.SchemeGroupVersion.Group,
+						Name:     "test-name",
+						Kind:     "JWTAuthenticator",
+						APIGroup: auth1alpha1.SchemeGroupVersion.Group,
 					},
 					newCacheValue(t, *someJWTAuthenticatorSpec, wantClose),
 				)
 			},
 			wantClose: false,
-			syncKey:   controllerlib.Key{Namespace: "test-namespace", Name: "test-name"},
+			syncKey:   controllerlib.Key{Name: "test-name"},
 			jwtAuthenticators: []runtime.Object{
 				&auth1alpha1.JWTAuthenticator{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "test-namespace",
-						Name:      "test-name",
+						Name: "test-name",
 					},
 					Spec: *someJWTAuthenticatorSpec,
 				},
 			},
 			wantLogs: []string{
-				`jwtcachefiller-controller "level"=0 "msg"="actual jwt authenticator and desired jwt authenticator are the same" "issuer"="` + goodIssuer + `" "jwtAuthenticator"={"name":"test-name","namespace":"test-namespace"}`,
+				`jwtcachefiller-controller "level"=0 "msg"="actual jwt authenticator and desired jwt authenticator are the same" "issuer"="` + goodIssuer + `" "jwtAuthenticator"={"name":"test-name"}`,
 			},
 			wantCacheEntries:                 1,
 			runTestsOnResultingAuthenticator: false, // skip the tests because the authenticator left in the cache is the mock version that was added above
@@ -261,57 +254,53 @@ func TestController(t *testing.T) {
 			cache: func(t *testing.T, cache *authncache.Cache, wantClose bool) {
 				cache.Store(
 					authncache.Key{
-						Name:      "test-name",
-						Namespace: "test-namespace",
-						Kind:      "JWTAuthenticator",
-						APIGroup:  auth1alpha1.SchemeGroupVersion.Group,
+						Name:     "test-name",
+						Kind:     "JWTAuthenticator",
+						APIGroup: auth1alpha1.SchemeGroupVersion.Group,
 					},
 					struct{ authenticator.Token }{},
 				)
 			},
-			syncKey: controllerlib.Key{Namespace: "test-namespace", Name: "test-name"},
+			syncKey: controllerlib.Key{Name: "test-name"},
 			jwtAuthenticators: []runtime.Object{
 				&auth1alpha1.JWTAuthenticator{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "test-namespace",
-						Name:      "test-name",
+						Name: "test-name",
 					},
 					Spec: *someJWTAuthenticatorSpec,
 				},
 			},
 			wantLogs: []string{
 				`jwtcachefiller-controller "level"=0 "msg"="wrong JWT authenticator type in cache" "actualType"="struct { authenticator.Token }"`,
-				`jwtcachefiller-controller "level"=0 "msg"="added new jwt authenticator" "issuer"="` + goodIssuer + `" "jwtAuthenticator"={"name":"test-name","namespace":"test-namespace"}`,
+				`jwtcachefiller-controller "level"=0 "msg"="added new jwt authenticator" "issuer"="` + goodIssuer + `" "jwtAuthenticator"={"name":"test-name"}`,
 			},
 			wantCacheEntries:                 1,
 			runTestsOnResultingAuthenticator: true,
 		},
 		{
 			name:    "valid jwt authenticator without CA",
-			syncKey: controllerlib.Key{Namespace: "test-namespace", Name: "test-name"},
+			syncKey: controllerlib.Key{Name: "test-name"},
 			jwtAuthenticators: []runtime.Object{
 				&auth1alpha1.JWTAuthenticator{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "test-namespace",
-						Name:      "test-name",
+						Name: "test-name",
 					},
 					Spec: *missingTLSJWTAuthenticatorSpec,
 				},
 			},
 			wantLogs: []string{
-				`jwtcachefiller-controller "level"=0 "msg"="added new jwt authenticator" "issuer"="` + goodIssuer + `" "jwtAuthenticator"={"name":"test-name","namespace":"test-namespace"}`,
+				`jwtcachefiller-controller "level"=0 "msg"="added new jwt authenticator" "issuer"="` + goodIssuer + `" "jwtAuthenticator"={"name":"test-name"}`,
 			},
 			wantCacheEntries:                 1,
 			runTestsOnResultingAuthenticator: false, // skip the tests because the authenticator left in the cache doesn't have the CA for our test discovery server
 		},
 		{
 			name:    "invalid jwt authenticator CA",
-			syncKey: controllerlib.Key{Namespace: "test-namespace", Name: "test-name"},
+			syncKey: controllerlib.Key{Name: "test-name"},
 			jwtAuthenticators: []runtime.Object{
 				&auth1alpha1.JWTAuthenticator{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "test-namespace",
-						Name:      "test-name",
+						Name: "test-name",
 					},
 					Spec: *invalidTLSJWTAuthenticatorSpec,
 				},

--- a/internal/controller/authenticator/webhookcachefiller/webhookcachefiller.go
+++ b/internal/controller/authenticator/webhookcachefiller/webhookcachefiller.go
@@ -69,10 +69,9 @@ func (c *controller) Sync(ctx controllerlib.Context) error {
 	}
 
 	c.cache.Store(authncache.Key{
-		APIGroup:  auth1alpha1.GroupName,
-		Kind:      "WebhookAuthenticator",
-		Namespace: ctx.Key.Namespace,
-		Name:      ctx.Key.Name,
+		APIGroup: auth1alpha1.GroupName,
+		Kind:     "WebhookAuthenticator",
+		Name:     ctx.Key.Name,
 	}, webhookAuthenticator)
 	c.log.WithValues("webhook", klog.KObj(obj), "endpoint", obj.Spec.Endpoint).Info("added new webhook authenticator")
 	return nil

--- a/internal/controller/authenticator/webhookcachefiller/webhookcachefiller.go
+++ b/internal/controller/authenticator/webhookcachefiller/webhookcachefiller.go
@@ -54,7 +54,7 @@ type controller struct {
 
 // Sync implements controllerlib.Syncer.
 func (c *controller) Sync(ctx controllerlib.Context) error {
-	obj, err := c.webhooks.Lister().WebhookAuthenticators(ctx.Key.Namespace).Get(ctx.Key.Name)
+	obj, err := c.webhooks.Lister().Get(ctx.Key.Name)
 	if err != nil && errors.IsNotFound(err) {
 		c.log.Info("Sync() found that the WebhookAuthenticator does not exist yet or was deleted")
 		return nil

--- a/internal/controller/authenticator/webhookcachefiller/webhookcachefiller_test.go
+++ b/internal/controller/authenticator/webhookcachefiller/webhookcachefiller_test.go
@@ -41,19 +41,18 @@ func TestController(t *testing.T) {
 	}{
 		{
 			name:    "not found",
-			syncKey: controllerlib.Key{Namespace: "test-namespace", Name: "test-name"},
+			syncKey: controllerlib.Key{Name: "test-name"},
 			wantLogs: []string{
 				`webhookcachefiller-controller "level"=0 "msg"="Sync() found that the WebhookAuthenticator does not exist yet or was deleted"`,
 			},
 		},
 		{
 			name:    "invalid webhook",
-			syncKey: controllerlib.Key{Namespace: "test-namespace", Name: "test-name"},
+			syncKey: controllerlib.Key{Name: "test-name"},
 			webhooks: []runtime.Object{
 				&auth1alpha1.WebhookAuthenticator{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "test-namespace",
-						Name:      "test-name",
+						Name: "test-name",
 					},
 					Spec: auth1alpha1.WebhookAuthenticatorSpec{
 						Endpoint: "invalid url",
@@ -64,12 +63,11 @@ func TestController(t *testing.T) {
 		},
 		{
 			name:    "valid webhook",
-			syncKey: controllerlib.Key{Namespace: "test-namespace", Name: "test-name"},
+			syncKey: controllerlib.Key{Name: "test-name"},
 			webhooks: []runtime.Object{
 				&auth1alpha1.WebhookAuthenticator{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "test-namespace",
-						Name:      "test-name",
+						Name: "test-name",
 					},
 					Spec: auth1alpha1.WebhookAuthenticatorSpec{
 						Endpoint: "https://example.com",
@@ -78,7 +76,7 @@ func TestController(t *testing.T) {
 				},
 			},
 			wantLogs: []string{
-				`webhookcachefiller-controller "level"=0 "msg"="added new webhook authenticator" "endpoint"="https://example.com" "webhook"={"name":"test-name","namespace":"test-namespace"}`,
+				`webhookcachefiller-controller "level"=0 "msg"="added new webhook authenticator" "endpoint"="https://example.com" "webhook"={"name":"test-name"}`,
 			},
 			wantCacheEntries: 1,
 		},

--- a/internal/controller/issuerconfig/create_or_update_credential_issuer_config.go
+++ b/internal/controller/issuerconfig/create_or_update_credential_issuer_config.go
@@ -19,7 +19,6 @@ import (
 
 func CreateOrUpdateCredentialIssuer(
 	ctx context.Context,
-	credentialIssuerNamespace string,
 	credentialIssuerResourceName string,
 	credentialIssuerLabels map[string]string,
 	pinnipedClient pinnipedclientset.Interface,
@@ -28,7 +27,7 @@ func CreateOrUpdateCredentialIssuer(
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		existingCredentialIssuer, err := pinnipedClient.
 			ConfigV1alpha1().
-			CredentialIssuers(credentialIssuerNamespace).
+			CredentialIssuers().
 			Get(ctx, credentialIssuerResourceName, metav1.GetOptions{})
 
 		notFound := k8serrors.IsNotFound(err)
@@ -36,12 +35,12 @@ func CreateOrUpdateCredentialIssuer(
 			return fmt.Errorf("get failed: %w", err)
 		}
 
-		credentialIssuersClient := pinnipedClient.ConfigV1alpha1().CredentialIssuers(credentialIssuerNamespace)
+		credentialIssuersClient := pinnipedClient.ConfigV1alpha1().CredentialIssuers()
 
 		if notFound {
 			// Create it
 			credentialIssuer := minimalValidCredentialIssuer(
-				credentialIssuerResourceName, credentialIssuerNamespace, credentialIssuerLabels,
+				credentialIssuerResourceName, credentialIssuerLabels,
 			)
 			applyUpdatesToCredentialIssuerFunc(credentialIssuer)
 
@@ -73,15 +72,13 @@ func CreateOrUpdateCredentialIssuer(
 
 func minimalValidCredentialIssuer(
 	credentialIssuerName string,
-	credentialIssuerNamespace string,
 	credentialIssuerLabels map[string]string,
 ) *configv1alpha1.CredentialIssuer {
 	return &configv1alpha1.CredentialIssuer{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      credentialIssuerName,
-			Namespace: credentialIssuerNamespace,
-			Labels:    credentialIssuerLabels,
+			Name:   credentialIssuerName,
+			Labels: credentialIssuerLabels,
 		},
 		Status: configv1alpha1.CredentialIssuerStatus{
 			Strategies:     []configv1alpha1.CredentialIssuerStrategy{},

--- a/internal/controller/issuerconfig/create_or_update_credential_issuer_config.go
+++ b/internal/controller/issuerconfig/create_or_update_credential_issuer_config.go
@@ -17,12 +17,12 @@ import (
 	pinnipedclientset "go.pinniped.dev/generated/1.20/client/concierge/clientset/versioned"
 )
 
-func CreateOrUpdateCredentialIssuer(
+func CreateOrUpdateCredentialIssuerStatus(
 	ctx context.Context,
 	credentialIssuerResourceName string,
 	credentialIssuerLabels map[string]string,
 	pinnipedClient pinnipedclientset.Interface,
-	applyUpdatesToCredentialIssuerFunc func(configToUpdate *configv1alpha1.CredentialIssuer),
+	applyUpdatesToCredentialIssuerFunc func(configToUpdate *configv1alpha1.CredentialIssuerStatus),
 ) error {
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		existingCredentialIssuer, err := pinnipedClient.
@@ -38,29 +38,30 @@ func CreateOrUpdateCredentialIssuer(
 		credentialIssuersClient := pinnipedClient.ConfigV1alpha1().CredentialIssuers()
 
 		if notFound {
-			// Create it
-			credentialIssuer := minimalValidCredentialIssuer(
-				credentialIssuerResourceName, credentialIssuerLabels,
-			)
-			applyUpdatesToCredentialIssuerFunc(credentialIssuer)
+			// create an empty credential issuer
+			minCredentialIssuer := minimalValidCredentialIssuer(credentialIssuerResourceName, credentialIssuerLabels)
 
-			if _, err := credentialIssuersClient.Create(ctx, credentialIssuer, metav1.CreateOptions{}); err != nil {
+			newCredentialIssuer, err := credentialIssuersClient.Create(ctx, minCredentialIssuer, metav1.CreateOptions{})
+			if err != nil {
 				return fmt.Errorf("create failed: %w", err)
 			}
-		} else {
-			// Already exists, so check to see if we need to update it
-			credentialIssuer := existingCredentialIssuer.DeepCopy()
-			applyUpdatesToCredentialIssuerFunc(credentialIssuer)
 
-			if equality.Semantic.DeepEqual(existingCredentialIssuer, credentialIssuer) {
-				// Nothing interesting would change as a result of this update, so skip it
-				return nil
-			}
-
-			if _, err := credentialIssuersClient.Update(ctx, credentialIssuer, metav1.UpdateOptions{}); err != nil {
-				return err
-			}
+			existingCredentialIssuer = newCredentialIssuer
 		}
+
+		// check to see if we need to update the status
+		credentialIssuer := existingCredentialIssuer.DeepCopy()
+		applyUpdatesToCredentialIssuerFunc(&credentialIssuer.Status)
+
+		if equality.Semantic.DeepEqual(existingCredentialIssuer, credentialIssuer) {
+			// Nothing interesting would change as a result of this update, so skip it
+			return nil
+		}
+
+		if _, err := credentialIssuersClient.UpdateStatus(ctx, credentialIssuer, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+
 		return nil
 	})
 
@@ -79,10 +80,6 @@ func minimalValidCredentialIssuer(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   credentialIssuerName,
 			Labels: credentialIssuerLabels,
-		},
-		Status: configv1alpha1.CredentialIssuerStatus{
-			Strategies:     []configv1alpha1.CredentialIssuerStrategy{},
-			KubeConfigInfo: nil,
 		},
 	}
 }

--- a/internal/controller/issuerconfig/kube_config_info_publisher.go
+++ b/internal/controller/issuerconfig/kube_config_info_publisher.go
@@ -104,14 +104,14 @@ func (c *kubeConigInfoPublisherController) Sync(ctx controllerlib.Context) error
 		server = *c.serverOverride
 	}
 
-	updateServerAndCAFunc := func(c *configv1alpha1.CredentialIssuer) {
-		c.Status.KubeConfigInfo = &configv1alpha1.CredentialIssuerKubeConfigInfo{
+	updateServerAndCAFunc := func(c *configv1alpha1.CredentialIssuerStatus) {
+		c.KubeConfigInfo = &configv1alpha1.CredentialIssuerKubeConfigInfo{
 			Server:                   server,
 			CertificateAuthorityData: certificateAuthorityData,
 		}
 	}
 
-	return CreateOrUpdateCredentialIssuer(
+	return CreateOrUpdateCredentialIssuerStatus(
 		ctx.Context,
 		c.credentialIssuerResourceName,
 		c.credentialIssuerLabels,

--- a/internal/controller/issuerconfig/kube_config_info_publisher.go
+++ b/internal/controller/issuerconfig/kube_config_info_publisher.go
@@ -26,19 +26,17 @@ const (
 )
 
 type kubeConigInfoPublisherController struct {
-	credentialIssuerNamespaceName string
-	credentialIssuerResourceName  string
-	credentialIssuerLabels        map[string]string
-	serverOverride                *string
-	pinnipedClient                pinnipedclientset.Interface
-	configMapInformer             corev1informers.ConfigMapInformer
+	credentialIssuerResourceName string
+	credentialIssuerLabels       map[string]string
+	serverOverride               *string
+	pinnipedClient               pinnipedclientset.Interface
+	configMapInformer            corev1informers.ConfigMapInformer
 }
 
 // NewKubeConfigInfoPublisherController returns a controller that syncs the
 // configv1alpha1.CredentialIssuer.Status.KubeConfigInfo field with the cluster-info ConfigMap
 // in the kube-public namespace.
 func NewKubeConfigInfoPublisherController(
-	credentialIssuerNamespaceName string,
 	credentialIssuerResourceName string,
 	credentialIssuerLabels map[string]string,
 	serverOverride *string,
@@ -50,12 +48,11 @@ func NewKubeConfigInfoPublisherController(
 		controllerlib.Config{
 			Name: "publisher-controller",
 			Syncer: &kubeConigInfoPublisherController{
-				credentialIssuerResourceName:  credentialIssuerResourceName,
-				credentialIssuerNamespaceName: credentialIssuerNamespaceName,
-				credentialIssuerLabels:        credentialIssuerLabels,
-				serverOverride:                serverOverride,
-				pinnipedClient:                pinnipedClient,
-				configMapInformer:             configMapInformer,
+				credentialIssuerResourceName: credentialIssuerResourceName,
+				credentialIssuerLabels:       credentialIssuerLabels,
+				serverOverride:               serverOverride,
+				pinnipedClient:               pinnipedClient,
+				configMapInformer:            configMapInformer,
 			},
 		},
 		withInformer(
@@ -116,7 +113,6 @@ func (c *kubeConigInfoPublisherController) Sync(ctx controllerlib.Context) error
 
 	return CreateOrUpdateCredentialIssuer(
 		ctx.Context,
-		c.credentialIssuerNamespaceName,
 		c.credentialIssuerResourceName,
 		c.credentialIssuerLabels,
 		c.pinnipedClient,

--- a/internal/controller/kubecertagent/annotater_test.go
+++ b/internal/controller/kubecertagent/annotater_test.go
@@ -59,7 +59,6 @@ func TestAnnotaterControllerSync(t *testing.T) {
 		const agentPodNamespace = "agent-pod-namespace"
 		const defaultKubeControllerManagerClusterSigningCertFileFlagValue = "/etc/kubernetes/ca/ca.pem"
 		const defaultKubeControllerManagerClusterSigningKeyFileFlagValue = "/etc/kubernetes/ca/ca.key"
-		const credentialIssuerNamespaceName = "ci-namespace-name"
 		const credentialIssuerResourceName = "ci-resource-name"
 
 		const (
@@ -102,8 +101,7 @@ func TestAnnotaterControllerSync(t *testing.T) {
 					},
 				},
 				&CredentialIssuerLocationConfig{
-					Namespace: credentialIssuerNamespaceName,
-					Name:      credentialIssuerResourceName,
+					Name: credentialIssuerResourceName,
 				},
 				clock.NewFakeClock(frozenNow),
 				kubeAPIClient,
@@ -236,8 +234,7 @@ func TestAnnotaterControllerSync(t *testing.T) {
 							initialCredentialIssuer = &configv1alpha1.CredentialIssuer{
 								TypeMeta: metav1.TypeMeta{},
 								ObjectMeta: metav1.ObjectMeta{
-									Name:      credentialIssuerResourceName,
-									Namespace: credentialIssuerNamespaceName,
+									Name: credentialIssuerResourceName,
 								},
 								Status: configv1alpha1.CredentialIssuerStatus{
 									Strategies: []configv1alpha1.CredentialIssuerStrategy{},
@@ -264,14 +261,12 @@ func TestAnnotaterControllerSync(t *testing.T) {
 									LastUpdateTime: metav1.NewTime(frozenNow),
 								},
 							}
-							expectedGetAction := coretesting.NewGetAction(
+							expectedGetAction := coretesting.NewRootGetAction(
 								credentialIssuerGVR,
-								credentialIssuerNamespaceName,
 								credentialIssuerResourceName,
 							)
-							expectedUpdateAction := coretesting.NewUpdateAction(
+							expectedUpdateAction := coretesting.NewRootUpdateAction(
 								credentialIssuerGVR,
-								credentialIssuerNamespaceName,
 								expectedCredentialIssuer,
 							)
 
@@ -312,8 +307,7 @@ func TestAnnotaterControllerSync(t *testing.T) {
 							expectedCredentialIssuer := &configv1alpha1.CredentialIssuer{
 								TypeMeta: metav1.TypeMeta{},
 								ObjectMeta: metav1.ObjectMeta{
-									Name:      credentialIssuerResourceName,
-									Namespace: credentialIssuerNamespaceName,
+									Name: credentialIssuerResourceName,
 								},
 								Status: configv1alpha1.CredentialIssuerStatus{
 									Strategies: []configv1alpha1.CredentialIssuerStrategy{
@@ -327,14 +321,12 @@ func TestAnnotaterControllerSync(t *testing.T) {
 									},
 								},
 							}
-							expectedGetAction := coretesting.NewGetAction(
+							expectedGetAction := coretesting.NewRootGetAction(
 								credentialIssuerGVR,
-								credentialIssuerNamespaceName,
 								credentialIssuerResourceName,
 							)
-							expectedCreateAction := coretesting.NewCreateAction(
+							expectedCreateAction := coretesting.NewRootCreateAction(
 								credentialIssuerGVR,
-								credentialIssuerNamespaceName,
 								expectedCredentialIssuer,
 							)
 

--- a/internal/controller/kubecertagent/annotater_test.go
+++ b/internal/controller/kubecertagent/annotater_test.go
@@ -265,8 +265,9 @@ func TestAnnotaterControllerSync(t *testing.T) {
 								credentialIssuerGVR,
 								credentialIssuerResourceName,
 							)
-							expectedUpdateAction := coretesting.NewRootUpdateAction(
+							expectedUpdateAction := coretesting.NewRootUpdateSubresourceAction(
 								credentialIssuerGVR,
+								"status",
 								expectedCredentialIssuer,
 							)
 
@@ -304,6 +305,13 @@ func TestAnnotaterControllerSync(t *testing.T) {
 							startInformersAndController()
 							err := controllerlib.TestSync(t, subject, *syncContext)
 
+							expectedCreateCredentialIssuer := &configv1alpha1.CredentialIssuer{
+								TypeMeta: metav1.TypeMeta{},
+								ObjectMeta: metav1.ObjectMeta{
+									Name: credentialIssuerResourceName,
+								},
+							}
+
 							expectedCredentialIssuer := &configv1alpha1.CredentialIssuer{
 								TypeMeta: metav1.TypeMeta{},
 								ObjectMeta: metav1.ObjectMeta{
@@ -327,6 +335,11 @@ func TestAnnotaterControllerSync(t *testing.T) {
 							)
 							expectedCreateAction := coretesting.NewRootCreateAction(
 								credentialIssuerGVR,
+								expectedCreateCredentialIssuer,
+							)
+							expectedUpdateAction := coretesting.NewRootUpdateSubresourceAction(
+								credentialIssuerGVR,
+								"status",
 								expectedCredentialIssuer,
 							)
 
@@ -335,6 +348,7 @@ func TestAnnotaterControllerSync(t *testing.T) {
 								[]coretesting.Action{
 									expectedGetAction,
 									expectedCreateAction,
+									expectedUpdateAction,
 								},
 								pinnipedAPIClient.Actions(),
 							)

--- a/internal/controller/kubecertagent/creater_test.go
+++ b/internal/controller/kubecertagent/creater_test.go
@@ -336,8 +336,9 @@ func TestCreaterControllerSync(t *testing.T) {
 								credentialIssuerGVR,
 								credentialIssuerResourceName,
 							)
-							expectedUpdateAction := coretesting.NewRootUpdateAction(
+							expectedUpdateAction := coretesting.NewRootUpdateSubresourceAction(
 								credentialIssuerGVR,
+								"status",
 								expectedCredentialIssuer,
 							)
 
@@ -375,6 +376,17 @@ func TestCreaterControllerSync(t *testing.T) {
 							startInformersAndController()
 							err := controllerlib.TestSync(t, subject, *syncContext)
 
+							expectedCreateCredentialIssuer := &configv1alpha1.CredentialIssuer{
+								TypeMeta: metav1.TypeMeta{},
+								ObjectMeta: metav1.ObjectMeta{
+									Name: credentialIssuerResourceName,
+									Labels: map[string]string{
+										"myLabelKey1": "myLabelValue1",
+										"myLabelKey2": "myLabelValue2",
+									},
+								},
+							}
+
 							expectedCredentialIssuer := &configv1alpha1.CredentialIssuer{
 								TypeMeta: metav1.TypeMeta{},
 								ObjectMeta: metav1.ObjectMeta{
@@ -402,6 +414,11 @@ func TestCreaterControllerSync(t *testing.T) {
 							)
 							expectedCreateAction := coretesting.NewRootCreateAction(
 								credentialIssuerGVR,
+								expectedCreateCredentialIssuer,
+							)
+							expectedUpdateAction := coretesting.NewRootUpdateSubresourceAction(
+								credentialIssuerGVR,
+								"status",
 								expectedCredentialIssuer,
 							)
 
@@ -410,6 +427,7 @@ func TestCreaterControllerSync(t *testing.T) {
 								[]coretesting.Action{
 									expectedGetAction,
 									expectedCreateAction,
+									expectedUpdateAction,
 								},
 								pinnipedAPIClient.Actions(),
 							)
@@ -458,8 +476,9 @@ func TestCreaterControllerSync(t *testing.T) {
 						credentialIssuerGVR,
 						credentialIssuerResourceName,
 					)
-					expectedUpdateAction := coretesting.NewRootUpdateAction(
+					expectedUpdateAction := coretesting.NewRootUpdateSubresourceAction(
 						credentialIssuerGVR,
+						"status",
 						expectedCredentialIssuer,
 					)
 
@@ -514,6 +533,17 @@ func TestCreaterControllerSync(t *testing.T) {
 					startInformersAndController()
 					err := controllerlib.TestSync(t, subject, *syncContext)
 
+					expectedCreateCredentialIssuer := &configv1alpha1.CredentialIssuer{
+						TypeMeta: metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{
+							Name: credentialIssuerResourceName,
+							Labels: map[string]string{
+								"myLabelKey1": "myLabelValue1",
+								"myLabelKey2": "myLabelValue2",
+							},
+						},
+					}
+
 					expectedCredentialIssuer := &configv1alpha1.CredentialIssuer{
 						TypeMeta: metav1.TypeMeta{},
 						ObjectMeta: metav1.ObjectMeta{
@@ -541,6 +571,11 @@ func TestCreaterControllerSync(t *testing.T) {
 					)
 					expectedCreateAction := coretesting.NewRootCreateAction(
 						credentialIssuerGVR,
+						expectedCreateCredentialIssuer,
+					)
+					expectedUpdateAction := coretesting.NewRootUpdateSubresourceAction(
+						credentialIssuerGVR,
+						"status",
 						expectedCredentialIssuer,
 					)
 
@@ -549,6 +584,7 @@ func TestCreaterControllerSync(t *testing.T) {
 						[]coretesting.Action{
 							expectedGetAction,
 							expectedCreateAction,
+							expectedUpdateAction,
 						},
 						pinnipedAPIClient.Actions(),
 					)

--- a/internal/controller/kubecertagent/creater_test.go
+++ b/internal/controller/kubecertagent/creater_test.go
@@ -83,7 +83,6 @@ func TestCreaterControllerSync(t *testing.T) {
 	spec.Run(t, "CreaterControllerSync", func(t *testing.T, when spec.G, it spec.S) {
 		const kubeSystemNamespace = "kube-system"
 		const agentPodNamespace = "agent-pod-namespace"
-		const credentialIssuerNamespaceName = "ci-namespace-name"
 		const credentialIssuerResourceName = "ci-resource-name"
 
 		var r *require.Assertions
@@ -119,8 +118,7 @@ func TestCreaterControllerSync(t *testing.T) {
 					},
 				},
 				&CredentialIssuerLocationConfig{
-					Namespace: credentialIssuerNamespaceName,
-					Name:      credentialIssuerResourceName,
+					Name: credentialIssuerResourceName,
 				},
 				map[string]string{
 					"myLabelKey1": "myLabelValue1",
@@ -307,8 +305,7 @@ func TestCreaterControllerSync(t *testing.T) {
 							initialCredentialIssuer = &configv1alpha1.CredentialIssuer{
 								TypeMeta: metav1.TypeMeta{},
 								ObjectMeta: metav1.ObjectMeta{
-									Name:      credentialIssuerResourceName,
-									Namespace: credentialIssuerNamespaceName,
+									Name: credentialIssuerResourceName,
 								},
 								Status: configv1alpha1.CredentialIssuerStatus{
 									Strategies: []configv1alpha1.CredentialIssuerStrategy{},
@@ -335,14 +332,12 @@ func TestCreaterControllerSync(t *testing.T) {
 									LastUpdateTime: metav1.NewTime(frozenNow),
 								},
 							}
-							expectedGetAction := coretesting.NewGetAction(
+							expectedGetAction := coretesting.NewRootGetAction(
 								credentialIssuerGVR,
-								credentialIssuerNamespaceName,
 								credentialIssuerResourceName,
 							)
-							expectedUpdateAction := coretesting.NewUpdateAction(
+							expectedUpdateAction := coretesting.NewRootUpdateAction(
 								credentialIssuerGVR,
-								credentialIssuerNamespaceName,
 								expectedCredentialIssuer,
 							)
 
@@ -383,8 +378,7 @@ func TestCreaterControllerSync(t *testing.T) {
 							expectedCredentialIssuer := &configv1alpha1.CredentialIssuer{
 								TypeMeta: metav1.TypeMeta{},
 								ObjectMeta: metav1.ObjectMeta{
-									Name:      credentialIssuerResourceName,
-									Namespace: credentialIssuerNamespaceName,
+									Name: credentialIssuerResourceName,
 									Labels: map[string]string{
 										"myLabelKey1": "myLabelValue1",
 										"myLabelKey2": "myLabelValue2",
@@ -402,14 +396,12 @@ func TestCreaterControllerSync(t *testing.T) {
 									},
 								},
 							}
-							expectedGetAction := coretesting.NewGetAction(
+							expectedGetAction := coretesting.NewRootGetAction(
 								credentialIssuerGVR,
-								credentialIssuerNamespaceName,
 								credentialIssuerResourceName,
 							)
-							expectedCreateAction := coretesting.NewCreateAction(
+							expectedCreateAction := coretesting.NewRootCreateAction(
 								credentialIssuerGVR,
-								credentialIssuerNamespaceName,
 								expectedCredentialIssuer,
 							)
 
@@ -435,8 +427,7 @@ func TestCreaterControllerSync(t *testing.T) {
 					initialCredentialIssuer = &configv1alpha1.CredentialIssuer{
 						TypeMeta: metav1.TypeMeta{},
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      credentialIssuerResourceName,
-							Namespace: credentialIssuerNamespaceName,
+							Name: credentialIssuerResourceName,
 						},
 						Status: configv1alpha1.CredentialIssuerStatus{
 							Strategies: []configv1alpha1.CredentialIssuerStrategy{},
@@ -463,14 +454,12 @@ func TestCreaterControllerSync(t *testing.T) {
 							LastUpdateTime: metav1.NewTime(frozenNow),
 						},
 					}
-					expectedGetAction := coretesting.NewGetAction(
+					expectedGetAction := coretesting.NewRootGetAction(
 						credentialIssuerGVR,
-						credentialIssuerNamespaceName,
 						credentialIssuerResourceName,
 					)
-					expectedUpdateAction := coretesting.NewUpdateAction(
+					expectedUpdateAction := coretesting.NewRootUpdateAction(
 						credentialIssuerGVR,
-						credentialIssuerNamespaceName,
 						expectedCredentialIssuer,
 					)
 
@@ -528,8 +517,7 @@ func TestCreaterControllerSync(t *testing.T) {
 					expectedCredentialIssuer := &configv1alpha1.CredentialIssuer{
 						TypeMeta: metav1.TypeMeta{},
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      credentialIssuerResourceName,
-							Namespace: credentialIssuerNamespaceName,
+							Name: credentialIssuerResourceName,
 							Labels: map[string]string{
 								"myLabelKey1": "myLabelValue1",
 								"myLabelKey2": "myLabelValue2",
@@ -547,14 +535,12 @@ func TestCreaterControllerSync(t *testing.T) {
 							},
 						},
 					}
-					expectedGetAction := coretesting.NewGetAction(
+					expectedGetAction := coretesting.NewRootGetAction(
 						credentialIssuerGVR,
-						credentialIssuerNamespaceName,
 						credentialIssuerResourceName,
 					)
-					expectedCreateAction := coretesting.NewCreateAction(
+					expectedCreateAction := coretesting.NewRootCreateAction(
 						credentialIssuerGVR,
-						credentialIssuerNamespaceName,
 						expectedCredentialIssuer,
 					)
 

--- a/internal/controller/kubecertagent/execer_test.go
+++ b/internal/controller/kubecertagent/execer_test.go
@@ -358,7 +358,7 @@ func TestManagerControllerSync(t *testing.T) {
 							},
 						}
 						expectedGetAction := coretesting.NewRootGetAction(credentialIssuerGVR, credentialIssuerResourceName)
-						expectedCreateAction := coretesting.NewRootUpdateAction(credentialIssuerGVR, expectedCredentialIssuer)
+						expectedCreateAction := coretesting.NewRootUpdateSubresourceAction(credentialIssuerGVR, "status", expectedCredentialIssuer)
 						r.Equal([]coretesting.Action{expectedGetAction, expectedCreateAction}, pinnipedAPIClient.Actions())
 					})
 
@@ -389,6 +389,13 @@ func TestManagerControllerSync(t *testing.T) {
 					it("also creates the the CredentialIssuer with the appropriate status field", func() {
 						r.NoError(controllerlib.TestSync(t, subject, *syncContext))
 
+						expectedCreateCredentialIssuer := &configv1alpha1.CredentialIssuer{
+							TypeMeta: metav1.TypeMeta{},
+							ObjectMeta: metav1.ObjectMeta{
+								Name: credentialIssuerResourceName,
+							},
+						}
+
 						expectedCredentialIssuer := &configv1alpha1.CredentialIssuer{
 							TypeMeta: metav1.TypeMeta{},
 							ObjectMeta: metav1.ObjectMeta{
@@ -407,8 +414,9 @@ func TestManagerControllerSync(t *testing.T) {
 							},
 						}
 						expectedGetAction := coretesting.NewRootGetAction(credentialIssuerGVR, credentialIssuerResourceName)
-						expectedCreateAction := coretesting.NewRootCreateAction(credentialIssuerGVR, expectedCredentialIssuer)
-						r.Equal([]coretesting.Action{expectedGetAction, expectedCreateAction}, pinnipedAPIClient.Actions())
+						expectedCreateAction := coretesting.NewRootCreateAction(credentialIssuerGVR, expectedCreateCredentialIssuer)
+						expectedUpdateAction := coretesting.NewRootUpdateSubresourceAction(credentialIssuerGVR, "status", expectedCredentialIssuer)
+						r.Equal([]coretesting.Action{expectedGetAction, expectedCreateAction, expectedUpdateAction}, pinnipedAPIClient.Actions())
 					})
 				})
 			})
@@ -431,6 +439,13 @@ func TestManagerControllerSync(t *testing.T) {
 				it("creates or updates the the CredentialIssuer status field with an error", func() {
 					r.EqualError(controllerlib.TestSync(t, subject, *syncContext), podExecErrorMessage)
 
+					expectedCreateCredentialIssuer := &configv1alpha1.CredentialIssuer{
+						TypeMeta: metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{
+							Name: credentialIssuerResourceName,
+						},
+					}
+
 					expectedCredentialIssuer := &configv1alpha1.CredentialIssuer{
 						TypeMeta: metav1.TypeMeta{},
 						ObjectMeta: metav1.ObjectMeta{
@@ -449,8 +464,9 @@ func TestManagerControllerSync(t *testing.T) {
 						},
 					}
 					expectedGetAction := coretesting.NewRootGetAction(credentialIssuerGVR, credentialIssuerResourceName)
-					expectedCreateAction := coretesting.NewRootCreateAction(credentialIssuerGVR, expectedCredentialIssuer)
-					r.Equal([]coretesting.Action{expectedGetAction, expectedCreateAction}, pinnipedAPIClient.Actions())
+					expectedCreateAction := coretesting.NewRootCreateAction(credentialIssuerGVR, expectedCreateCredentialIssuer)
+					expectedUpdateAction := coretesting.NewRootUpdateSubresourceAction(credentialIssuerGVR, "status", expectedCredentialIssuer)
+					r.Equal([]coretesting.Action{expectedGetAction, expectedCreateAction, expectedUpdateAction}, pinnipedAPIClient.Actions())
 				})
 			})
 
@@ -472,6 +488,13 @@ func TestManagerControllerSync(t *testing.T) {
 				it("creates or updates the the CredentialIssuer status field with an error", func() {
 					r.EqualError(controllerlib.TestSync(t, subject, *syncContext), podExecErrorMessage)
 
+					expectedCreateCredentialIssuer := &configv1alpha1.CredentialIssuer{
+						TypeMeta: metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{
+							Name: credentialIssuerResourceName,
+						},
+					}
+
 					expectedCredentialIssuer := &configv1alpha1.CredentialIssuer{
 						TypeMeta: metav1.TypeMeta{},
 						ObjectMeta: metav1.ObjectMeta{
@@ -490,8 +513,9 @@ func TestManagerControllerSync(t *testing.T) {
 						},
 					}
 					expectedGetAction := coretesting.NewRootGetAction(credentialIssuerGVR, credentialIssuerResourceName)
-					expectedCreateAction := coretesting.NewRootCreateAction(credentialIssuerGVR, expectedCredentialIssuer)
-					r.Equal([]coretesting.Action{expectedGetAction, expectedCreateAction}, pinnipedAPIClient.Actions())
+					expectedCreateAction := coretesting.NewRootCreateAction(credentialIssuerGVR, expectedCreateCredentialIssuer)
+					expectedUpdateAction := coretesting.NewRootUpdateSubresourceAction(credentialIssuerGVR, "status", expectedCredentialIssuer)
+					r.Equal([]coretesting.Action{expectedGetAction, expectedCreateAction, expectedUpdateAction}, pinnipedAPIClient.Actions())
 				})
 			})
 		})

--- a/internal/controller/kubecertagent/execer_test.go
+++ b/internal/controller/kubecertagent/execer_test.go
@@ -44,8 +44,7 @@ func TestExecerControllerOptions(t *testing.T) {
 			agentPodsInformer := kubeinformers.NewSharedInformerFactory(nil, 0).Core().V1().Pods()
 			_ = NewExecerController(
 				&CredentialIssuerLocationConfig{
-					Namespace: "ignored by this test",
-					Name:      "ignored by this test",
+					Name: "ignored by this test",
 				},
 				nil, // dynamicCertProvider, not needed for this test
 				nil, // podCommandExecutor, not needed for this test
@@ -136,7 +135,6 @@ func TestManagerControllerSync(t *testing.T) {
 		const fakeKeyPath = "/some/key/path"
 		const defaultDynamicCertProviderCert = "initial-cert"
 		const defaultDynamicCertProviderKey = "initial-key"
-		const credentialIssuerNamespaceName = "ci-namespace-name"
 		const credentialIssuerResourceName = "ci-resource-name"
 
 		var r *require.Assertions
@@ -160,8 +158,7 @@ func TestManagerControllerSync(t *testing.T) {
 			// Set this at the last second to allow for injection of server override.
 			subject = NewExecerController(
 				&CredentialIssuerLocationConfig{
-					Namespace: credentialIssuerNamespaceName,
-					Name:      credentialIssuerResourceName,
+					Name: credentialIssuerResourceName,
 				},
 				dynamicCertProvider,
 				fakeExecutor,
@@ -333,8 +330,7 @@ func TestManagerControllerSync(t *testing.T) {
 						initialCredentialIssuer = &configv1alpha1.CredentialIssuer{
 							TypeMeta: metav1.TypeMeta{},
 							ObjectMeta: metav1.ObjectMeta{
-								Name:      credentialIssuerResourceName,
-								Namespace: credentialIssuerNamespaceName,
+								Name: credentialIssuerResourceName,
 							},
 							Status: configv1alpha1.CredentialIssuerStatus{
 								Strategies: []configv1alpha1.CredentialIssuerStrategy{},
@@ -361,8 +357,8 @@ func TestManagerControllerSync(t *testing.T) {
 								LastUpdateTime: metav1.NewTime(frozenNow),
 							},
 						}
-						expectedGetAction := coretesting.NewGetAction(credentialIssuerGVR, credentialIssuerNamespaceName, credentialIssuerResourceName)
-						expectedCreateAction := coretesting.NewUpdateAction(credentialIssuerGVR, credentialIssuerNamespaceName, expectedCredentialIssuer)
+						expectedGetAction := coretesting.NewRootGetAction(credentialIssuerGVR, credentialIssuerResourceName)
+						expectedCreateAction := coretesting.NewRootUpdateAction(credentialIssuerGVR, expectedCredentialIssuer)
 						r.Equal([]coretesting.Action{expectedGetAction, expectedCreateAction}, pinnipedAPIClient.Actions())
 					})
 
@@ -396,8 +392,7 @@ func TestManagerControllerSync(t *testing.T) {
 						expectedCredentialIssuer := &configv1alpha1.CredentialIssuer{
 							TypeMeta: metav1.TypeMeta{},
 							ObjectMeta: metav1.ObjectMeta{
-								Name:      credentialIssuerResourceName,
-								Namespace: credentialIssuerNamespaceName,
+								Name: credentialIssuerResourceName,
 							},
 							Status: configv1alpha1.CredentialIssuerStatus{
 								Strategies: []configv1alpha1.CredentialIssuerStrategy{
@@ -411,8 +406,8 @@ func TestManagerControllerSync(t *testing.T) {
 								},
 							},
 						}
-						expectedGetAction := coretesting.NewGetAction(credentialIssuerGVR, credentialIssuerNamespaceName, credentialIssuerResourceName)
-						expectedCreateAction := coretesting.NewCreateAction(credentialIssuerGVR, credentialIssuerNamespaceName, expectedCredentialIssuer)
+						expectedGetAction := coretesting.NewRootGetAction(credentialIssuerGVR, credentialIssuerResourceName)
+						expectedCreateAction := coretesting.NewRootCreateAction(credentialIssuerGVR, expectedCredentialIssuer)
 						r.Equal([]coretesting.Action{expectedGetAction, expectedCreateAction}, pinnipedAPIClient.Actions())
 					})
 				})
@@ -439,8 +434,7 @@ func TestManagerControllerSync(t *testing.T) {
 					expectedCredentialIssuer := &configv1alpha1.CredentialIssuer{
 						TypeMeta: metav1.TypeMeta{},
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      credentialIssuerResourceName,
-							Namespace: credentialIssuerNamespaceName,
+							Name: credentialIssuerResourceName,
 						},
 						Status: configv1alpha1.CredentialIssuerStatus{
 							Strategies: []configv1alpha1.CredentialIssuerStrategy{
@@ -454,8 +448,8 @@ func TestManagerControllerSync(t *testing.T) {
 							},
 						},
 					}
-					expectedGetAction := coretesting.NewGetAction(credentialIssuerGVR, credentialIssuerNamespaceName, credentialIssuerResourceName)
-					expectedCreateAction := coretesting.NewCreateAction(credentialIssuerGVR, credentialIssuerNamespaceName, expectedCredentialIssuer)
+					expectedGetAction := coretesting.NewRootGetAction(credentialIssuerGVR, credentialIssuerResourceName)
+					expectedCreateAction := coretesting.NewRootCreateAction(credentialIssuerGVR, expectedCredentialIssuer)
 					r.Equal([]coretesting.Action{expectedGetAction, expectedCreateAction}, pinnipedAPIClient.Actions())
 				})
 			})
@@ -481,8 +475,7 @@ func TestManagerControllerSync(t *testing.T) {
 					expectedCredentialIssuer := &configv1alpha1.CredentialIssuer{
 						TypeMeta: metav1.TypeMeta{},
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      credentialIssuerResourceName,
-							Namespace: credentialIssuerNamespaceName,
+							Name: credentialIssuerResourceName,
 						},
 						Status: configv1alpha1.CredentialIssuerStatus{
 							Strategies: []configv1alpha1.CredentialIssuerStrategy{
@@ -496,8 +489,8 @@ func TestManagerControllerSync(t *testing.T) {
 							},
 						},
 					}
-					expectedGetAction := coretesting.NewGetAction(credentialIssuerGVR, credentialIssuerNamespaceName, credentialIssuerResourceName)
-					expectedCreateAction := coretesting.NewCreateAction(credentialIssuerGVR, credentialIssuerNamespaceName, expectedCredentialIssuer)
+					expectedGetAction := coretesting.NewRootGetAction(credentialIssuerGVR, credentialIssuerResourceName)
+					expectedCreateAction := coretesting.NewRootCreateAction(credentialIssuerGVR, expectedCredentialIssuer)
 					r.Equal([]coretesting.Action{expectedGetAction, expectedCreateAction}, pinnipedAPIClient.Actions())
 				})
 			})

--- a/internal/controller/kubecertagent/kubecertagent.go
+++ b/internal/controller/kubecertagent/kubecertagent.go
@@ -287,19 +287,19 @@ func createOrUpdateCredentialIssuer(ctx context.Context,
 	pinnipedAPIClient pinnipedclientset.Interface,
 	err error,
 ) error {
-	return issuerconfig.CreateOrUpdateCredentialIssuer(
+	return issuerconfig.CreateOrUpdateCredentialIssuerStatus(
 		ctx,
 		ciConfig.Name,
 		credentialIssuerLabels,
 		pinnipedAPIClient,
-		func(configToUpdate *configv1alpha1.CredentialIssuer) {
+		func(configToUpdate *configv1alpha1.CredentialIssuerStatus) {
 			var strategyResult configv1alpha1.CredentialIssuerStrategy
 			if err == nil {
 				strategyResult = strategySuccess(clock)
 			} else {
 				strategyResult = strategyError(clock, err)
 			}
-			configToUpdate.Status.Strategies = []configv1alpha1.CredentialIssuerStrategy{
+			configToUpdate.Strategies = []configv1alpha1.CredentialIssuerStrategy{
 				strategyResult,
 			}
 		},

--- a/internal/controller/kubecertagent/kubecertagent.go
+++ b/internal/controller/kubecertagent/kubecertagent.go
@@ -74,9 +74,6 @@ type AgentPodConfig struct {
 }
 
 type CredentialIssuerLocationConfig struct {
-	// The namespace in which the CredentialIssuer should be created/updated.
-	Namespace string
-
 	// The resource name for the CredentialIssuer to be created/updated.
 	Name string
 }
@@ -292,7 +289,6 @@ func createOrUpdateCredentialIssuer(ctx context.Context,
 ) error {
 	return issuerconfig.CreateOrUpdateCredentialIssuer(
 		ctx,
-		ciConfig.Namespace,
 		ciConfig.Name,
 		credentialIssuerLabels,
 		pinnipedAPIClient,

--- a/internal/controller/supervisorconfig/federation_domain_watcher.go
+++ b/internal/controller/supervisorconfig/federation_domain_watcher.go
@@ -204,7 +204,7 @@ func (c *federationDomainWatcherController) updateStatus(
 		federationDomain.Status.Status = status
 		federationDomain.Status.Message = message
 		federationDomain.Status.LastUpdateTime = timePtr(metav1.NewTime(c.clock.Now()))
-		_, err = c.client.ConfigV1alpha1().FederationDomains(namespace).Update(ctx, federationDomain, metav1.UpdateOptions{})
+		_, err = c.client.ConfigV1alpha1().FederationDomains(namespace).UpdateStatus(ctx, federationDomain, metav1.UpdateOptions{})
 		return err
 	})
 }

--- a/internal/controller/supervisorconfig/federation_domain_watcher_test.go
+++ b/internal/controller/supervisorconfig/federation_domain_watcher_test.go
@@ -222,8 +222,9 @@ func TestSync(t *testing.T) {
 						federationDomain1.Namespace,
 						federationDomain1.Name,
 					),
-					coretesting.NewUpdateAction(
+					coretesting.NewUpdateSubresourceAction(
 						federationDomainGVR,
+						"status",
 						federationDomain1.Namespace,
 						federationDomain1,
 					),
@@ -232,8 +233,9 @@ func TestSync(t *testing.T) {
 						federationDomain2.Namespace,
 						federationDomain2.Name,
 					),
-					coretesting.NewUpdateAction(
+					coretesting.NewUpdateSubresourceAction(
 						federationDomainGVR,
+						"status",
 						federationDomain2.Namespace,
 						federationDomain2,
 					),
@@ -271,8 +273,9 @@ func TestSync(t *testing.T) {
 							federationDomain2.Namespace,
 							federationDomain2.Name,
 						),
-						coretesting.NewUpdateAction(
+						coretesting.NewUpdateSubresourceAction(
 							federationDomainGVR,
+							"status",
 							federationDomain2.Namespace,
 							federationDomain2,
 						),
@@ -356,8 +359,9 @@ func TestSync(t *testing.T) {
 							federationDomain1.Namespace,
 							federationDomain1.Name,
 						),
-						coretesting.NewUpdateAction(
+						coretesting.NewUpdateSubresourceAction(
 							federationDomainGVR,
+							"status",
 							federationDomain1.Namespace,
 							federationDomain1,
 						),
@@ -366,8 +370,9 @@ func TestSync(t *testing.T) {
 							federationDomain2.Namespace,
 							federationDomain2.Name,
 						),
-						coretesting.NewUpdateAction(
+						coretesting.NewUpdateSubresourceAction(
 							federationDomainGVR,
+							"status",
 							federationDomain2.Namespace,
 							federationDomain2,
 						),
@@ -422,8 +427,9 @@ func TestSync(t *testing.T) {
 							federationDomain.Namespace,
 							federationDomain.Name,
 						),
-						coretesting.NewUpdateAction(
+						coretesting.NewUpdateSubresourceAction(
 							federationDomainGVR,
+							"status",
 							federationDomain.Namespace,
 							federationDomain,
 						),
@@ -432,8 +438,9 @@ func TestSync(t *testing.T) {
 							federationDomain.Namespace,
 							federationDomain.Name,
 						),
-						coretesting.NewUpdateAction(
+						coretesting.NewUpdateSubresourceAction(
 							federationDomainGVR,
+							"status",
 							federationDomain.Namespace,
 							federationDomain,
 						),
@@ -468,8 +475,9 @@ func TestSync(t *testing.T) {
 							federationDomain.Namespace,
 							federationDomain.Name,
 						),
-						coretesting.NewUpdateAction(
+						coretesting.NewUpdateSubresourceAction(
 							federationDomainGVR,
+							"status",
 							federationDomain.Namespace,
 							federationDomain,
 						),
@@ -568,8 +576,9 @@ func TestSync(t *testing.T) {
 						invalidFederationDomain.Namespace,
 						invalidFederationDomain.Name,
 					),
-					coretesting.NewUpdateAction(
+					coretesting.NewUpdateSubresourceAction(
 						federationDomainGVR,
+						"status",
 						invalidFederationDomain.Namespace,
 						invalidFederationDomain,
 					),
@@ -578,8 +587,9 @@ func TestSync(t *testing.T) {
 						validFederationDomain.Namespace,
 						validFederationDomain.Name,
 					),
-					coretesting.NewUpdateAction(
+					coretesting.NewUpdateSubresourceAction(
 						federationDomainGVR,
+						"status",
 						validFederationDomain.Namespace,
 						validFederationDomain,
 					),
@@ -640,8 +650,9 @@ func TestSync(t *testing.T) {
 							invalidFederationDomain.Namespace,
 							invalidFederationDomain.Name,
 						),
-						coretesting.NewUpdateAction(
+						coretesting.NewUpdateSubresourceAction(
 							federationDomainGVR,
+							"status",
 							invalidFederationDomain.Namespace,
 							invalidFederationDomain,
 						),
@@ -650,8 +661,9 @@ func TestSync(t *testing.T) {
 							validFederationDomain.Namespace,
 							validFederationDomain.Name,
 						),
-						coretesting.NewUpdateAction(
+						coretesting.NewUpdateSubresourceAction(
 							federationDomainGVR,
+							"status",
 							validFederationDomain.Namespace,
 							validFederationDomain,
 						),
@@ -732,8 +744,9 @@ func TestSync(t *testing.T) {
 						federationDomainDuplicate1.Namespace,
 						federationDomainDuplicate1.Name,
 					),
-					coretesting.NewUpdateAction(
+					coretesting.NewUpdateSubresourceAction(
 						federationDomainGVR,
+						"status",
 						federationDomainDuplicate1.Namespace,
 						federationDomainDuplicate1,
 					),
@@ -742,8 +755,9 @@ func TestSync(t *testing.T) {
 						federationDomainDuplicate2.Namespace,
 						federationDomainDuplicate2.Name,
 					),
-					coretesting.NewUpdateAction(
+					coretesting.NewUpdateSubresourceAction(
 						federationDomainGVR,
+						"status",
 						federationDomainDuplicate2.Namespace,
 						federationDomainDuplicate2,
 					),
@@ -752,8 +766,9 @@ func TestSync(t *testing.T) {
 						federationDomain.Namespace,
 						federationDomain.Name,
 					),
-					coretesting.NewUpdateAction(
+					coretesting.NewUpdateSubresourceAction(
 						federationDomainGVR,
+						"status",
 						federationDomain.Namespace,
 						federationDomain,
 					),
@@ -906,8 +921,9 @@ func TestSync(t *testing.T) {
 						federationDomainSameIssuerAddress1.Namespace,
 						federationDomainSameIssuerAddress1.Name,
 					),
-					coretesting.NewUpdateAction(
+					coretesting.NewUpdateSubresourceAction(
 						federationDomainGVR,
+						"status",
 						federationDomainSameIssuerAddress1.Namespace,
 						federationDomainSameIssuerAddress1,
 					),
@@ -916,8 +932,9 @@ func TestSync(t *testing.T) {
 						federationDomainSameIssuerAddress2.Namespace,
 						federationDomainSameIssuerAddress2.Name,
 					),
-					coretesting.NewUpdateAction(
+					coretesting.NewUpdateSubresourceAction(
 						federationDomainGVR,
+						"status",
 						federationDomainSameIssuerAddress2.Namespace,
 						federationDomainSameIssuerAddress2,
 					),
@@ -926,8 +943,9 @@ func TestSync(t *testing.T) {
 						federationDomainDifferentIssuerAddress.Namespace,
 						federationDomainDifferentIssuerAddress.Name,
 					),
-					coretesting.NewUpdateAction(
+					coretesting.NewUpdateSubresourceAction(
 						federationDomainGVR,
+						"status",
 						federationDomainDifferentIssuerAddress.Namespace,
 						federationDomainDifferentIssuerAddress,
 					),
@@ -936,8 +954,9 @@ func TestSync(t *testing.T) {
 						federationDomainWithInvalidIssuerURL.Namespace,
 						federationDomainWithInvalidIssuerURL.Name,
 					),
-					coretesting.NewUpdateAction(
+					coretesting.NewUpdateSubresourceAction(
 						federationDomainGVR,
+						"status",
 						federationDomainWithInvalidIssuerURL.Namespace,
 						federationDomainWithInvalidIssuerURL,
 					),

--- a/internal/controller/supervisorconfig/generator/federation_domain_secrets_test.go
+++ b/internal/controller/supervisorconfig/generator/federation_domain_secrets_test.go
@@ -393,7 +393,7 @@ func TestFederationDomainSecretsControllerSync(t *testing.T) {
 			},
 			wantFederationDomainActions: []kubetesting.Action{
 				kubetesting.NewGetAction(federationDomainGVR, namespace, goodFederationDomain.Name),
-				kubetesting.NewUpdateAction(federationDomainGVR, namespace, goodFederationDomainWithTokenSigningKey),
+				kubetesting.NewUpdateSubresourceAction(federationDomainGVR, "status", namespace, goodFederationDomainWithTokenSigningKey),
 			},
 			wantSecretActions: []kubetesting.Action{
 				kubetesting.NewGetAction(secretGVR, namespace, goodSecret.Name),
@@ -416,7 +416,7 @@ func TestFederationDomainSecretsControllerSync(t *testing.T) {
 			},
 			wantFederationDomainActions: []kubetesting.Action{
 				kubetesting.NewGetAction(federationDomainGVR, namespace, goodFederationDomain.Name),
-				kubetesting.NewUpdateAction(federationDomainGVR, namespace, goodFederationDomainWithJWKSAndTokenSigningKey),
+				kubetesting.NewUpdateSubresourceAction(federationDomainGVR, "status", namespace, goodFederationDomainWithJWKSAndTokenSigningKey),
 			},
 			wantSecretActions: []kubetesting.Action{
 				kubetesting.NewGetAction(secretGVR, namespace, goodSecret.Name),
@@ -457,7 +457,7 @@ func TestFederationDomainSecretsControllerSync(t *testing.T) {
 			},
 			wantFederationDomainActions: []kubetesting.Action{
 				kubetesting.NewGetAction(federationDomainGVR, namespace, goodFederationDomain.Name),
-				kubetesting.NewUpdateAction(federationDomainGVR, namespace, goodFederationDomainWithTokenSigningKey),
+				kubetesting.NewUpdateSubresourceAction(federationDomainGVR, "status", namespace, goodFederationDomainWithTokenSigningKey),
 			},
 			wantSecretActions: []kubetesting.Action{
 				kubetesting.NewGetAction(secretGVR, namespace, goodSecret.Name),
@@ -484,7 +484,7 @@ func TestFederationDomainSecretsControllerSync(t *testing.T) {
 			},
 			wantFederationDomainActions: []kubetesting.Action{
 				kubetesting.NewGetAction(federationDomainGVR, namespace, goodFederationDomain.Name),
-				kubetesting.NewUpdateAction(federationDomainGVR, namespace, goodFederationDomainWithTokenSigningKey),
+				kubetesting.NewUpdateSubresourceAction(federationDomainGVR, "status", namespace, goodFederationDomainWithTokenSigningKey),
 			},
 			wantSecretActions: []kubetesting.Action{
 				kubetesting.NewGetAction(secretGVR, namespace, goodSecret.Name),
@@ -562,7 +562,7 @@ func TestFederationDomainSecretsControllerSync(t *testing.T) {
 			},
 			wantFederationDomainActions: []kubetesting.Action{
 				kubetesting.NewGetAction(federationDomainGVR, namespace, goodFederationDomain.Name),
-				kubetesting.NewUpdateAction(federationDomainGVR, namespace, goodFederationDomainWithTokenSigningKey),
+				kubetesting.NewUpdateSubresourceAction(federationDomainGVR, "status", namespace, goodFederationDomainWithTokenSigningKey),
 			},
 			wantSecretActions: []kubetesting.Action{
 				kubetesting.NewGetAction(secretGVR, namespace, goodSecret.Name),
@@ -615,9 +615,9 @@ func TestFederationDomainSecretsControllerSync(t *testing.T) {
 			},
 			wantFederationDomainActions: []kubetesting.Action{
 				kubetesting.NewGetAction(federationDomainGVR, namespace, goodFederationDomain.Name),
-				kubetesting.NewUpdateAction(federationDomainGVR, namespace, goodFederationDomainWithTokenSigningKey),
+				kubetesting.NewUpdateSubresourceAction(federationDomainGVR, "status", namespace, goodFederationDomainWithTokenSigningKey),
 				kubetesting.NewGetAction(federationDomainGVR, namespace, goodFederationDomain.Name),
-				kubetesting.NewUpdateAction(federationDomainGVR, namespace, goodFederationDomainWithTokenSigningKey),
+				kubetesting.NewUpdateSubresourceAction(federationDomainGVR, "status", namespace, goodFederationDomainWithTokenSigningKey),
 			},
 			wantSecretActions: []kubetesting.Action{
 				kubetesting.NewGetAction(secretGVR, namespace, goodSecret.Name),
@@ -677,8 +677,8 @@ func TestFederationDomainSecretsControllerSync(t *testing.T) {
 
 			c := NewFederationDomainSecretsController(
 				secretHelper,
-				func(fd *configv1alpha1.FederationDomain) *corev1.LocalObjectReference {
-					return &fd.Status.Secrets.TokenSigningKey
+				func(fd *configv1alpha1.FederationDomainStatus) *corev1.LocalObjectReference {
+					return &fd.Secrets.TokenSigningKey
 				},
 				kubeAPIClient,
 				pinnipedAPIClient,

--- a/internal/controller/supervisorconfig/jwks_writer.go
+++ b/internal/controller/supervisorconfig/jwks_writer.go
@@ -161,7 +161,7 @@ func (c *jwksWriterController) Sync(ctx controllerlib.Context) error {
 	// Ensure that the FederationDomain points to the secret.
 	newFederationDomain := federationDomain.DeepCopy()
 	newFederationDomain.Status.Secrets.JWKS.Name = secret.Name
-	if err := c.updateFederationDomain(ctx.Context, newFederationDomain); err != nil {
+	if err := c.updateFederationDomainStatus(ctx.Context, newFederationDomain); err != nil {
 		return fmt.Errorf("cannot update FederationDomain: %w", err)
 	}
 	plog.Debug("updated FederationDomain", "federationdomain", klog.KObj(newFederationDomain))
@@ -283,7 +283,7 @@ func (c *jwksWriterController) createOrUpdateSecret(
 	})
 }
 
-func (c *jwksWriterController) updateFederationDomain(
+func (c *jwksWriterController) updateFederationDomainStatus(
 	ctx context.Context,
 	newFederationDomain *configv1alpha1.FederationDomain,
 ) error {
@@ -300,7 +300,7 @@ func (c *jwksWriterController) updateFederationDomain(
 		}
 
 		oldFederationDomain.Status.Secrets.JWKS.Name = newFederationDomain.Status.Secrets.JWKS.Name
-		_, err = federationDomainClient.Update(ctx, oldFederationDomain, metav1.UpdateOptions{})
+		_, err = federationDomainClient.UpdateStatus(ctx, oldFederationDomain, metav1.UpdateOptions{})
 		return err
 	})
 }

--- a/internal/controller/supervisorconfig/jwks_writer_test.go
+++ b/internal/controller/supervisorconfig/jwks_writer_test.go
@@ -355,7 +355,7 @@ func TestJWKSWriterControllerSync(t *testing.T) {
 			},
 			wantFederationDomainActions: []kubetesting.Action{
 				kubetesting.NewGetAction(federationDomainGVR, namespace, goodFederationDomain.Name),
-				kubetesting.NewUpdateAction(federationDomainGVR, namespace, goodFederationDomainWithStatus),
+				kubetesting.NewUpdateSubresourceAction(federationDomainGVR, "status", namespace, goodFederationDomainWithStatus),
 			},
 		},
 		{
@@ -373,7 +373,7 @@ func TestJWKSWriterControllerSync(t *testing.T) {
 			},
 			wantFederationDomainActions: []kubetesting.Action{
 				kubetesting.NewGetAction(federationDomainGVR, namespace, goodFederationDomain.Name),
-				kubetesting.NewUpdateAction(federationDomainGVR, namespace, goodFederationDomainWithStatus),
+				kubetesting.NewUpdateSubresourceAction(federationDomainGVR, "status", namespace, goodFederationDomainWithStatus),
 			},
 		},
 		{

--- a/internal/controllermanager/prepare_controllers.go
+++ b/internal/controllermanager/prepare_controllers.go
@@ -109,8 +109,7 @@ func PrepareControllers(c *Config) (func(ctx context.Context), error) {
 		AdditionalLabels:          c.Labels,
 	}
 	credentialIssuerLocationConfig := &kubecertagent.CredentialIssuerLocationConfig{
-		Namespace: c.ServerInstallationInfo.Namespace,
-		Name:      c.NamesConfig.CredentialIssuer,
+		Name: c.NamesConfig.CredentialIssuer,
 	}
 
 	groupName, ok := groupsuffix.Replace(loginv1alpha1.GroupName, c.APIGroupSuffix)
@@ -127,7 +126,6 @@ func PrepareControllers(c *Config) (func(ctx context.Context), error) {
 		// CredentialIssuer resource and keeping that information up to date.
 		WithController(
 			issuerconfig.NewKubeConfigInfoPublisherController(
-				c.ServerInstallationInfo.Namespace,
 				c.NamesConfig.CredentialIssuer,
 				c.Labels,
 				c.DiscoveryURLOverride,
@@ -245,7 +243,7 @@ func PrepareControllers(c *Config) (func(ctx context.Context), error) {
 		WithController(
 			webhookcachefiller.New(
 				c.AuthenticatorCache,
-				informers.installationNamespacePinniped.Authentication().V1alpha1().WebhookAuthenticators(),
+				informers.pinniped.Authentication().V1alpha1().WebhookAuthenticators(),
 				klogr.New(),
 			),
 			singletonWorker,
@@ -253,7 +251,7 @@ func PrepareControllers(c *Config) (func(ctx context.Context), error) {
 		WithController(
 			jwtcachefiller.New(
 				c.AuthenticatorCache,
-				informers.installationNamespacePinniped.Authentication().V1alpha1().JWTAuthenticators(),
+				informers.pinniped.Authentication().V1alpha1().JWTAuthenticators(),
 				klogr.New(),
 			),
 			singletonWorker,
@@ -261,8 +259,8 @@ func PrepareControllers(c *Config) (func(ctx context.Context), error) {
 		WithController(
 			cachecleaner.New(
 				c.AuthenticatorCache,
-				informers.installationNamespacePinniped.Authentication().V1alpha1().WebhookAuthenticators(),
-				informers.installationNamespacePinniped.Authentication().V1alpha1().JWTAuthenticators(),
+				informers.pinniped.Authentication().V1alpha1().WebhookAuthenticators(),
+				informers.pinniped.Authentication().V1alpha1().JWTAuthenticators(),
 				klogr.New(),
 			),
 			singletonWorker,
@@ -276,10 +274,10 @@ func PrepareControllers(c *Config) (func(ctx context.Context), error) {
 }
 
 type informers struct {
-	kubePublicNamespaceK8s        k8sinformers.SharedInformerFactory
-	kubeSystemNamespaceK8s        k8sinformers.SharedInformerFactory
-	installationNamespaceK8s      k8sinformers.SharedInformerFactory
-	installationNamespacePinniped pinnipedinformers.SharedInformerFactory
+	kubePublicNamespaceK8s   k8sinformers.SharedInformerFactory
+	kubeSystemNamespaceK8s   k8sinformers.SharedInformerFactory
+	installationNamespaceK8s k8sinformers.SharedInformerFactory
+	pinniped                 pinnipedinformers.SharedInformerFactory
 }
 
 // Create the informers that will be used by the controllers.
@@ -304,10 +302,9 @@ func createInformers(
 			defaultResyncInterval,
 			k8sinformers.WithNamespace(serverInstallationNamespace),
 		),
-		installationNamespacePinniped: pinnipedinformers.NewSharedInformerFactoryWithOptions(
+		pinniped: pinnipedinformers.NewSharedInformerFactoryWithOptions(
 			pinnipedClient,
 			defaultResyncInterval,
-			pinnipedinformers.WithNamespace(serverInstallationNamespace),
 		),
 	}
 }
@@ -316,10 +313,10 @@ func (i *informers) startAndWaitForSync(ctx context.Context) {
 	i.kubePublicNamespaceK8s.Start(ctx.Done())
 	i.kubeSystemNamespaceK8s.Start(ctx.Done())
 	i.installationNamespaceK8s.Start(ctx.Done())
-	i.installationNamespacePinniped.Start(ctx.Done())
+	i.pinniped.Start(ctx.Done())
 
 	i.kubePublicNamespaceK8s.WaitForCacheSync(ctx.Done())
 	i.kubeSystemNamespaceK8s.WaitForCacheSync(ctx.Done())
 	i.installationNamespaceK8s.WaitForCacheSync(ctx.Done())
-	i.installationNamespacePinniped.WaitForCacheSync(ctx.Done())
+	i.pinniped.WaitForCacheSync(ctx.Done())
 }

--- a/internal/deploymentref/deploymentref.go
+++ b/internal/deploymentref/deploymentref.go
@@ -19,7 +19,7 @@ import (
 
 // getTempClient is stubbed out for testing.
 //
-// We would normally inject a kubernetes.Interface into New(), but the client we want to create in
+// We would normally pass a kubernetes.Interface into New(), but the client we want to create in
 // the calling code depends on the return value of New() (i.e., on the kubeclient.Option for the
 // OwnerReference).
 //nolint: gochecknoglobals

--- a/internal/kubeclient/kubeclient_test.go
+++ b/internal/kubeclient/kubeclient_test.go
@@ -259,7 +259,7 @@ func TestKubeclient(t *testing.T) {
 				// create
 				tokenCredentialRequest, err := c.PinnipedConcierge.
 					LoginV1alpha1().
-					TokenCredentialRequests(goodTokenCredentialRequest.Namespace).
+					TokenCredentialRequests().
 					Create(context.Background(), goodTokenCredentialRequest, metav1.CreateOptions{})
 				require.NoError(t, err)
 				require.Equal(t, goodTokenCredentialRequest, tokenCredentialRequest)
@@ -267,7 +267,7 @@ func TestKubeclient(t *testing.T) {
 				// read
 				tokenCredentialRequest, err = c.PinnipedConcierge.
 					LoginV1alpha1().
-					TokenCredentialRequests(tokenCredentialRequest.Namespace).
+					TokenCredentialRequests().
 					Get(context.Background(), tokenCredentialRequest.Name, metav1.GetOptions{})
 				require.NoError(t, err)
 				require.Equal(t, with(goodTokenCredentialRequest, annotations(), labels()), tokenCredentialRequest)
@@ -276,7 +276,7 @@ func TestKubeclient(t *testing.T) {
 				goodTokenCredentialRequestWithAnnotationsAndLabelsAndClusterName := with(goodTokenCredentialRequest, annotations(), labels(), clusterName()).(*loginv1alpha1.TokenCredentialRequest)
 				tokenCredentialRequest, err = c.PinnipedConcierge.
 					LoginV1alpha1().
-					TokenCredentialRequests(tokenCredentialRequest.Namespace).
+					TokenCredentialRequests().
 					Update(context.Background(), goodTokenCredentialRequestWithAnnotationsAndLabelsAndClusterName, metav1.UpdateOptions{})
 				require.NoError(t, err)
 				require.Equal(t, goodTokenCredentialRequestWithAnnotationsAndLabelsAndClusterName, tokenCredentialRequest)
@@ -284,7 +284,7 @@ func TestKubeclient(t *testing.T) {
 				// delete
 				err = c.PinnipedConcierge.
 					LoginV1alpha1().
-					TokenCredentialRequests(tokenCredentialRequest.Namespace).
+					TokenCredentialRequests().
 					Delete(context.Background(), tokenCredentialRequest.Name, metav1.DeleteOptions{})
 				require.NoError(t, err)
 			},

--- a/internal/registry/credentialrequest/rest.go
+++ b/internal/registry/credentialrequest/rest.go
@@ -80,7 +80,7 @@ func (r *REST) ConvertToTable(ctx context.Context, obj runtime.Object, tableOpti
 }
 
 func (*REST) NamespaceScoped() bool {
-	return true
+	return false
 }
 
 func (*REST) Categories() []string {

--- a/internal/registry/credentialrequest/rest_test.go
+++ b/internal/registry/credentialrequest/rest_test.go
@@ -31,7 +31,7 @@ import (
 func TestNew(t *testing.T) {
 	r := NewREST(nil, nil, schema.GroupResource{Group: "bears", Resource: "panda"})
 	require.NotNil(t, r)
-	require.True(t, r.NamespaceScoped())
+	require.False(t, r.NamespaceScoped())
 	require.Equal(t, []string{"pinniped"}, r.Categories())
 	require.IsType(t, &loginapi.TokenCredentialRequest{}, r.New())
 	require.IsType(t, &loginapi.TokenCredentialRequestList{}, r.NewList())

--- a/pkg/conciergeclient/conciergeclient_test.go
+++ b/pkg/conciergeclient/conciergeclient_test.go
@@ -125,7 +125,6 @@ func TestNew(t *testing.T) {
 		{
 			name: "valid",
 			opts: []Option{
-				WithNamespace("test-namespace"),
 				WithEndpoint("https://example.com"),
 				WithCABundle(""),
 				WithCABundle(string(testCA.Bundle())),
@@ -223,7 +222,7 @@ func TestExchangeToken(t *testing.T) {
 		// Start a test server that returns successfully and asserts various properties of the request.
 		caBundle, endpoint := testutil.TLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 			require.Equal(t, http.MethodPost, r.Method)
-			require.Equal(t, "/apis/login.concierge.pinniped.dev/v1alpha1/namespaces/test-namespace/tokencredentialrequests", r.URL.Path)
+			require.Equal(t, "/apis/login.concierge.pinniped.dev/v1alpha1/tokencredentialrequests", r.URL.Path)
 			require.Equal(t, "application/json", r.Header.Get("content-type"))
 
 			body, err := ioutil.ReadAll(r.Body)
@@ -233,8 +232,7 @@ func TestExchangeToken(t *testing.T) {
 				  "kind": "TokenCredentialRequest",
 				  "apiVersion": "login.concierge.pinniped.dev/v1alpha1",
 				  "metadata": {
-					"creationTimestamp": null,
-					"namespace": "test-namespace"
+					"creationTimestamp": null
 				  },
 				  "spec": {
 					"token": "test-token",
@@ -262,7 +260,7 @@ func TestExchangeToken(t *testing.T) {
 			})
 		})
 
-		client, err := New(WithNamespace("test-namespace"), WithEndpoint(endpoint), WithCABundle(caBundle), WithAuthenticator("webhook", "test-webhook"))
+		client, err := New(WithEndpoint(endpoint), WithCABundle(caBundle), WithAuthenticator("webhook", "test-webhook"))
 		require.NoError(t, err)
 
 		got, err := client.ExchangeToken(ctx, "test-token")

--- a/site/content/docs/concierge-and-supervisor-demo.md
+++ b/site/content/docs/concierge-and-supervisor-demo.md
@@ -163,7 +163,7 @@ to authenticate federated identities from the Supervisor.
    object to configure the Pinniped Concierge to authenticate using the Pinniped Supervisor.
 
     ```bash
-    cat <<EOF | kubectl create --context kind-pinniped-concierge --namespace pinniped-concierge -f -
+    cat <<EOF | kubectl create --context kind-pinniped-concierge -f -
     apiVersion: authentication.concierge.pinniped.dev/v1alpha1
     kind: JWTAuthenticator
     metadata:
@@ -185,7 +185,6 @@ to authenticate federated identities from the Supervisor.
    ```bash
    pinniped get kubeconfig \
      --kubeconfig-context kind-pinniped-concierge \
-     --concierge-namespace pinniped-concierge \
      > /tmp/pinniped-kubeconfig
    ```
 

--- a/site/content/docs/concierge-only-demo.md
+++ b/site/content/docs/concierge-only-demo.md
@@ -102,7 +102,7 @@ as the authenticator.
 1. Create a `WebhookAuthenticator` object to configure the Pinniped Concierge to authenticate using local-user-authenticator.
 
     ```bash
-    cat <<EOF | kubectl create --namespace pinniped-concierge -f -
+    cat <<EOF | kubectl create -f -
     apiVersion: authentication.concierge.pinniped.dev/v1alpha1
     kind: WebhookAuthenticator
     metadata:
@@ -124,7 +124,7 @@ as the authenticator.
    allow you to authenticate as the user that you created above.
 
    ```bash
-   pinniped get kubeconfig --concierge-namespace pinniped-concierge --static-token "pinny-the-seal:password123" --concierge-authenticator-type webhook --concierge-authenticator-name local-user-authenticator > /tmp/pinniped-kubeconfig
+   pinniped get kubeconfig --static-token "pinny-the-seal:password123" --concierge-authenticator-type webhook --concierge-authenticator-name local-user-authenticator > /tmp/pinniped-kubeconfig
    ```
 
    If you are using MacOS, you may get an error dialog that says

--- a/test/integration/cli_test.go
+++ b/test/integration/cli_test.go
@@ -57,7 +57,6 @@ func TestCLIGetKubeconfigStaticToken(t *testing.T) {
 				"get", "kubeconfig",
 				"--static-token", env.TestUser.Token,
 				"--concierge-api-group-suffix", env.APIGroupSuffix,
-				"--concierge-namespace", env.ConciergeNamespace,
 				"--concierge-authenticator-type", "webhook",
 				"--concierge-authenticator-name", authenticator.Name,
 			},

--- a/test/integration/concierge_api_serving_certs_test.go
+++ b/test/integration/concierge_api_serving_certs_test.go
@@ -146,7 +146,7 @@ func TestAPIServingCertificateAutoCreationAndRotation(t *testing.T) {
 			// pod has rotated their cert, but not the other ones sitting behind the service.
 			aggregatedAPIWorking := func() bool {
 				for i := 0; i < 10; i++ {
-					_, err = conciergeClient.LoginV1alpha1().TokenCredentialRequests(env.ConciergeNamespace).Create(ctx, &loginv1alpha1.TokenCredentialRequest{
+					_, err = conciergeClient.LoginV1alpha1().TokenCredentialRequests().Create(ctx, &loginv1alpha1.TokenCredentialRequest{
 						TypeMeta:   metav1.TypeMeta{},
 						ObjectMeta: metav1.ObjectMeta{},
 						Spec:       loginv1alpha1.TokenCredentialRequestSpec{Token: "not a good token", Authenticator: testWebhook},

--- a/test/integration/concierge_client_test.go
+++ b/test/integration/concierge_client_test.go
@@ -72,7 +72,6 @@ func TestClient(t *testing.T) {
 	// Using the CA bundle and host from the current (admin) kubeconfig, do the token exchange.
 	clientConfig := library.NewClientConfig(t)
 	client, err := conciergeclient.New(
-		conciergeclient.WithNamespace(env.ConciergeNamespace),
 		conciergeclient.WithCABundle(string(clientConfig.CAData)),
 		conciergeclient.WithEndpoint(clientConfig.Host),
 		conciergeclient.WithAuthenticator("webhook", webhook.Name),

--- a/test/integration/concierge_credentialissuerconfig_test.go
+++ b/test/integration/concierge_credentialissuerconfig_test.go
@@ -29,7 +29,7 @@ func TestCredentialIssuer(t *testing.T) {
 	t.Run("test successful CredentialIssuer", func(t *testing.T) {
 		actualConfigList, err := client.
 			ConfigV1alpha1().
-			CredentialIssuers(env.ConciergeNamespace).
+			CredentialIssuers().
 			List(ctx, metav1.ListOptions{})
 		require.NoError(t, err)
 

--- a/test/integration/concierge_credentialissuerconfig_test.go
+++ b/test/integration/concierge_credentialissuerconfig_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 
 	configv1alpha1 "go.pinniped.dev/generated/1.20/apis/concierge/config/v1alpha1"
 	"go.pinniped.dev/test/library"
@@ -20,6 +21,7 @@ func TestCredentialIssuer(t *testing.T) {
 	env := library.IntegrationEnv(t)
 	config := library.NewClientConfig(t)
 	client := library.NewConciergeClientset(t)
+	aggregatedClientset := library.NewAggregatedClientset(t)
 
 	library.AssertNoRestartsDuringTest(t, env.ConciergeNamespace, "")
 
@@ -42,6 +44,23 @@ func TestCredentialIssuer(t *testing.T) {
 			require.Equalf(t, v, actualConfig.Labels[k], "expected ci to have label `%s: %s`", k, v)
 		}
 		require.Equal(t, env.ConciergeAppName, actualConfig.Labels["app"])
+
+		// verify owner ref is set
+		require.Len(t, actualConfig.OwnerReferences, 1)
+
+		apiService, err := aggregatedClientset.ApiregistrationV1().APIServices().Get(ctx, "v1alpha1.login.concierge."+env.APIGroupSuffix, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		// work around stupid behavior of WithoutVersionDecoder.Decode
+		apiService.APIVersion, apiService.Kind = apiregistrationv1.SchemeGroupVersion.WithKind("APIService").ToAPIVersionAndKind()
+
+		ref := metav1.OwnerReference{
+			APIVersion: apiService.APIVersion,
+			Kind:       apiService.Kind,
+			Name:       apiService.Name,
+			UID:        apiService.UID,
+		}
+		require.Equal(t, ref, actualConfig.OwnerReferences[0])
 
 		// Verify the cluster strategy status based on what's expected of the test cluster's ability to share signing keys.
 		actualStatusStrategies := actualConfigList.Items[0].Status.Strategies

--- a/test/integration/concierge_credentialrequest_test.go
+++ b/test/integration/concierge_credentialrequest_test.go
@@ -211,7 +211,7 @@ func makeRequest(ctx context.Context, t *testing.T, spec loginv1alpha1.TokenCred
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	return client.LoginV1alpha1().TokenCredentialRequests(env.ConciergeNamespace).Create(ctx, &loginv1alpha1.TokenCredentialRequest{
+	return client.LoginV1alpha1().TokenCredentialRequests().Create(ctx, &loginv1alpha1.TokenCredentialRequest{
 		TypeMeta:   metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{Namespace: env.ConciergeNamespace},
 		Spec:       spec,

--- a/test/integration/e2e_test.go
+++ b/test/integration/e2e_test.go
@@ -142,7 +142,6 @@ func TestE2EFullIntegration(t *testing.T) {
 	// Run "pinniped get kubeconfig" to get a kubeconfig YAML.
 	kubeconfigYAML, stderr := runPinnipedCLI(t, pinnipedExe, "get", "kubeconfig",
 		"--concierge-api-group-suffix", env.APIGroupSuffix,
-		"--concierge-namespace", env.ConciergeNamespace,
 		"--concierge-authenticator-type", "jwt",
 		"--concierge-authenticator-name", authenticator.Name,
 		"--oidc-skip-browser",

--- a/test/integration/kube_api_discovery_test.go
+++ b/test/integration/kube_api_discovery_test.go
@@ -73,7 +73,7 @@ func TestGetAPIResourceList(t *testing.T) {
 						Name:       "tokencredentialrequests",
 						Kind:       "TokenCredentialRequest",
 						Verbs:      []string{"create", "list"},
-						Namespaced: true,
+						Namespaced: false,
 						Categories: []string{"pinniped"},
 					},
 				},
@@ -158,7 +158,7 @@ func TestGetAPIResourceList(t *testing.T) {
 					{
 						Name:         "credentialissuers",
 						SingularName: "credentialissuer",
-						Namespaced:   true,
+						Namespaced:   false,
 						Kind:         "CredentialIssuer",
 						Verbs:        []string{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
 						Categories:   []string{"pinniped"},
@@ -185,7 +185,7 @@ func TestGetAPIResourceList(t *testing.T) {
 					{
 						Name:         "webhookauthenticators",
 						SingularName: "webhookauthenticator",
-						Namespaced:   true,
+						Namespaced:   false,
 						Kind:         "WebhookAuthenticator",
 						Verbs:        []string{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
 						Categories:   []string{"pinniped", "pinniped-authenticator", "pinniped-authenticators"},
@@ -193,7 +193,7 @@ func TestGetAPIResourceList(t *testing.T) {
 					{
 						Name:         "jwtauthenticators",
 						SingularName: "jwtauthenticator",
-						Namespaced:   true,
+						Namespaced:   false,
 						Kind:         "JWTAuthenticator",
 						Verbs:        []string{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
 						Categories:   []string{"pinniped", "pinniped-authenticator", "pinniped-authenticators"},
@@ -232,6 +232,23 @@ func TestGetAPIResourceList(t *testing.T) {
 				}
 				assert.Containsf(t, a.Categories, "pinniped", "expected resource %q to be in the 'pinniped' category", a.Name)
 				assert.NotContainsf(t, a.Categories, "all", "expected resource %q not to be in the 'all' category", a.Name)
+			}
+		}
+	})
+
+	t.Run("every concierge API is cluster scoped", func(t *testing.T) {
+		t.Parallel()
+		for _, r := range resources {
+			if !strings.Contains(r.GroupVersion, env.APIGroupSuffix) {
+				continue
+			}
+
+			if !strings.Contains(r.GroupVersion, ".concierge.") {
+				continue
+			}
+
+			for _, a := range r.APIResources {
+				assert.False(t, a.Namespaced, "concierge APIs must be cluster scoped: %#v", a)
 			}
 		}
 	})

--- a/test/integration/kubeclient_test.go
+++ b/test/integration/kubeclient_test.go
@@ -220,9 +220,6 @@ func TestKubeClientOwnerRef(t *testing.T) {
 				GenerateName:    "owner-ref-test-",
 				OwnerReferences: nil, // no owner refs set
 			},
-			Status: conciergeconfigv1alpha1.CredentialIssuerStatus{
-				Strategies: []conciergeconfigv1alpha1.CredentialIssuerStrategy{},
-			},
 		},
 		metav1.CreateOptions{},
 	)

--- a/test/integration/kubeclient_test.go
+++ b/test/integration/kubeclient_test.go
@@ -17,6 +17,7 @@ import (
 
 	conciergeconfigv1alpha1 "go.pinniped.dev/generated/1.20/apis/concierge/config/v1alpha1"
 	supervisorconfigv1alpha1 "go.pinniped.dev/generated/1.20/apis/supervisor/config/v1alpha1"
+	"go.pinniped.dev/internal/apiserviceref"
 	"go.pinniped.dev/internal/groupsuffix"
 	"go.pinniped.dev/internal/kubeclient"
 	"go.pinniped.dev/internal/ownerref"
@@ -27,6 +28,7 @@ func TestKubeClientOwnerRef(t *testing.T) {
 	env := library.IntegrationEnv(t)
 
 	regularClient := library.NewKubernetesClientset(t)
+	regularAggregationClient := library.NewAggregatedClientset(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
@@ -73,9 +75,47 @@ func TestKubeClientOwnerRef(t *testing.T) {
 		UID:        parentSecret.UID,
 	}
 
+	parentAPIService, err := regularAggregationClient.ApiregistrationV1().APIServices().Create(
+		ctx,
+		&apiregistrationv1.APIService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "v1.snorlax.dev",
+			},
+			Spec: apiregistrationv1.APIServiceSpec{
+				Version:              "v1",
+				Group:                "snorlax.dev",
+				GroupPriorityMinimum: 10_000,
+				VersionPriority:      500,
+			},
+		},
+		metav1.CreateOptions{},
+	)
+	require.NoError(t, err)
+	defer func() {
+		err := regularAggregationClient.ApiregistrationV1().APIServices().Delete(ctx, parentAPIService.Name, metav1.DeleteOptions{})
+		if errors.IsNotFound(err) {
+			return
+		}
+		require.NoError(t, err)
+	}()
+
+	// work around stupid behavior of WithoutVersionDecoder.Decode
+	parentAPIService.APIVersion, parentAPIService.Kind = apiregistrationv1.SchemeGroupVersion.WithKind("APIService").ToAPIVersionAndKind()
+
+	parentAPIServiceRef := metav1.OwnerReference{
+		APIVersion: parentAPIService.APIVersion,
+		Kind:       parentAPIService.Kind,
+		Name:       parentAPIService.Name,
+		UID:        parentAPIService.UID,
+	}
+
+	apiServiceRef, err := apiserviceref.New(parentAPIService.Name, kubeclient.WithConfig(library.NewClientConfig(t)))
+	require.NoError(t, err)
+
 	// create a client that should set an owner ref back to parent on create
 	ownerRefClient, err := kubeclient.New(
-		kubeclient.WithMiddleware(ownerref.New(parentSecret)),
+		kubeclient.WithMiddleware(ownerref.New(parentSecret)), // secret owner ref first when possible
+		apiServiceRef, // api service for everything else
 		kubeclient.WithMiddleware(groupsuffix.New(env.APIGroupSuffix)),
 		kubeclient.WithConfig(library.NewClientConfig(t)),
 	)
@@ -132,7 +172,7 @@ func TestKubeClientOwnerRef(t *testing.T) {
 	require.NotEqual(t, parentSecret.ResourceVersion, updatedParentSecret.ResourceVersion)
 	require.Len(t, updatedParentSecret.OwnerReferences, 0)
 
-	// delete the parent object
+	// delete the parent secret object
 	err = ownerRefSecrets.Delete(ctx, parentSecret.Name, metav1.DeleteOptions{})
 	require.NoError(t, err)
 
@@ -142,9 +182,7 @@ func TestKubeClientOwnerRef(t *testing.T) {
 		return err
 	})
 
-	// sanity check API service client - the middleware code shouldn't add an owner reference to this
-	// APIService because the APIService is cluster-scoped and the parent object is namespace-scoped,
-	// which is invalid in Kubernetes
+	// cluster scoped API service should be owned by the other one we created above
 	apiService, err := ownerRefClient.Aggregation.ApiregistrationV1().APIServices().Create(
 		ctx,
 		&apiregistrationv1.APIService{
@@ -162,9 +200,17 @@ func TestKubeClientOwnerRef(t *testing.T) {
 		metav1.CreateOptions{},
 	)
 	require.NoError(t, err)
-	hasNoOwnerRef(t, apiService)
-	err = ownerRefClient.Aggregation.ApiregistrationV1().APIServices().Delete(ctx, apiService.Name, metav1.DeleteOptions{})
+	hasOwnerRef(t, apiService, parentAPIServiceRef)
+
+	// delete the parent API service object
+	err = ownerRefClient.Aggregation.ApiregistrationV1().APIServices().Delete(ctx, parentAPIService.Name, metav1.DeleteOptions{})
 	require.NoError(t, err)
+
+	// the child object should be cleaned up on its own
+	isEventuallyDeleted(t, func() error {
+		_, err := ownerRefClient.Aggregation.ApiregistrationV1().APIServices().Get(ctx, apiService.Name, metav1.GetOptions{})
+		return err
+	})
 
 	// sanity check concierge client
 	credentialIssuer, err := ownerRefClient.PinnipedConcierge.ConfigV1alpha1().CredentialIssuers().Create(
@@ -181,7 +227,7 @@ func TestKubeClientOwnerRef(t *testing.T) {
 		metav1.CreateOptions{},
 	)
 	require.NoError(t, err)
-	hasOwnerRef(t, credentialIssuer, ref)
+	hasOwnerRef(t, credentialIssuer, parentAPIServiceRef)
 	// this owner has already been deleted so the cred issuer should be immediately deleted
 	isEventuallyDeleted(t, func() error {
 		_, err := ownerRefClient.PinnipedConcierge.ConfigV1alpha1().CredentialIssuers().Get(ctx, credentialIssuer.Name, metav1.GetOptions{})
@@ -244,13 +290,6 @@ func hasOwnerRef(t *testing.T, obj metav1.Object, ref metav1.OwnerReference) {
 	ownerReferences := obj.GetOwnerReferences()
 	require.Len(t, ownerReferences, 1)
 	require.Equal(t, ref, ownerReferences[0])
-}
-
-func hasNoOwnerRef(t *testing.T, obj metav1.Object) {
-	t.Helper()
-
-	ownerReferences := obj.GetOwnerReferences()
-	require.Len(t, ownerReferences, 0)
 }
 
 func isEventuallyDeleted(t *testing.T, f func() error) {

--- a/test/integration/kubeclient_test.go
+++ b/test/integration/kubeclient_test.go
@@ -167,7 +167,7 @@ func TestKubeClientOwnerRef(t *testing.T) {
 	require.NoError(t, err)
 
 	// sanity check concierge client
-	credentialIssuer, err := ownerRefClient.PinnipedConcierge.ConfigV1alpha1().CredentialIssuers(namespace.Name).Create(
+	credentialIssuer, err := ownerRefClient.PinnipedConcierge.ConfigV1alpha1().CredentialIssuers().Create(
 		ctx,
 		&conciergeconfigv1alpha1.CredentialIssuer{
 			ObjectMeta: metav1.ObjectMeta{
@@ -184,7 +184,7 @@ func TestKubeClientOwnerRef(t *testing.T) {
 	hasOwnerRef(t, credentialIssuer, ref)
 	// this owner has already been deleted so the cred issuer should be immediately deleted
 	isEventuallyDeleted(t, func() error {
-		_, err := ownerRefClient.PinnipedConcierge.ConfigV1alpha1().CredentialIssuers(namespace.Name).Get(ctx, credentialIssuer.Name, metav1.GetOptions{})
+		_, err := ownerRefClient.PinnipedConcierge.ConfigV1alpha1().CredentialIssuers().Get(ctx, credentialIssuer.Name, metav1.GetOptions{})
 		return err
 	})
 

--- a/test/library/client.go
+++ b/test/library/client.go
@@ -153,7 +153,7 @@ func CreateTestWebhookAuthenticator(ctx context.Context, t *testing.T) corev1.Ty
 	testEnv := IntegrationEnv(t)
 
 	client := NewConciergeClientset(t)
-	webhooks := client.AuthenticationV1alpha1().WebhookAuthenticators(testEnv.ConciergeNamespace)
+	webhooks := client.AuthenticationV1alpha1().WebhookAuthenticators()
 
 	createContext, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
@@ -220,10 +220,9 @@ func CreateTestJWTAuthenticatorForCLIUpstream(ctx context.Context, t *testing.T)
 // authenticator within the test namespace.
 func CreateTestJWTAuthenticator(ctx context.Context, t *testing.T, spec auth1alpha1.JWTAuthenticatorSpec) corev1.TypedLocalObjectReference {
 	t.Helper()
-	testEnv := IntegrationEnv(t)
 
 	client := NewConciergeClientset(t)
-	jwtAuthenticators := client.AuthenticationV1alpha1().JWTAuthenticators(testEnv.ConciergeNamespace)
+	jwtAuthenticators := client.AuthenticationV1alpha1().JWTAuthenticators()
 
 	createContext, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()


### PR DESCRIPTION
Signed-off-by: Monis Khan <mok@vmware.com>

**Release note**:

```release-note
All concierge APIs (listed below) are now cluster scoped.
The related namespace flags have been deprecated and will be removed in a future release.

NAME                              SHORTNAMES   APIVERSION                                       NAMESPACED   KIND
jwtauthenticators                              authentication.concierge.pinniped.dev/v1alpha1   false        JWTAuthenticator
webhookauthenticators                          authentication.concierge.pinniped.dev/v1alpha1   false        WebhookAuthenticator
credentialissuers                              config.concierge.pinniped.dev/v1alpha1           false        CredentialIssuer
tokencredentialrequests                        login.concierge.pinniped.dev/v1alpha1            false        TokenCredentialRequest

All concierge and supervisor CRD based APIs now correctly have a status subresource.

No other changes have been made to the supervisor APIs.
```
