### PR TITLE
Generate more helpful context/cluster/user names in `pinniped get kubeconfig`

### DIFF
--- a/cmd/pinniped/cmd/kubeconfig_test.go
+++ b/cmd/pinniped/cmd/kubeconfig_test.go
@@ -73,6 +73,7 @@ func TestGetKubeconfig(t *testing.T) {
 				      --concierge-endpoint string             API base for the Concierge endpoint
 				      --concierge-mode mode                   Concierge mode of operation (default TokenCredentialRequestAPI)
 				      --concierge-skip-wait                   Skip waiting for any pending Concierge strategies to become ready (default: false)
+				      --generated-name-suffix string          Suffix to append to generated cluster, context, user kubeconfig entries (default "-pinniped")
 				  -h, --help                                  help for kubeconfig
 				      --kubeconfig string                     Path to kubeconfig file
 				      --kubeconfig-context string             Kubeconfig context name (default: current active context)
@@ -133,7 +134,7 @@ func TestGetKubeconfig(t *testing.T) {
 			`),
 		},
 		{
-			name: "invalid kubeconfig context",
+			name: "invalid kubeconfig context, missing",
 			args: []string{
 				"--kubeconfig", "./testdata/kubeconfig.yaml",
 				"--kubeconfig-context", "invalid",
@@ -141,6 +142,28 @@ func TestGetKubeconfig(t *testing.T) {
 			wantError: true,
 			wantStderr: here.Doc(`
 				Error: could not load --kubeconfig/--kubeconfig-context: no such context "invalid"
+			`),
+		},
+		{
+			name: "invalid kubeconfig context, missing cluster",
+			args: []string{
+				"--kubeconfig", "./testdata/kubeconfig.yaml",
+				"--kubeconfig-context", "invalid-context-no-such-cluster",
+			},
+			wantError: true,
+			wantStderr: here.Doc(`
+				Error: could not load --kubeconfig/--kubeconfig-context: no such cluster "invalid-cluster"
+			`),
+		},
+		{
+			name: "invalid kubeconfig context, missing user",
+			args: []string{
+				"--kubeconfig", "./testdata/kubeconfig.yaml",
+				"--kubeconfig-context", "invalid-context-no-such-user",
+			},
+			wantError: true,
+			wantStderr: here.Doc(`
+				Error: could not load --kubeconfig/--kubeconfig-context: no such user "invalid-user"
 			`),
 		},
 		{
@@ -584,17 +607,17 @@ func TestGetKubeconfig(t *testing.T) {
         		- cluster:
         		    certificate-authority-data: ZmFrZS1jZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YS12YWx1ZQ==
         		    server: https://fake-server-url-value
-        		  name: pinniped
+        		  name: kind-cluster-pinniped
         		contexts:
         		- context:
-        		    cluster: pinniped
-        		    user: pinniped
-        		  name: pinniped
-        		current-context: pinniped
+        		    cluster: kind-cluster-pinniped
+        		    user: kind-user-pinniped
+        		  name: kind-context-pinniped
+        		current-context: kind-context-pinniped
         		kind: Config
         		preferences: {}
         		users:
-        		- name: pinniped
+        		- name: kind-user-pinniped
         		  user:
         		    exec:
         		      apiVersion: client.authentication.k8s.io/v1beta1
@@ -653,17 +676,17 @@ func TestGetKubeconfig(t *testing.T) {
         		- cluster:
         		    certificate-authority-data: ZmFrZS1jZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YS12YWx1ZQ==
         		    server: https://fake-server-url-value
-        		  name: pinniped
+        		  name: kind-cluster-pinniped
         		contexts:
         		- context:
-        		    cluster: pinniped
-        		    user: pinniped
-        		  name: pinniped
-        		current-context: pinniped
+        		    cluster: kind-cluster-pinniped
+        		    user: kind-user-pinniped
+        		  name: kind-context-pinniped
+        		current-context: kind-context-pinniped
         		kind: Config
         		preferences: {}
         		users:
-        		- name: pinniped
+        		- name: kind-user-pinniped
         		  user:
         		    exec:
         		      apiVersion: client.authentication.k8s.io/v1beta1
@@ -733,17 +756,17 @@ func TestGetKubeconfig(t *testing.T) {
         		- cluster:
         		    certificate-authority-data: ZmFrZS1jZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YS12YWx1ZQ==
         		    server: https://fake-server-url-value
-        		  name: pinniped
+        		  name: kind-cluster-pinniped
         		contexts:
         		- context:
-        		    cluster: pinniped
-        		    user: pinniped
-        		  name: pinniped
-        		current-context: pinniped
+        		    cluster: kind-cluster-pinniped
+        		    user: kind-user-pinniped
+        		  name: kind-context-pinniped
+        		current-context: kind-context-pinniped
         		kind: Config
         		preferences: {}
         		users:
-        		- name: pinniped
+        		- name: kind-user-pinniped
         		  user:
         		    exec:
         		      apiVersion: client.authentication.k8s.io/v1beta1
@@ -785,6 +808,7 @@ func TestGetKubeconfig(t *testing.T) {
 				"--oidc-debug-session-cache",
 				"--oidc-request-audience", "test-audience",
 				"--skip-validation",
+				"--generated-name-suffix", "-sso",
 			},
 			conciergeObjects: []runtime.Object{
 				&configv1alpha1.CredentialIssuer{
@@ -815,17 +839,17 @@ func TestGetKubeconfig(t *testing.T) {
         		- cluster:
         		    certificate-authority-data: %s
         		    server: https://explicit-concierge-endpoint.example.com
-        		  name: pinniped
+        		  name: kind-cluster-sso
         		contexts:
         		- context:
-        		    cluster: pinniped
-        		    user: pinniped
-        		  name: pinniped
-        		current-context: pinniped
+        		    cluster: kind-cluster-sso
+        		    user: kind-user-sso
+        		  name: kind-context-sso
+        		current-context: kind-context-sso
         		kind: Config
         		preferences: {}
         		users:
-        		- name: pinniped
+        		- name: kind-user-sso
         		  user:
         		    exec:
         		      apiVersion: client.authentication.k8s.io/v1beta1
@@ -929,17 +953,17 @@ func TestGetKubeconfig(t *testing.T) {
         		- cluster:
         		    certificate-authority-data: %s
         		    server: https://impersonation-proxy-endpoint.test
-        		  name: pinniped
+        		  name: kind-cluster-pinniped
         		contexts:
         		- context:
-        		    cluster: pinniped
-        		    user: pinniped
-        		  name: pinniped
-        		current-context: pinniped
+        		    cluster: kind-cluster-pinniped
+        		    user: kind-user-pinniped
+        		  name: kind-context-pinniped
+        		current-context: kind-context-pinniped
         		kind: Config
         		preferences: {}
         		users:
-        		- name: pinniped
+        		- name: kind-user-pinniped
         		  user:
         		    exec:
         		      apiVersion: client.authentication.k8s.io/v1beta1
@@ -1035,17 +1059,17 @@ func TestGetKubeconfig(t *testing.T) {
         		- cluster:
         		    certificate-authority-data: dGVzdC1jb25jaWVyZ2UtY2E=
         		    server: https://impersonation-proxy-endpoint.test
-        		  name: pinniped
+        		  name: kind-cluster-pinniped
         		contexts:
         		- context:
-        		    cluster: pinniped
-        		    user: pinniped
-        		  name: pinniped
-        		current-context: pinniped
+        		    cluster: kind-cluster-pinniped
+        		    user: kind-user-pinniped
+        		  name: kind-context-pinniped
+        		current-context: kind-context-pinniped
         		kind: Config
         		preferences: {}
         		users:
-        		- name: pinniped
+        		- name: kind-user-pinniped
         		  user:
         		    exec:
         		      apiVersion: client.authentication.k8s.io/v1beta1

--- a/cmd/pinniped/cmd/testdata/kubeconfig.yaml
+++ b/cmd/pinniped/cmd/testdata/kubeconfig.yaml
@@ -3,25 +3,33 @@ clusters:
   - cluster:
       certificate-authority-data: ZmFrZS1jZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YS12YWx1ZQ== # fake-certificate-authority-data-value
       server: https://fake-server-url-value
-    name: kind-kind
+    name: kind-cluster
   - cluster:
       certificate-authority-data: c29tZS1vdGhlci1mYWtlLWNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhLXZhbHVl # some-other-fake-certificate-authority-data-value
       server: https://some-other-fake-server-url-value
     name: some-other-cluster
 contexts:
   - context:
-      cluster: kind-kind
-      user: kind-kind
-    name: kind-kind
+      cluster: kind-cluster
+      user: kind-user
+    name: kind-context
   - context:
       cluster: some-other-cluster
       user: some-other-user
     name: some-other-context
-current-context: kind-kind
+  - context:
+      cluster: invalid-cluster
+      user: some-other-user
+    name: invalid-context-no-such-cluster
+  - context:
+      cluster: some-other-cluster
+      user: invalid-user
+    name: invalid-context-no-such-user
+current-context: kind-context
 kind: Config
 preferences: {}
 users:
-  - name: kind-kind
+  - name: kind-user
     user:
       client-certificate-data: ZmFrZS1jbGllbnQtY2VydGlmaWNhdGUtZGF0YS12YWx1ZQ== # fake-client-certificate-data-value
       client-key-data: ZmFrZS1jbGllbnQta2V5LWRhdGEtdmFsdWU= # fake-client-key-data-value

--- a/cmd/pinniped/cmd/whoami_test.go
+++ b/cmd/pinniped/cmd/whoami_test.go
@@ -53,7 +53,7 @@ func TestWhoami(t *testing.T) {
 			wantStdout: here.Doc(`
 				Current cluster info:
 
-				Name: kind-kind
+				Name: kind-cluster
 				URL: https://fake-server-url-value
 
 				Current user info:
@@ -68,7 +68,7 @@ func TestWhoami(t *testing.T) {
 			wantStdout: here.Doc(`
 				Current cluster info:
 
-				Name: kind-kind
+				Name: kind-cluster
 				URL: https://fake-server-url-value
 
 				Current user info:
@@ -84,7 +84,7 @@ func TestWhoami(t *testing.T) {
 			wantStdout: here.Doc(`
 				Current cluster info:
 
-				Name: kind-kind
+				Name: kind-cluster
 				URL: https://fake-server-url-value
 
 				Current user info:
@@ -100,7 +100,7 @@ func TestWhoami(t *testing.T) {
 			wantStdout: here.Doc(`
 				Current cluster info:
 
-				Name: kind-kind
+				Name: kind-cluster
 				URL: https://fake-server-url-value
 
 				Current user info:
@@ -209,12 +209,12 @@ func TestWhoami(t *testing.T) {
 			name: "different kubeconfig context, but same as current",
 			args: []string{
 				"--kubeconfig", "./testdata/kubeconfig.yaml",
-				"--kubeconfig-context", "kind-kind",
+				"--kubeconfig-context", "kind-context",
 			},
 			wantStdout: here.Doc(`
 				Current cluster info:
 
-				Name: kind-kind
+				Name: kind-cluster
 				URL: https://fake-server-url-value
 
 				Current user info:


### PR DESCRIPTION
Before this change, the "context", "cluster", and "user" fields in generated kubeconfig YAML were always hardcoded to "pinniped". This could be confusing if you generated many kubeconfigs for different clusters.

After this change, the fields will be copied from their names in the original kubeconfig, suffixed with "-pinniped". This suffix can be overridden by setting the new `--generated-name-suffix` CLI flag.

The goal of this change is that you can distinguish between kubeconfigs generated for different clusters, as well as being able to distinguish between the Pinniped and original (admin) kubeconfigs for a cluster.

See #513 for more context.

**Release note**:

```release-note
The `pinniped get kubeconfig` command now generates more helpful "context", "cluster", and "user" names. The names will now be copied from the original kubeconfig but suffixed with "-pinniped". This suffix can be overridden with the`--generated-name-suffix` flag.
```
