### PR TITLE
CLI cluster-specific credentials enhancements (followup to #562)

### DIFF
--- a/cmd/pinniped/cmd/kubeconfig_test.go
+++ b/cmd/pinniped/cmd/kubeconfig_test.go
@@ -73,6 +73,7 @@ func TestGetKubeconfig(t *testing.T) {
 				      --concierge-endpoint string             API base for the Concierge endpoint
 				      --concierge-mode mode                   Concierge mode of operation (default TokenCredentialRequestAPI)
 				      --concierge-skip-wait                   Skip waiting for any pending Concierge strategies to become ready (default: false)
+				      --credential-cache string               Path to cluster-specific credentials cache
 				      --generated-name-suffix string          Suffix to append to generated cluster, context, user kubeconfig entries (default "-pinniped")
 				  -h, --help                                  help for kubeconfig
 				      --kubeconfig string                     Path to kubeconfig file
@@ -642,6 +643,7 @@ func TestGetKubeconfig(t *testing.T) {
 				"--kubeconfig", "./testdata/kubeconfig.yaml",
 				"--static-token-env", "TEST_TOKEN",
 				"--skip-validation",
+				"--credential-cache", "",
 			},
 			conciergeObjects: []runtime.Object{
 				&configv1alpha1.CredentialIssuer{
@@ -699,6 +701,7 @@ func TestGetKubeconfig(t *testing.T) {
         		      - --concierge-authenticator-type=webhook
         		      - --concierge-endpoint=https://fake-server-url-value
         		      - --concierge-ca-bundle-data=ZmFrZS1jZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YS12YWx1ZQ==
+        		      - --credential-cache=
         		      - --token-env=TEST_TOKEN
         		      command: '.../path/to/pinniped'
         		      env: []
@@ -809,6 +812,7 @@ func TestGetKubeconfig(t *testing.T) {
 				"--oidc-request-audience", "test-audience",
 				"--skip-validation",
 				"--generated-name-suffix", "-sso",
+				"--credential-cache", "/path/to/cache/dir/credentials.yaml",
 			},
 			conciergeObjects: []runtime.Object{
 				&configv1alpha1.CredentialIssuer{
@@ -862,6 +866,7 @@ func TestGetKubeconfig(t *testing.T) {
         		      - --concierge-authenticator-type=webhook
         		      - --concierge-endpoint=https://explicit-concierge-endpoint.example.com
         		      - --concierge-ca-bundle-data=%s
+        		      - --credential-cache=/path/to/cache/dir/credentials.yaml
         		      - --issuer=https://example.com/issuer
         		      - --client-id=pinniped-cli
         		      - --scopes=offline_access,openid,pinniped:request-audience

--- a/cmd/pinniped/cmd/login.go
+++ b/cmd/pinniped/cmd/login.go
@@ -5,6 +5,8 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	clientauthv1beta1 "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
+	"k8s.io/client-go/tools/auth/exec"
 )
 
 //nolint: gochecknoglobals
@@ -19,4 +21,16 @@ var loginCmd = &cobra.Command{
 //nolint: gochecknoinits
 func init() {
 	rootCmd.AddCommand(loginCmd)
+}
+
+func loadClusterInfo() *clientauthv1beta1.Cluster {
+	obj, _, err := exec.LoadExecCredentialFromEnv()
+	if err != nil {
+		return nil
+	}
+	cred, ok := obj.(*clientauthv1beta1.ExecCredential)
+	if !ok {
+		return nil
+	}
+	return cred.Spec.Cluster
 }

--- a/cmd/pinniped/cmd/login_oidc.go
+++ b/cmd/pinniped/cmd/login_oidc.go
@@ -167,11 +167,13 @@ func runOIDCLogin(cmd *cobra.Command, deps oidcLoginCommandDeps, flags oidcLogin
 		opts = append(opts, oidcclient.WithClient(client))
 	}
 
-	// Look up cached credentials based on a hash of all the CLI arguments.
+	// Look up cached credentials based on a hash of all the CLI arguments and the cluster info.
 	cacheKey := struct {
-		Args []string `json:"args"`
+		Args        []string                   `json:"args"`
+		ClusterInfo *clientauthv1beta1.Cluster `json:"cluster"`
 	}{
-		Args: os.Args[1:],
+		Args:        os.Args[1:],
+		ClusterInfo: loadClusterInfo(),
 	}
 	var credCache *execcredcache.Cache
 	if flags.credentialCachePath != "" {

--- a/cmd/pinniped/cmd/login_oidc.go
+++ b/cmd/pinniped/cmd/login_oidc.go
@@ -97,7 +97,7 @@ func oidcLoginCommand(deps oidcLoginCommandDeps) *cobra.Command {
 	cmd.Flags().StringVar(&flags.conciergeEndpoint, "concierge-endpoint", "", "API base for the Concierge endpoint")
 	cmd.Flags().StringVar(&flags.conciergeCABundle, "concierge-ca-bundle-data", "", "CA bundle to use when connecting to the Concierge")
 	cmd.Flags().StringVar(&flags.conciergeAPIGroupSuffix, "concierge-api-group-suffix", groupsuffix.PinnipedDefaultSuffix, "Concierge API group suffix")
-	cmd.Flags().StringVar(&flags.credentialCachePath, "credential-cache", filepath.Join(mustGetConfigDir(), "credentials.yaml"), "Cluster-specific credentials cache path (\"\" disables the cache)")
+	cmd.Flags().StringVar(&flags.credentialCachePath, "credential-cache", filepath.Join(mustGetConfigDir(), "credentials.yaml"), "Path to cluster-specific credentials cache (\"\" disables the cache)")
 
 	mustMarkHidden(cmd, "debug-session-cache")
 	mustMarkRequired(cmd, "issuer")

--- a/cmd/pinniped/cmd/login_oidc_test.go
+++ b/cmd/pinniped/cmd/login_oidc_test.go
@@ -64,7 +64,7 @@ func TestLoginOIDCCommand(t *testing.T) {
 				      --concierge-authenticator-type string   Concierge authenticator type (e.g., 'webhook', 'jwt')
 				      --concierge-ca-bundle-data string       CA bundle to use when connecting to the Concierge
 				      --concierge-endpoint string             API base for the Concierge endpoint
-				      --credential-cache string               Cluster-specific credentials cache path ("" disables the cache) (default "` + cfgDir + `/credentials.yaml")
+				      --credential-cache string               Path to cluster-specific credentials cache ("" disables the cache) (default "` + cfgDir + `/credentials.yaml")
 				      --enable-concierge                      Use the Concierge to login
 				  -h, --help                                  help for oidc
 				      --issuer string                         OpenID Connect issuer URL

--- a/cmd/pinniped/cmd/login_static.go
+++ b/cmd/pinniped/cmd/login_static.go
@@ -72,7 +72,7 @@ func staticLoginCommand(deps staticLoginDeps) *cobra.Command {
 	cmd.Flags().StringVar(&flags.conciergeEndpoint, "concierge-endpoint", "", "API base for the Concierge endpoint")
 	cmd.Flags().StringVar(&flags.conciergeCABundle, "concierge-ca-bundle-data", "", "CA bundle to use when connecting to the Concierge")
 	cmd.Flags().StringVar(&flags.conciergeAPIGroupSuffix, "concierge-api-group-suffix", groupsuffix.PinnipedDefaultSuffix, "Concierge API group suffix")
-	cmd.Flags().StringVar(&flags.credentialCachePath, "credential-cache", filepath.Join(mustGetConfigDir(), "credentials.yaml"), "Cluster-specific credentials cache path (\"\" disables the cache)")
+	cmd.Flags().StringVar(&flags.credentialCachePath, "credential-cache", filepath.Join(mustGetConfigDir(), "credentials.yaml"), "Path to cluster-specific credentials cache (\"\" disables the cache)")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error { return runStaticLogin(cmd.OutOrStdout(), deps, flags) }
 

--- a/cmd/pinniped/cmd/login_static.go
+++ b/cmd/pinniped/cmd/login_static.go
@@ -117,13 +117,15 @@ func runStaticLogin(out io.Writer, deps staticLoginDeps, flags staticLoginParams
 	}
 	cred := tokenCredential(&oidctypes.Token{IDToken: &oidctypes.IDToken{Token: token}})
 
-	// Look up cached credentials based on a hash of all the CLI arguments and the current token value.
+	// Look up cached credentials based on a hash of all the CLI arguments, the current token value, and the cluster info.
 	cacheKey := struct {
-		Args  []string `json:"args"`
-		Token string   `json:"token"`
+		Args        []string                   `json:"args"`
+		Token       string                     `json:"token"`
+		ClusterInfo *clientauthv1beta1.Cluster `json:"cluster"`
 	}{
-		Args:  os.Args[1:],
-		Token: token,
+		Args:        os.Args[1:],
+		Token:       token,
+		ClusterInfo: loadClusterInfo(),
 	}
 	var credCache *execcredcache.Cache
 	if flags.credentialCachePath != "" {

--- a/cmd/pinniped/cmd/login_static_test.go
+++ b/cmd/pinniped/cmd/login_static_test.go
@@ -57,7 +57,7 @@ func TestLoginStaticCommand(t *testing.T) {
 				      --concierge-authenticator-type string   Concierge authenticator type (e.g., 'webhook', 'jwt')
 				      --concierge-ca-bundle-data string       CA bundle to use when connecting to the Concierge
 				      --concierge-endpoint string             API base for the Concierge endpoint
-				      --credential-cache string               Cluster-specific credentials cache path ("" disables the cache) (default "` + cfgDir + `/credentials.yaml")
+				      --credential-cache string               Path to cluster-specific credentials cache ("" disables the cache) (default "` + cfgDir + `/credentials.yaml")
 				      --enable-concierge                      Use the Concierge to login
 				  -h, --help                                  help for static
 				      --token string                          Static token to present during login

--- a/test/integration/cli_test.go
+++ b/test/integration/cli_test.go
@@ -49,11 +49,13 @@ func TestCLIGetKubeconfigStaticToken(t *testing.T) {
 	// Build pinniped CLI.
 	pinnipedExe := library.PinnipedCLIPath(t)
 
+	credCacheDir := testutil.TempDir(t)
 	stdout, stderr := runPinnipedCLI(t, nil, pinnipedExe, "get", "kubeconfig",
 		"--static-token", env.TestUser.Token,
 		"--concierge-api-group-suffix", env.APIGroupSuffix,
 		"--concierge-authenticator-type", "webhook",
 		"--concierge-authenticator-name", authenticator.Name,
+		"--credential-cache", credCacheDir+"/credentials.yaml",
 	)
 	assert.Contains(t, stderr, "discovered CredentialIssuer")
 	assert.Contains(t, stderr, "discovered Concierge endpoint")
@@ -383,6 +385,7 @@ func oidcLoginCommand(ctx context.Context, t *testing.T, pinnipedExe string, ses
 		"--scopes", "offline_access,openid,email,profile",
 		"--listen-port", callbackURL.Port(),
 		"--session-cache", sessionCachePath,
+		"--credential-cache", testutil.TempDir(t)+"/credentials.yaml",
 		"--skip-browser",
 	)
 


### PR DESCRIPTION
This is a smallish follow-up to #562 that adds a few enhancements:

- Add `--credential-cache` flag to `pinniped get kubeconfig`. This lets you tweak or disable the credential cache when you're generating a kubeconfig.
- Tweak usage messages for consistency with other flags.
- Add cluster info (from `$KUBERNETES_EXEC_INFO`) to the cache key for cluster-specific credential cache. This isn't strictly necessary because we currently always have the concierge endpoint and CA as CLI flags, but it doesn't hurt and it's better to err on the side of _not_ reusing a cache entry.
- Use a temporary directory for credential cache in CLI tests. This avoids polluting the main cache directory on developer machines.

I also looked into writing a benchmark test to ensure that caching was improving performance, but I was never able to get it to a point where I was happy merging it. We'll test this manually for now I think.

**Release note**:

This change contains only tweaks to the change in #562 which has not otherwise been released.

```release-note
NONE
```
