### PR TITLE
Fix a broken docs link in our README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To learn more, see [architecture](https://pinniped.dev/docs/background/architect
 
 ## Getting started with Pinniped
 
-Care to kick the tires? It's easy to [install and try Pinniped](https://pinniped.dev/docs/demo/).
+Care to kick the tires? It's easy to [install and try Pinniped](https://pinniped.dev/docs/).
 
 ## Community meetings
 


### PR DESCRIPTION
Addresses #583 

**Release note**:

```release-note
NONE
```
