### PR TITLE
Tweak some assertions in TestSupervisorOIDCDiscovery.

### DIFF
--- a/test/integration/supervisor_discovery_test.go
+++ b/test/integration/supervisor_discovery_test.go
@@ -602,18 +602,25 @@ func requireDelete(t *testing.T, client pinnipedclientset.Interface, ns, name st
 
 func requireStatus(t *testing.T, client pinnipedclientset.Interface, ns, name string, status v1alpha1.FederationDomainStatusCondition) {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
 
 	var federationDomain *v1alpha1.FederationDomain
 	var err error
 	assert.Eventually(t, func() bool {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
 		federationDomain, err = client.ConfigV1alpha1().FederationDomains(ns).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
-			t.Logf("error trying to get FederationDomain: %s", err.Error())
+			t.Logf("error trying to get FederationDomain %s/%s: %v", ns, name, err)
+			return false
 		}
-		return err == nil && federationDomain.Status.Status == status
-	}, time.Minute, 200*time.Millisecond)
+
+		if federationDomain.Status.Status != status {
+			t.Logf("found FederationDomain %s/%s with status %s", ns, name, federationDomain.Status.Status)
+			return false
+		}
+		return true
+	}, 5*time.Minute, 200*time.Millisecond)
 	require.NoError(t, err)
 	require.Equalf(t, status, federationDomain.Status.Status, "unexpected status (message = '%s')", federationDomain.Status.Message)
 }


### PR DESCRIPTION
We've seen some test flakes caused by this test. Some small changes:

- Use a 30s timeout for each iteration of the test loop (so each iteration needs to check or fail more quickly).
- Log a bit more during the checks so we can diagnose what's going on.
- Increase the overall timeout from one minute to five minutes

Example test failure:
```
    supervisor_discovery_test.go:117: 
        	Error Trace:	client.go:284
        	            				supervisor_discovery_test.go:444
        	            				supervisor_discovery_test.go:117
        	Error:      	Received unexpected error:
        	            	Post "https://6E33A366107DE5DF604520AB177790CD.gr7.us-west-2.eks.amazonaws.com/apis/config.supervisor.pinniped.dev/v1alpha1/namespaces/supervisor/federationdomains": context deadline exceeded
        	Test:       	TestSupervisorOIDCDiscovery
        	Messages:   	could not create test FederationDomain
```

**Release note**:

This is a test-only change.

```release-note
NONE
```
