### PR TITLE
impersonator: add support for service account token authentication

### DIFF
--- a/internal/concierge/impersonator/doc.go
+++ b/internal/concierge/impersonator/doc.go
@@ -35,6 +35,13 @@ only shares this information with the audit stack).  To keep things simple,
 we use the fake audit backend at the Metadata level for all requests.  This
 guarantees that we always have an audit event on every request.
 
+One final wrinkle is that impersonation cannot impersonate UIDs (yet).  This is
+problematic because service account tokens always assert a UID.  To handle this
+case without losing authentication information, when we see an identity with a
+UID that was asserted via a bearer token, we simply pass the request through
+with the original bearer token and no impersonation headers set (as if the user
+had made the request directly against the Kubernetes API server).
+
 For all normal requests, we only use http/2.0 when proxying to the API server.
 For upgrade requests, we only use http/1.1 since these always go from http/1.1
 to either websockets or SPDY.

--- a/internal/controller/authenticator/authncache/cache.go
+++ b/internal/controller/authenticator/authncache/cache.go
@@ -16,6 +16,7 @@ import (
 	loginapi "go.pinniped.dev/generated/latest/apis/concierge/login"
 	"go.pinniped.dev/internal/constable"
 	"go.pinniped.dev/internal/plog"
+	"go.pinniped.dev/internal/valuelesscontext"
 )
 
 // ErrNoSuchAuthenticator is returned by Cache.AuthenticateTokenCredentialRequest() when the requested authenticator is not configured.
@@ -101,7 +102,7 @@ func (c *Cache) AuthenticateTokenCredentialRequest(ctx context.Context, req *log
 
 	// The incoming context could have an audience. Since we do not want to handle audiences right now, do not pass it
 	// through directly to the authentication webhook.
-	ctx = valuelessContext{ctx}
+	ctx = valuelesscontext.New(ctx)
 
 	// Call the selected authenticator.
 	resp, authenticated, err := val.AuthenticateToken(ctx, req.Spec.Token)
@@ -119,7 +120,3 @@ func (c *Cache) AuthenticateTokenCredentialRequest(ctx context.Context, req *log
 	}
 	return respUser, nil
 }
-
-type valuelessContext struct{ context.Context }
-
-func (valuelessContext) Value(interface{}) interface{} { return nil }

--- a/internal/valuelesscontext/valuelesscontext.go
+++ b/internal/valuelesscontext/valuelesscontext.go
@@ -1,0 +1,14 @@
+// Copyright 2021 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package valuelesscontext
+
+import "context"
+
+func New(ctx context.Context) context.Context {
+	return valuelessContext{Context: ctx}
+}
+
+type valuelessContext struct{ context.Context }
+
+func (valuelessContext) Value(interface{}) interface{} { return nil }


### PR DESCRIPTION
This change updates the impersonator logic to pass through requests
that authenticated via a bearer token that asserts a UID.  This
allows us to support service account tokens (as well as any other
form of token based authentication).

Signed-off-by: Monis Khan <mok@vmware.com>

Fixes #452 

**Release note**:

```release-note
Service account tokens now work when used against the concierge impersonation proxy.
```