### PR TITLE
Ignore test coverage for local-user-authenticator.

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,7 +2,7 @@ codecov:
   strict_yaml_branch: main
   require_ci_to_pass: no
   notify:
-    wait_for_ci: no  
+    wait_for_ci: no
 coverage:
   status:
     project:
@@ -11,3 +11,5 @@ coverage:
     patch:
       default:
         informational: true
+ignore:
+- cmd/local-user-authenticator/


### PR DESCRIPTION
This should ignore coverage changes in this test-only component, using the syntax described here: https://docs.codecov.io/docs/ignoring-paths.

Addresses #489.

**Release note**:

```release-note
NONE
```
