### PR TITLE
Rework integration test assertions for pod restarts.

### DIFF
--- a/test/integration/cli_test.go
+++ b/test/integration/cli_test.go
@@ -35,8 +35,6 @@ import (
 func TestCLIGetKubeconfigStaticToken(t *testing.T) {
 	env := library.IntegrationEnv(t).WithCapability(library.ClusterSigningKeyIsAvailable)
 
-	library.AssertNoRestartsDuringTest(t, env.ConciergeNamespace, "")
-
 	// Create a test webhook configuration to use with the CLI.
 	ctx, cancelFunc := context.WithTimeout(context.Background(), 4*time.Minute)
 	defer cancelFunc()

--- a/test/integration/concierge_api_serving_certs_test.go
+++ b/test/integration/concierge_api_serving_certs_test.go
@@ -23,8 +23,6 @@ func TestAPIServingCertificateAutoCreationAndRotation(t *testing.T) {
 	env := library.IntegrationEnv(t)
 	defaultServingCertResourceName := env.ConciergeAppName + "-api-tls-serving-certificate"
 
-	library.AssertNoRestartsDuringTest(t, env.ConciergeNamespace, "")
-
 	tests := []struct {
 		name          string
 		forceRotation func(context.Context, kubernetes.Interface, string) error

--- a/test/integration/concierge_client_test.go
+++ b/test/integration/concierge_client_test.go
@@ -57,8 +57,6 @@ var maskKey = func(s string) string { return strings.ReplaceAll(s, "TESTING KEY"
 func TestClient(t *testing.T) {
 	env := library.IntegrationEnv(t).WithCapability(library.ClusterSigningKeyIsAvailable)
 
-	library.AssertNoRestartsDuringTest(t, env.ConciergeNamespace, "")
-
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 

--- a/test/integration/concierge_credentialissuer_test.go
+++ b/test/integration/concierge_credentialissuer_test.go
@@ -23,8 +23,6 @@ func TestCredentialIssuer(t *testing.T) {
 	client := library.NewConciergeClientset(t)
 	aggregatedClientset := library.NewAggregatedClientset(t)
 
-	library.AssertNoRestartsDuringTest(t, env.ConciergeNamespace, "")
-
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 

--- a/test/integration/concierge_credentialrequest_test.go
+++ b/test/integration/concierge_credentialrequest_test.go
@@ -23,9 +23,7 @@ import (
 )
 
 func TestUnsuccessfulCredentialRequest(t *testing.T) {
-	env := library.IntegrationEnv(t).WithCapability(library.AnonymousAuthenticationSupported)
-
-	library.AssertNoRestartsDuringTest(t, env.ConciergeNamespace, "")
+	_ = library.IntegrationEnv(t).WithCapability(library.AnonymousAuthenticationSupported)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -43,8 +41,6 @@ func TestUnsuccessfulCredentialRequest(t *testing.T) {
 
 func TestSuccessfulCredentialRequest(t *testing.T) {
 	env := library.IntegrationEnv(t).WithCapability(library.ClusterSigningKeyIsAvailable)
-
-	library.AssertNoRestartsDuringTest(t, env.ConciergeNamespace, "")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
 	defer cancel()
@@ -131,9 +127,7 @@ func TestSuccessfulCredentialRequest(t *testing.T) {
 }
 
 func TestFailedCredentialRequestWhenTheRequestIsValidButTheTokenDoesNotAuthenticateTheUser(t *testing.T) {
-	env := library.IntegrationEnv(t).WithCapability(library.ClusterSigningKeyIsAvailable)
-
-	library.AssertNoRestartsDuringTest(t, env.ConciergeNamespace, "")
+	_ = library.IntegrationEnv(t).WithCapability(library.ClusterSigningKeyIsAvailable)
 
 	// Create a testWebhook so we have a legitimate authenticator to pass to the
 	// TokenCredentialRequest API.
@@ -154,9 +148,7 @@ func TestFailedCredentialRequestWhenTheRequestIsValidButTheTokenDoesNotAuthentic
 }
 
 func TestCredentialRequest_ShouldFailWhenRequestDoesNotIncludeToken(t *testing.T) {
-	env := library.IntegrationEnv(t).WithCapability(library.ClusterSigningKeyIsAvailable)
-
-	library.AssertNoRestartsDuringTest(t, env.ConciergeNamespace, "")
+	_ = library.IntegrationEnv(t).WithCapability(library.ClusterSigningKeyIsAvailable)
 
 	// Create a testWebhook so we have a legitimate authenticator to pass to the
 	// TokenCredentialRequest API.
@@ -184,9 +176,7 @@ func TestCredentialRequest_ShouldFailWhenRequestDoesNotIncludeToken(t *testing.T
 }
 
 func TestCredentialRequest_OtherwiseValidRequestWithRealTokenShouldFailWhenTheClusterIsNotCapable(t *testing.T) {
-	env := library.IntegrationEnv(t).WithoutCapability(library.ClusterSigningKeyIsAvailable).WithCapability(library.AnonymousAuthenticationSupported)
-
-	library.AssertNoRestartsDuringTest(t, env.ConciergeNamespace, "")
+	_ = library.IntegrationEnv(t).WithoutCapability(library.ClusterSigningKeyIsAvailable).WithCapability(library.AnonymousAuthenticationSupported)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()

--- a/test/integration/concierge_kubecertagent_test.go
+++ b/test/integration/concierge_kubecertagent_test.go
@@ -28,8 +28,6 @@ const (
 func TestKubeCertAgent(t *testing.T) {
 	env := library.IntegrationEnv(t).WithCapability(library.ClusterSigningKeyIsAvailable)
 
-	library.AssertNoRestartsDuringTest(t, env.ConciergeNamespace, "")
-
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 

--- a/test/integration/e2e_test.go
+++ b/test/integration/e2e_test.go
@@ -46,9 +46,6 @@ func TestE2EFullIntegration(t *testing.T) {
 	defer library.DumpLogs(t, env.SupervisorNamespace, "")
 	defer library.DumpLogs(t, "dex", "app=proxy")
 
-	library.AssertNoRestartsDuringTest(t, env.ConciergeNamespace, "")
-	library.AssertNoRestartsDuringTest(t, env.SupervisorNamespace, "")
-
 	ctx, cancelFunc := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancelFunc()
 

--- a/test/integration/supervisor_discovery_test.go
+++ b/test/integration/supervisor_discovery_test.go
@@ -45,8 +45,6 @@ func TestSupervisorOIDCDiscovery(t *testing.T) {
 	env := library.IntegrationEnv(t)
 	client := library.NewSupervisorClientset(t)
 
-	library.AssertNoRestartsDuringTest(t, env.SupervisorNamespace, "")
-
 	ns := env.SupervisorNamespace
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
@@ -152,8 +150,6 @@ func TestSupervisorTLSTerminationWithSNI(t *testing.T) {
 	pinnipedClient := library.NewSupervisorClientset(t)
 	kubeClient := library.NewKubernetesClientset(t)
 
-	library.AssertNoRestartsDuringTest(t, env.SupervisorNamespace, "")
-
 	ns := env.SupervisorNamespace
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
@@ -224,8 +220,6 @@ func TestSupervisorTLSTerminationWithDefaultCerts(t *testing.T) {
 	env := library.IntegrationEnv(t)
 	pinnipedClient := library.NewSupervisorClientset(t)
 	kubeClient := library.NewKubernetesClientset(t)
-
-	library.AssertNoRestartsDuringTest(t, env.SupervisorNamespace, "")
 
 	ns := env.SupervisorNamespace
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)

--- a/test/integration/supervisor_healthz_test.go
+++ b/test/integration/supervisor_healthz_test.go
@@ -29,8 +29,6 @@ func TestSupervisorHealthz(t *testing.T) {
 		t.Skip("PINNIPED_TEST_SUPERVISOR_HTTP_ADDRESS not defined")
 	}
 
-	library.AssertNoRestartsDuringTest(t, env.SupervisorNamespace, "")
-
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 

--- a/test/integration/supervisor_login_test.go
+++ b/test/integration/supervisor_login_test.go
@@ -44,8 +44,6 @@ func TestSupervisorLogin(t *testing.T) {
 	defer library.DumpLogs(t, env.SupervisorNamespace, "")
 	defer library.DumpLogs(t, "dex", "app=proxy")
 
-	library.AssertNoRestartsDuringTest(t, env.SupervisorNamespace, "")
-
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 

--- a/test/integration/supervisor_secrets_test.go
+++ b/test/integration/supervisor_secrets_test.go
@@ -24,8 +24,6 @@ func TestSupervisorSecrets(t *testing.T) {
 	kubeClient := library.NewKubernetesClientset(t)
 	supervisorClient := library.NewSupervisorClientset(t)
 
-	library.AssertNoRestartsDuringTest(t, env.SupervisorNamespace, "")
-
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 

--- a/test/integration/supervisor_upstream_test.go
+++ b/test/integration/supervisor_upstream_test.go
@@ -17,8 +17,6 @@ import (
 func TestSupervisorUpstreamOIDCDiscovery(t *testing.T) {
 	env := library.IntegrationEnv(t)
 
-	library.AssertNoRestartsDuringTest(t, env.SupervisorNamespace, "")
-
 	t.Run("invalid missing secret and bad issuer", func(t *testing.T) {
 		t.Parallel()
 		spec := v1alpha1.OIDCIdentityProviderSpec{

--- a/test/library/assertions.go
+++ b/test/library/assertions.go
@@ -29,9 +29,9 @@ func RequireEventuallyWithoutError(
 	require.NoError(t, wait.PollImmediate(tick, waitFor, f), msgAndArgs...)
 }
 
-// NewRestartAssertion allows a caller to assert that there were no restarts for a Pod in the
+// assertNoRestartsDuringTest allows a caller to assert that there were no restarts for a Pod in the
 // provided namespace with the provided labelSelector during the lifetime of a test.
-func AssertNoRestartsDuringTest(t *testing.T, namespace, labelSelector string) {
+func assertNoRestartsDuringTest(t *testing.T, namespace, labelSelector string) {
 	t.Helper()
 
 	previousRestartCounts := getRestartCounts(t, namespace, labelSelector)

--- a/test/library/dumplogs.go
+++ b/test/library/dumplogs.go
@@ -6,12 +6,15 @@ package library
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 // DumpLogs is meant to be called in a `defer` to dump the logs of components in the cluster on a test failure.
@@ -25,25 +28,37 @@ func DumpLogs(t *testing.T, namespace string, labelSelector string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	logTailLines := int64(40)
 	pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
 	require.NoError(t, err)
 
 	for _, pod := range pods.Items {
 		for _, container := range pod.Status.ContainerStatuses {
-			t.Logf("pod %s/%s container %s restarted %d times:", pod.Namespace, pod.Name, container.Name, container.RestartCount)
-			req := kubeClient.CoreV1().Pods(namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
-				Container: container.Name,
-				TailLines: &logTailLines,
-			})
-			logReader, err := req.Stream(ctx)
-			require.NoError(t, err)
-
-			scanner := bufio.NewScanner(logReader)
-			for scanner.Scan() {
-				t.Logf("%s/%s/%s > %s", pod.Namespace, pod.Name, container.Name, scanner.Text())
+			if container.RestartCount > 0 {
+				dumpContainerLogs(ctx, t, kubeClient, pod.Namespace, pod.Name, container.Name, true)
 			}
-			require.NoError(t, scanner.Err())
+			dumpContainerLogs(ctx, t, kubeClient, pod.Namespace, pod.Name, container.Name, false)
 		}
 	}
+}
+
+func dumpContainerLogs(ctx context.Context, t *testing.T, kubeClient kubernetes.Interface, namespace, pod, container string, prev bool) {
+	logTailLines := int64(40)
+	shortName := fmt.Sprintf("%s/%s/%s", namespace, pod, container)
+	logReader, err := kubeClient.CoreV1().Pods(namespace).GetLogs(pod, &corev1.PodLogOptions{
+		Container: container,
+		TailLines: &logTailLines,
+		Previous:  prev,
+	}).Stream(ctx)
+	if !assert.NoErrorf(t, err, "failed to stream logs for container %s", shortName) {
+		return
+	}
+	scanner := bufio.NewScanner(logReader)
+	for scanner.Scan() {
+		prefix := shortName
+		if prev {
+			prefix += " (previous)"
+		}
+		t.Logf("%s > %s", prefix, scanner.Text())
+	}
+	assert.NoError(t, scanner.Err(), "failed to read logs from container %s", shortName)
 }

--- a/test/library/env.go
+++ b/test/library/env.go
@@ -97,6 +97,10 @@ func IntegrationEnv(t *testing.T) *TestEnv {
 
 	loadEnvVars(t, &result)
 
+	// In every integration test, assert that no pods in our namespaces restart during the test.
+	assertNoRestartsDuringTest(t, result.ConciergeNamespace, "")
+	assertNoRestartsDuringTest(t, result.SupervisorNamespace, "")
+
 	result.t = t
 	return &result
 }


### PR DESCRIPTION
A few changes related to how we assert over properties of the test cluster during integration tests:

- Remove `library.AssertNoRestartsDuringTest()` and make that assertion implicit in `library.IntegrationEnv()`. This means we (hopefully) can't forget to include these assertions in any integration test.
- Extend `library.DumpLogs()` to dump logs from the previous container, if one exists. This is important in case the container has crashed and has been restarted.
-  Extend the (now-internal) `assertNoRestartsDuringTest()` function to dump logs from containers that restarted.
- Memoize `library.IntegrationEnv()` so it's only constructed once per test. 

**Release note**:

This is a test-only change

```release-note
NONE
```
