### PR TITLE
Upgrade Debian base images from 10.7 to 10.8.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,11 +27,11 @@ RUN \
     ./cmd/local-user-authenticator/...
 
 # Use a Debian slim image to grab a reasonable default CA bundle.
-FROM debian:10.7-slim AS get-ca-bundle-env
+FROM debian:10.8-slim AS get-ca-bundle-env
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/* /var/cache/debconf/*
 
 # Use a runtime image based on Debian slim.
-FROM debian:10.7-slim
+FROM debian:10.8-slim
 COPY --from=get-ca-bundle-env /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 # Copy the binaries from the build-env stage.

--- a/hack/lib/tilt/Tiltfile
+++ b/hack/lib/tilt/Tiltfile
@@ -152,7 +152,7 @@ k8s_yaml(local([
     '--data-value namespace=concierge ' +
     '--data-value image_repo=image/concierge ' +
     '--data-value image_tag=tilt-dev ' +
-    '--data-value kube_cert_agent_image=debian:10.7-slim ' +
+    '--data-value kube_cert_agent_image=debian:10.8-slim ' +
     '--data-value discovery_url=$(TERM=dumb kubectl cluster-info | awk \'/master|control plane/ {print $NF}\') ' +
     '--data-value log_level=debug ' +
     '--data-value-yaml replicas=1 ' +

--- a/hack/lib/tilt/concierge.Dockerfile
+++ b/hack/lib/tilt/concierge.Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Use a runtime image based on Debian slim
-FROM debian:10.7-slim
+FROM debian:10.8-slim
 
 # Copy the binary which was built outside the container.
 COPY build/pinniped-concierge /usr/local/bin/pinniped-concierge

--- a/hack/lib/tilt/local-user-authenticator.Dockerfile
+++ b/hack/lib/tilt/local-user-authenticator.Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Use a runtime image based on Debian slim
-FROM debian:10.7-slim
+FROM debian:10.8-slim
 
 # Copy the binary which was built outside the container.
 COPY build/local-user-authenticator /usr/local/bin/local-user-authenticator

--- a/hack/lib/tilt/supervisor.Dockerfile
+++ b/hack/lib/tilt/supervisor.Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Use a runtime image based on Debian slim
-FROM debian:10.7-slim
+FROM debian:10.8-slim
 
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 

--- a/test/deploy/dex/proxy.yaml
+++ b/test/deploy/dex/proxy.yaml
@@ -48,7 +48,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 2
         - name: accesslogs
-          image: debian:10.7-slim
+          image: debian:10.8-slim
           command:
             - "/bin/sh"
             - "-c"


### PR DESCRIPTION
Updates our Debian base image layers in several places to 10.8: https://www.debian.org/News/2021/20210206

Replaces this Dependabot PR which misses some of the upgrades and is broken because of our CLA bot: #400 


**Release note**:
```release-note
Updated base image to Debian 10.8.
```
