### PR TITLE
Add annotation to make the idle timeout be over 1 hour rather than 1 minute

### DIFF
--- a/internal/controller/impersonatorconfig/impersonator_config.go
+++ b/internal/controller/impersonatorconfig/impersonator_config.go
@@ -441,6 +441,9 @@ func (c *impersonatorConfigController) ensureLoadBalancerIsStarted(ctx context.C
 			Name:      c.generatedLoadBalancerServiceName,
 			Namespace: c.namespace,
 			Labels:    c.labels,
+			Annotations: map[string]string{
+				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "4000", // AWS' default is to time out after 60 seconds idle. Prevent that.
+			},
 		},
 	}
 	plog.Info("creating load balancer for impersonation proxy",

--- a/internal/controller/impersonatorconfig/impersonator_config_test.go
+++ b/internal/controller/impersonatorconfig/impersonator_config_test.go
@@ -882,6 +882,7 @@ func TestImpersonatorConfigControllerSync(t *testing.T) {
 			r.Equal(corev1.ServiceTypeLoadBalancer, createdLoadBalancerService.Spec.Type)
 			r.Equal("app-name", createdLoadBalancerService.Spec.Selector["app"])
 			r.Equal(labels, createdLoadBalancerService.Labels)
+			r.Equal(map[string]string{"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "4000"}, createdLoadBalancerService.Annotations)
 		}
 
 		var requireLoadBalancerWasDeleted = func(action coretesting.Action) {


### PR DESCRIPTION
Note that 4000 seconds is the maximum value that AWS allows.