### PR TITLE
Make TestGetPinnipedCategory and TestKubeClientOwnerRef tests more resilient.

### DIFF
--- a/test/integration/kubeclient_test.go
+++ b/test/integration/kubeclient_test.go
@@ -5,6 +5,7 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -75,15 +76,18 @@ func TestKubeClientOwnerRef(t *testing.T) {
 		UID:        parentSecret.UID,
 	}
 
+	snorlaxAPIGroup := fmt.Sprintf("%s.snorlax.dev", library.RandHex(t, 8))
 	parentAPIService, err := regularAggregationClient.ApiregistrationV1().APIServices().Create(
 		ctx,
 		&apiregistrationv1.APIService{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "v1.snorlax.dev",
+				Name:        "v1." + snorlaxAPIGroup,
+				Labels:      map[string]string{"pinniped.dev/test": ""},
+				Annotations: map[string]string{"pinniped.dev/testName": t.Name()},
 			},
 			Spec: apiregistrationv1.APIServiceSpec{
 				Version:              "v1",
-				Group:                "snorlax.dev",
+				Group:                snorlaxAPIGroup,
 				GroupPriorityMinimum: 10_000,
 				VersionPriority:      500,
 			},
@@ -183,16 +187,19 @@ func TestKubeClientOwnerRef(t *testing.T) {
 	})
 
 	// cluster scoped API service should be owned by the other one we created above
+	pandasAPIGroup := fmt.Sprintf("%s.pandas.dev", library.RandHex(t, 8))
 	apiService, err := ownerRefClient.Aggregation.ApiregistrationV1().APIServices().Create(
 		ctx,
 		&apiregistrationv1.APIService{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            "v1.pandas.dev",
+				Name:            "v1." + pandasAPIGroup,
 				OwnerReferences: nil, // no owner refs set
+				Labels:          map[string]string{"pinniped.dev/test": ""},
+				Annotations:     map[string]string{"pinniped.dev/testName": t.Name()},
 			},
 			Spec: apiregistrationv1.APIServiceSpec{
 				Version:              "v1",
-				Group:                "pandas.dev",
+				Group:                pandasAPIGroup,
 				GroupPriorityMinimum: 10_000,
 				VersionPriority:      500,
 			},


### PR DESCRIPTION
If the test is run immediately after the Concierge is installed, the API server can still have broken discovery data and return an error on the first call.
This commit adds a retry loop to attempt this first kubectl command for up to 60s before declaring failure.
The subsequent tests should be covered by this as well since they are not run in parallel.

Attempts to fix https://github.com/vmware-tanzu/pinniped/issues/408.


**Release note**:

```release-note
NONE
```
