### PR TITLE
Use "0.0.0" as our fake version instead of "?.?.?" to avoid a panic.

### DIFF
--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -55,9 +55,11 @@ kube::version::get_version_vars() {
 
     else
       # KUBE_GIT_VERSION was not supplied
-      KUBE_GIT_VERSION='?.?.?'
-      KUBE_GIT_MAJOR='?'
-      KUBE_GIT_MINOR='?'
+      # These values need to pass the validation in k8s.io/component-base/metrics:
+      # https://github.com/kubernetes/component-base/blob/v0.20.5/metrics/version_parser.go#L28-L50
+      KUBE_GIT_VERSION='0.0.0'
+      KUBE_GIT_MAJOR='0'
+      KUBE_GIT_MINOR='0'
     fi
   fi
 }


### PR DESCRIPTION
These values need to pass the validation in k8s.io/component-base/metrics: https://github.com/kubernetes/component-base/blob/v0.20.5/metrics/version_parser.go#L28-L50

This should address #541.

**Release note**:
```release-note
Fix a panic when installing the Pinniped CLI from Homebrew using `--HEAD`.
```
