### PR TITLE
Update getting started link

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To learn more, see [architecture](https://pinniped.dev/docs/background/architect
 
 ## Getting started with Pinniped
 
-Care to kick the tires? It's easy to [install and try Pinniped](https://pinniped.dev/docs/demo/).
+Care to kick the tires? It's easy to [install and try Pinniped](https://pinniped.dev/docs/tutorials).
 
 ## Community meetings
 


### PR DESCRIPTION
Hello,

The `/docs/demo` docs site path linked from the repo README appears to no longer be supported.

I've proposed having the repo README link to the `/docs/tutorials` path that seems to have replaced it, but I could see linking to a particular demo as well.

Thanks,
Andrew

```release-note
NONE
```
