### PR TITLE
valuelesscontext: make unit tests more clear

### DIFF
--- a/internal/valuelesscontext/valuelesscontext_test.go
+++ b/internal/valuelesscontext/valuelesscontext_test.go
@@ -18,19 +18,25 @@ func TestNew(t *testing.T) {
 	type contextKey int
 
 	tests := []struct {
-		name string
-		f    func(*testing.T, context.Context) context.Context
-		want func(*testing.T, context.Context)
+		name                       string
+		f                          func(*testing.T, context.Context) context.Context
+		wantReg, wantNew, wantBoth func(*testing.T, context.Context)
 	}{
 		{
-			name: "standard context",
+			name: "empty context",
 			f: func(t *testing.T, ctx context.Context) context.Context {
 				return ctx
 			},
-			want: func(t *testing.T, ctx context.Context) {
+			wantReg: func(t *testing.T, ctx context.Context) {},
+			wantNew: func(t *testing.T, ctx context.Context) {},
+			wantBoth: func(t *testing.T, ctx context.Context) {
 				auds, ok := authenticator.AudiencesFrom(ctx)
 				require.False(t, ok)
 				require.Nil(t, auds)
+
+				val, ok := ctx.Value(contextKey(0xDEADBEEF)).(string)
+				require.False(t, ok)
+				require.Zero(t, val)
 
 				deadline, ok := ctx.Deadline()
 				require.False(t, ok)
@@ -42,14 +48,24 @@ func TestNew(t *testing.T) {
 			},
 		},
 		{
-			name: "standard context with audience",
+			name: "context with audience",
 			f: func(t *testing.T, ctx context.Context) context.Context {
 				return authenticator.WithAudiences(ctx, authenticator.Audiences{"1", "2"})
 			},
-			want: func(t *testing.T, ctx context.Context) {
+			wantReg: func(t *testing.T, ctx context.Context) {
 				auds, ok := authenticator.AudiencesFrom(ctx)
 				require.True(t, ok)
 				require.Equal(t, authenticator.Audiences{"1", "2"}, auds)
+			},
+			wantNew: func(t *testing.T, ctx context.Context) {
+				auds, ok := authenticator.AudiencesFrom(ctx)
+				require.False(t, ok)
+				require.Nil(t, auds)
+			},
+			wantBoth: func(t *testing.T, ctx context.Context) {
+				val, ok := ctx.Value(contextKey(0xDEADBEEF)).(string)
+				require.False(t, ok)
+				require.Zero(t, val)
 
 				deadline, ok := ctx.Deadline()
 				require.False(t, ok)
@@ -61,7 +77,7 @@ func TestNew(t *testing.T) {
 			},
 		},
 		{
-			name: "standard context with audience and past deadline",
+			name: "context with audience and past deadline",
 			f: func(t *testing.T, ctx context.Context) context.Context {
 				ctx = authenticator.WithAudiences(ctx, authenticator.Audiences{"3", "4"})
 				var cancel context.CancelFunc
@@ -69,107 +85,17 @@ func TestNew(t *testing.T) {
 				t.Cleanup(cancel)
 				return ctx
 			},
-			want: func(t *testing.T, ctx context.Context) {
+			wantReg: func(t *testing.T, ctx context.Context) {
 				auds, ok := authenticator.AudiencesFrom(ctx)
 				require.True(t, ok)
 				require.Equal(t, authenticator.Audiences{"3", "4"}, auds)
-
-				deadline, ok := ctx.Deadline()
-				require.True(t, ok)
-				require.NotZero(t, deadline)
-				require.True(t, deadline.Before(time.Now()))
-
-				ch := ctx.Done()
-				require.NotNil(t, ch)
-				select {
-				case <-ch:
-				case <-time.After(10 * time.Second):
-					t.Error("expected closed done channel")
-				}
-
-				require.Equal(t, context.DeadlineExceeded, ctx.Err())
 			},
-		},
-		{
-			name: "valueless context with audience and past deadline",
-			f: func(t *testing.T, ctx context.Context) context.Context {
-				ctx = authenticator.WithAudiences(ctx, authenticator.Audiences{"3", "4"})
-				var cancel context.CancelFunc
-				ctx, cancel = context.WithDeadline(ctx, time.Now().Add(-time.Hour))
-				t.Cleanup(cancel)
-				return New(ctx)
-			},
-			want: func(t *testing.T, ctx context.Context) {
+			wantNew: func(t *testing.T, ctx context.Context) {
 				auds, ok := authenticator.AudiencesFrom(ctx)
 				require.False(t, ok)
 				require.Nil(t, auds)
-
-				deadline, ok := ctx.Deadline()
-				require.True(t, ok)
-				require.NotZero(t, deadline)
-				require.True(t, deadline.Before(time.Now()))
-
-				ch := ctx.Done()
-				require.NotNil(t, ch)
-				select {
-				case <-ch:
-				case <-time.After(10 * time.Second):
-					t.Error("expected closed done channel")
-				}
-
-				require.Equal(t, context.DeadlineExceeded, ctx.Err())
 			},
-		},
-		{
-			name: "standard context with audience and custom value and past deadline",
-			f: func(t *testing.T, ctx context.Context) context.Context {
-				ctx = authenticator.WithAudiences(ctx, authenticator.Audiences{"3", "4"})
-				var cancel context.CancelFunc
-				ctx, cancel = context.WithDeadline(ctx, time.Now().Add(-time.Hour))
-				t.Cleanup(cancel)
-				ctx = context.WithValue(ctx, contextKey(0xDEADBEEF), "mooo")
-				return ctx
-			},
-			want: func(t *testing.T, ctx context.Context) {
-				auds, ok := authenticator.AudiencesFrom(ctx)
-				require.True(t, ok)
-				require.Equal(t, authenticator.Audiences{"3", "4"}, auds)
-
-				val, ok := ctx.Value(contextKey(0xDEADBEEF)).(string)
-				require.True(t, ok)
-				require.Equal(t, "mooo", val)
-
-				deadline, ok := ctx.Deadline()
-				require.True(t, ok)
-				require.NotZero(t, deadline)
-				require.True(t, deadline.Before(time.Now()))
-
-				ch := ctx.Done()
-				require.NotNil(t, ch)
-				select {
-				case <-ch:
-				case <-time.After(10 * time.Second):
-					t.Error("expected closed done channel")
-				}
-
-				require.Equal(t, context.DeadlineExceeded, ctx.Err())
-			},
-		},
-		{
-			name: "valueless context with audience and custom value and past deadline",
-			f: func(t *testing.T, ctx context.Context) context.Context {
-				ctx = authenticator.WithAudiences(ctx, authenticator.Audiences{"3", "4"})
-				var cancel context.CancelFunc
-				ctx, cancel = context.WithDeadline(ctx, time.Now().Add(-time.Hour))
-				t.Cleanup(cancel)
-				ctx = context.WithValue(ctx, contextKey(0xDEADBEEF), "mooo")
-				return New(ctx)
-			},
-			want: func(t *testing.T, ctx context.Context) {
-				auds, ok := authenticator.AudiencesFrom(ctx)
-				require.False(t, ok)
-				require.Nil(t, auds)
-
+			wantBoth: func(t *testing.T, ctx context.Context) {
 				val, ok := ctx.Value(contextKey(0xDEADBEEF)).(string)
 				require.False(t, ok)
 				require.Zero(t, val)
@@ -191,7 +117,52 @@ func TestNew(t *testing.T) {
 			},
 		},
 		{
-			name: "standard context with audience and custom value and future deadline",
+			name: "context with audience and custom value and past deadline",
+			f: func(t *testing.T, ctx context.Context) context.Context {
+				ctx = authenticator.WithAudiences(ctx, authenticator.Audiences{"3", "4"})
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithDeadline(ctx, time.Now().Add(-time.Hour))
+				t.Cleanup(cancel)
+				ctx = context.WithValue(ctx, contextKey(0xDEADBEEF), "mooo")
+				return ctx
+			},
+			wantReg: func(t *testing.T, ctx context.Context) {
+				auds, ok := authenticator.AudiencesFrom(ctx)
+				require.True(t, ok)
+				require.Equal(t, authenticator.Audiences{"3", "4"}, auds)
+
+				val, ok := ctx.Value(contextKey(0xDEADBEEF)).(string)
+				require.True(t, ok)
+				require.Equal(t, "mooo", val)
+			},
+			wantNew: func(t *testing.T, ctx context.Context) {
+				auds, ok := authenticator.AudiencesFrom(ctx)
+				require.False(t, ok)
+				require.Nil(t, auds)
+
+				val, ok := ctx.Value(contextKey(0xDEADBEEF)).(string)
+				require.False(t, ok)
+				require.Zero(t, val)
+			},
+			wantBoth: func(t *testing.T, ctx context.Context) {
+				deadline, ok := ctx.Deadline()
+				require.True(t, ok)
+				require.NotZero(t, deadline)
+				require.True(t, deadline.Before(time.Now()))
+
+				ch := ctx.Done()
+				require.NotNil(t, ch)
+				select {
+				case <-ch:
+				case <-time.After(10 * time.Second):
+					t.Error("expected closed done channel")
+				}
+
+				require.Equal(t, context.DeadlineExceeded, ctx.Err())
+			},
+		},
+		{
+			name: "context with audience and custom value and future deadline",
 			f: func(t *testing.T, ctx context.Context) context.Context {
 				ctx = authenticator.WithAudiences(ctx, authenticator.Audiences{"3", "4"})
 				var cancel context.CancelFunc
@@ -200,7 +171,7 @@ func TestNew(t *testing.T) {
 				ctx = context.WithValue(ctx, contextKey(0xDEADBEEF), "mooo")
 				return ctx
 			},
-			want: func(t *testing.T, ctx context.Context) {
+			wantReg: func(t *testing.T, ctx context.Context) {
 				auds, ok := authenticator.AudiencesFrom(ctx)
 				require.True(t, ok)
 				require.Equal(t, authenticator.Audiences{"3", "4"}, auds)
@@ -208,34 +179,8 @@ func TestNew(t *testing.T) {
 				val, ok := ctx.Value(contextKey(0xDEADBEEF)).(string)
 				require.True(t, ok)
 				require.Equal(t, "mooo", val)
-
-				deadline, ok := ctx.Deadline()
-				require.True(t, ok)
-				require.NotZero(t, deadline)
-				require.True(t, deadline.After(time.Now()))
-
-				ch := ctx.Done()
-				require.NotNil(t, ch)
-				select {
-				case <-ch:
-					t.Error("expected not closed done channel")
-				case <-time.After(3 * time.Second):
-				}
-
-				require.NoError(t, ctx.Err())
 			},
-		},
-		{
-			name: "valueless context with audience and custom value and future deadline",
-			f: func(t *testing.T, ctx context.Context) context.Context {
-				ctx = authenticator.WithAudiences(ctx, authenticator.Audiences{"3", "4"})
-				var cancel context.CancelFunc
-				ctx, cancel = context.WithDeadline(ctx, time.Now().Add(time.Hour))
-				t.Cleanup(cancel)
-				ctx = context.WithValue(ctx, contextKey(0xDEADBEEF), "mooo")
-				return New(ctx)
-			},
-			want: func(t *testing.T, ctx context.Context) {
+			wantNew: func(t *testing.T, ctx context.Context) {
 				auds, ok := authenticator.AudiencesFrom(ctx)
 				require.False(t, ok)
 				require.Nil(t, auds)
@@ -243,7 +188,8 @@ func TestNew(t *testing.T) {
 				val, ok := ctx.Value(contextKey(0xDEADBEEF)).(string)
 				require.False(t, ok)
 				require.Zero(t, val)
-
+			},
+			wantBoth: func(t *testing.T, ctx context.Context) {
 				deadline, ok := ctx.Deadline()
 				require.True(t, ok)
 				require.NotZero(t, deadline)
@@ -267,7 +213,30 @@ func TestNew(t *testing.T) {
 			t.Parallel()
 
 			ctx := tt.f(t, context.Background())
-			tt.want(t, ctx)
+
+			t.Run("reg", func(t *testing.T) {
+				t.Parallel()
+
+				tt.wantReg(t, ctx)
+			})
+
+			t.Run("reg-both", func(t *testing.T) {
+				t.Parallel()
+
+				tt.wantBoth(t, ctx)
+			})
+
+			t.Run("new", func(t *testing.T) {
+				t.Parallel()
+
+				tt.wantNew(t, New(ctx))
+			})
+
+			t.Run("new-both", func(t *testing.T) {
+				t.Parallel()
+
+				tt.wantBoth(t, New(ctx))
+			})
 		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: Monis Khan <mok@vmware.com>

```release-note
NONE
```