### PR TITLE
Fix PSP-related regression since kube-cert-agent change in #569.

### DIFF
--- a/deploy/concierge/deployment.yaml
+++ b/deploy/concierge/deployment.yaml
@@ -47,6 +47,7 @@ data:
       impersonationTLSCertificateSecret: (@= defaultResourceNameWithSuffix("impersonation-proxy-tls-serving-certificate") @)
       impersonationCACertificateSecret: (@= defaultResourceNameWithSuffix("impersonation-proxy-ca-certificate") @)
       impersonationSignerSecret: (@= defaultResourceNameWithSuffix("impersonation-proxy-signer-ca-certificate") @)
+      serviceAccount: (@= defaultResourceName() @)
     labels: (@= json.encode(labels()).rstrip() @)
     kubeCertAgent:
       namePrefix: (@= defaultResourceNameWithSuffix("kube-cert-agent-") @)

--- a/deploy/concierge/deployment.yaml
+++ b/deploy/concierge/deployment.yaml
@@ -22,6 +22,13 @@ metadata:
   labels: #@ labels()
 ---
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: #@ defaultResourceNameWithSuffix("kube-cert-agent")
+  namespace: #@ namespace()
+  labels: #@ labels()
+---
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: #@ defaultResourceNameWithSuffix("config")
@@ -47,7 +54,7 @@ data:
       impersonationTLSCertificateSecret: (@= defaultResourceNameWithSuffix("impersonation-proxy-tls-serving-certificate") @)
       impersonationCACertificateSecret: (@= defaultResourceNameWithSuffix("impersonation-proxy-ca-certificate") @)
       impersonationSignerSecret: (@= defaultResourceNameWithSuffix("impersonation-proxy-signer-ca-certificate") @)
-      serviceAccount: (@= defaultResourceName() @)
+      agentServiceAccount: (@= defaultResourceNameWithSuffix("kube-cert-agent") @)
     labels: (@= json.encode(labels()).rstrip() @)
     kubeCertAgent:
       namePrefix: (@= defaultResourceNameWithSuffix("kube-cert-agent-") @)

--- a/deploy/concierge/rbac.yaml
+++ b/deploy/concierge/rbac.yaml
@@ -24,9 +24,6 @@ rules:
   - apiGroups: [ flowcontrol.apiserver.k8s.io ]
     resources: [ flowschemas, prioritylevelconfigurations ]
     verbs: [ get, list, watch ]
-  - apiGroups: [ policy ]
-    resources: [ podsecuritypolicies ]
-    verbs: [ use ]
   - apiGroups: [ security.openshift.io ]
     resources: [ securitycontextconstraints ]
     verbs: [ use ]
@@ -65,6 +62,34 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: #@ defaultResourceNameWithSuffix("aggregated-api-server")
+  apiGroup: rbac.authorization.k8s.io
+
+#! Give permission to the kube-cert-agent Pod to run privileged.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: #@ defaultResourceNameWithSuffix("kube-cert-agent")
+  namespace: #@ namespace()
+  labels: #@ labels()
+rules:
+  - apiGroups: [ policy ]
+    resources: [ podsecuritypolicies ]
+    verbs: [ use ]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: #@ defaultResourceNameWithSuffix("kube-cert-agent")
+  namespace: #@ namespace()
+  labels: #@ labels()
+subjects:
+  - kind: ServiceAccount
+    name: #@ defaultResourceNameWithSuffix("kube-cert-agent")
+    namespace: #@ namespace()
+roleRef:
+  kind: Role
+  name: #@ defaultResourceNameWithSuffix("kube-cert-agent")
   apiGroup: rbac.authorization.k8s.io
 
 #! Give permission to various objects within the app's own namespace

--- a/internal/config/concierge/config.go
+++ b/internal/config/concierge/config.go
@@ -122,6 +122,9 @@ func validateNames(names *NamesConfigSpec) error {
 	if names.ImpersonationSignerSecret == "" {
 		missingNames = append(missingNames, "impersonationSignerSecret")
 	}
+	if names.ServiceAccount == "" {
+		missingNames = append(missingNames, "serviceAccount")
+	}
 	if len(missingNames) > 0 {
 		return constable.Error("missing required names: " + strings.Join(missingNames, ", "))
 	}

--- a/internal/config/concierge/config.go
+++ b/internal/config/concierge/config.go
@@ -122,8 +122,8 @@ func validateNames(names *NamesConfigSpec) error {
 	if names.ImpersonationSignerSecret == "" {
 		missingNames = append(missingNames, "impersonationSignerSecret")
 	}
-	if names.ServiceAccount == "" {
-		missingNames = append(missingNames, "serviceAccount")
+	if names.AgentServiceAccount == "" {
+		missingNames = append(missingNames, "agentServiceAccount")
 	}
 	if len(missingNames) > 0 {
 		return constable.Error("missing required names: " + strings.Join(missingNames, ", "))

--- a/internal/config/concierge/config_test.go
+++ b/internal/config/concierge/config_test.go
@@ -43,6 +43,7 @@ func TestFromPath(t *testing.T) {
 				  impersonationCACertificateSecret: impersonationCACertificateSecret-value
 				  impersonationSignerSecret: impersonationSignerSecret-value
 				  impersonationSignerSecret: impersonationSignerSecret-value
+				  serviceAccount: serviceAccount-value
 				labels:
 				  myLabelKey1: myLabelValue1
 				  myLabelKey2: myLabelValue2
@@ -72,6 +73,7 @@ func TestFromPath(t *testing.T) {
 					ImpersonationTLSCertificateSecret: "impersonationTLSCertificateSecret-value",
 					ImpersonationCACertificateSecret:  "impersonationCACertificateSecret-value",
 					ImpersonationSignerSecret:         "impersonationSignerSecret-value",
+					ServiceAccount:                    "serviceAccount-value",
 				},
 				Labels: map[string]string{
 					"myLabelKey1": "myLabelValue1",
@@ -98,6 +100,7 @@ func TestFromPath(t *testing.T) {
 				  impersonationTLSCertificateSecret: impersonationTLSCertificateSecret-value
 				  impersonationCACertificateSecret: impersonationCACertificateSecret-value
 				  impersonationSignerSecret: impersonationSignerSecret-value
+				  serviceAccount: serviceAccount-value
 			`),
 			wantConfig: &Config{
 				DiscoveryInfo: DiscoveryInfoSpec{
@@ -119,6 +122,7 @@ func TestFromPath(t *testing.T) {
 					ImpersonationTLSCertificateSecret: "impersonationTLSCertificateSecret-value",
 					ImpersonationCACertificateSecret:  "impersonationCACertificateSecret-value",
 					ImpersonationSignerSecret:         "impersonationSignerSecret-value",
+					ServiceAccount:                    "serviceAccount-value",
 				},
 				Labels: map[string]string{},
 				KubeCertAgentConfig: KubeCertAgentSpec{
@@ -133,7 +137,7 @@ func TestFromPath(t *testing.T) {
 			wantError: "validate names: missing required names: servingCertificateSecret, credentialIssuer, " +
 				"apiService, impersonationConfigMap, impersonationLoadBalancerService, " +
 				"impersonationTLSCertificateSecret, impersonationCACertificateSecret, " +
-				"impersonationSignerSecret",
+				"impersonationSignerSecret, serviceAccount",
 		},
 		{
 			name: "Missing apiService name",
@@ -147,6 +151,7 @@ func TestFromPath(t *testing.T) {
 				  impersonationTLSCertificateSecret: impersonationTLSCertificateSecret-value
 				  impersonationCACertificateSecret: impersonationCACertificateSecret-value
 				  impersonationSignerSecret: impersonationSignerSecret-value
+				  serviceAccount: serviceAccount-value
 			`),
 			wantError: "validate names: missing required names: apiService",
 		},
@@ -162,6 +167,7 @@ func TestFromPath(t *testing.T) {
 				  impersonationTLSCertificateSecret: impersonationTLSCertificateSecret-value
 				  impersonationCACertificateSecret: impersonationCACertificateSecret-value
 				  impersonationSignerSecret: impersonationSignerSecret-value
+				  serviceAccount: serviceAccount-value
 			`),
 			wantError: "validate names: missing required names: credentialIssuer",
 		},
@@ -177,6 +183,7 @@ func TestFromPath(t *testing.T) {
 				  impersonationTLSCertificateSecret: impersonationTLSCertificateSecret-value
 				  impersonationCACertificateSecret: impersonationCACertificateSecret-value
 				  impersonationSignerSecret: impersonationSignerSecret-value
+				  serviceAccount: serviceAccount-value
 			`),
 			wantError: "validate names: missing required names: servingCertificateSecret",
 		},
@@ -192,6 +199,7 @@ func TestFromPath(t *testing.T) {
 				  impersonationTLSCertificateSecret: impersonationTLSCertificateSecret-value
 				  impersonationCACertificateSecret: impersonationCACertificateSecret-value
 				  impersonationSignerSecret: impersonationSignerSecret-value
+				  serviceAccount: serviceAccount-value
 			`),
 			wantError: "validate names: missing required names: impersonationConfigMap",
 		},
@@ -207,6 +215,7 @@ func TestFromPath(t *testing.T) {
 				  impersonationTLSCertificateSecret: impersonationTLSCertificateSecret-value
 				  impersonationCACertificateSecret: impersonationCACertificateSecret-value
 				  impersonationSignerSecret: impersonationSignerSecret-value
+				  serviceAccount: serviceAccount-value
 			`),
 			wantError: "validate names: missing required names: impersonationLoadBalancerService",
 		},
@@ -222,6 +231,7 @@ func TestFromPath(t *testing.T) {
 				  impersonationLoadBalancerService: impersonationLoadBalancerService-value
 				  impersonationCACertificateSecret: impersonationCACertificateSecret-value
 				  impersonationSignerSecret: impersonationSignerSecret-value
+				  serviceAccount: serviceAccount-value
 			`),
 			wantError: "validate names: missing required names: impersonationTLSCertificateSecret",
 		},
@@ -237,6 +247,7 @@ func TestFromPath(t *testing.T) {
 				  impersonationLoadBalancerService: impersonationLoadBalancerService-value
 				  impersonationTLSCertificateSecret: impersonationTLSCertificateSecret-value
 				  impersonationSignerSecret: impersonationSignerSecret-value
+				  serviceAccount: serviceAccount-value
 			`),
 			wantError: "validate names: missing required names: impersonationCACertificateSecret",
 		},
@@ -252,6 +263,7 @@ func TestFromPath(t *testing.T) {
 				  impersonationLoadBalancerService: impersonationLoadBalancerService-value
 				  impersonationTLSCertificateSecret: impersonationTLSCertificateSecret-value
 				  impersonationCACertificateSecret: impersonationCACertificateSecret-value
+				  serviceAccount: serviceAccount-value
 			`),
 			wantError: "validate names: missing required names: impersonationSignerSecret",
 		},
@@ -265,6 +277,7 @@ func TestFromPath(t *testing.T) {
 				  apiService: pinniped-api
 				  impersonationLoadBalancerService: impersonationLoadBalancerService-value
 				  impersonationSignerSecret: impersonationSignerSecret-value
+				  serviceAccount: serviceAccount-value
 			`),
 			wantError: "validate names: missing required names: impersonationConfigMap, " +
 				"impersonationTLSCertificateSecret, impersonationCACertificateSecret",

--- a/internal/config/concierge/config_test.go
+++ b/internal/config/concierge/config_test.go
@@ -43,7 +43,7 @@ func TestFromPath(t *testing.T) {
 				  impersonationCACertificateSecret: impersonationCACertificateSecret-value
 				  impersonationSignerSecret: impersonationSignerSecret-value
 				  impersonationSignerSecret: impersonationSignerSecret-value
-				  serviceAccount: serviceAccount-value
+				  agentServiceAccount: agentServiceAccount-value
 				labels:
 				  myLabelKey1: myLabelValue1
 				  myLabelKey2: myLabelValue2
@@ -73,7 +73,7 @@ func TestFromPath(t *testing.T) {
 					ImpersonationTLSCertificateSecret: "impersonationTLSCertificateSecret-value",
 					ImpersonationCACertificateSecret:  "impersonationCACertificateSecret-value",
 					ImpersonationSignerSecret:         "impersonationSignerSecret-value",
-					ServiceAccount:                    "serviceAccount-value",
+					AgentServiceAccount:               "agentServiceAccount-value",
 				},
 				Labels: map[string]string{
 					"myLabelKey1": "myLabelValue1",
@@ -100,7 +100,7 @@ func TestFromPath(t *testing.T) {
 				  impersonationTLSCertificateSecret: impersonationTLSCertificateSecret-value
 				  impersonationCACertificateSecret: impersonationCACertificateSecret-value
 				  impersonationSignerSecret: impersonationSignerSecret-value
-				  serviceAccount: serviceAccount-value
+				  agentServiceAccount: agentServiceAccount-value
 			`),
 			wantConfig: &Config{
 				DiscoveryInfo: DiscoveryInfoSpec{
@@ -122,7 +122,7 @@ func TestFromPath(t *testing.T) {
 					ImpersonationTLSCertificateSecret: "impersonationTLSCertificateSecret-value",
 					ImpersonationCACertificateSecret:  "impersonationCACertificateSecret-value",
 					ImpersonationSignerSecret:         "impersonationSignerSecret-value",
-					ServiceAccount:                    "serviceAccount-value",
+					AgentServiceAccount:               "agentServiceAccount-value",
 				},
 				Labels: map[string]string{},
 				KubeCertAgentConfig: KubeCertAgentSpec{
@@ -137,7 +137,7 @@ func TestFromPath(t *testing.T) {
 			wantError: "validate names: missing required names: servingCertificateSecret, credentialIssuer, " +
 				"apiService, impersonationConfigMap, impersonationLoadBalancerService, " +
 				"impersonationTLSCertificateSecret, impersonationCACertificateSecret, " +
-				"impersonationSignerSecret, serviceAccount",
+				"impersonationSignerSecret, agentServiceAccount",
 		},
 		{
 			name: "Missing apiService name",
@@ -151,7 +151,7 @@ func TestFromPath(t *testing.T) {
 				  impersonationTLSCertificateSecret: impersonationTLSCertificateSecret-value
 				  impersonationCACertificateSecret: impersonationCACertificateSecret-value
 				  impersonationSignerSecret: impersonationSignerSecret-value
-				  serviceAccount: serviceAccount-value
+				  agentServiceAccount: agentServiceAccount-value
 			`),
 			wantError: "validate names: missing required names: apiService",
 		},
@@ -167,7 +167,7 @@ func TestFromPath(t *testing.T) {
 				  impersonationTLSCertificateSecret: impersonationTLSCertificateSecret-value
 				  impersonationCACertificateSecret: impersonationCACertificateSecret-value
 				  impersonationSignerSecret: impersonationSignerSecret-value
-				  serviceAccount: serviceAccount-value
+				  agentServiceAccount: agentServiceAccount-value
 			`),
 			wantError: "validate names: missing required names: credentialIssuer",
 		},
@@ -183,7 +183,7 @@ func TestFromPath(t *testing.T) {
 				  impersonationTLSCertificateSecret: impersonationTLSCertificateSecret-value
 				  impersonationCACertificateSecret: impersonationCACertificateSecret-value
 				  impersonationSignerSecret: impersonationSignerSecret-value
-				  serviceAccount: serviceAccount-value
+				  agentServiceAccount: agentServiceAccount-value
 			`),
 			wantError: "validate names: missing required names: servingCertificateSecret",
 		},
@@ -199,7 +199,7 @@ func TestFromPath(t *testing.T) {
 				  impersonationTLSCertificateSecret: impersonationTLSCertificateSecret-value
 				  impersonationCACertificateSecret: impersonationCACertificateSecret-value
 				  impersonationSignerSecret: impersonationSignerSecret-value
-				  serviceAccount: serviceAccount-value
+				  agentServiceAccount: agentServiceAccount-value
 			`),
 			wantError: "validate names: missing required names: impersonationConfigMap",
 		},
@@ -215,7 +215,7 @@ func TestFromPath(t *testing.T) {
 				  impersonationTLSCertificateSecret: impersonationTLSCertificateSecret-value
 				  impersonationCACertificateSecret: impersonationCACertificateSecret-value
 				  impersonationSignerSecret: impersonationSignerSecret-value
-				  serviceAccount: serviceAccount-value
+				  agentServiceAccount: agentServiceAccount-value
 			`),
 			wantError: "validate names: missing required names: impersonationLoadBalancerService",
 		},
@@ -231,7 +231,7 @@ func TestFromPath(t *testing.T) {
 				  impersonationLoadBalancerService: impersonationLoadBalancerService-value
 				  impersonationCACertificateSecret: impersonationCACertificateSecret-value
 				  impersonationSignerSecret: impersonationSignerSecret-value
-				  serviceAccount: serviceAccount-value
+				  agentServiceAccount: agentServiceAccount-value
 			`),
 			wantError: "validate names: missing required names: impersonationTLSCertificateSecret",
 		},
@@ -247,7 +247,7 @@ func TestFromPath(t *testing.T) {
 				  impersonationLoadBalancerService: impersonationLoadBalancerService-value
 				  impersonationTLSCertificateSecret: impersonationTLSCertificateSecret-value
 				  impersonationSignerSecret: impersonationSignerSecret-value
-				  serviceAccount: serviceAccount-value
+				  agentServiceAccount: agentServiceAccount-value
 			`),
 			wantError: "validate names: missing required names: impersonationCACertificateSecret",
 		},
@@ -263,7 +263,7 @@ func TestFromPath(t *testing.T) {
 				  impersonationLoadBalancerService: impersonationLoadBalancerService-value
 				  impersonationTLSCertificateSecret: impersonationTLSCertificateSecret-value
 				  impersonationCACertificateSecret: impersonationCACertificateSecret-value
-				  serviceAccount: serviceAccount-value
+				  agentServiceAccount: agentServiceAccount-value
 			`),
 			wantError: "validate names: missing required names: impersonationSignerSecret",
 		},
@@ -277,7 +277,7 @@ func TestFromPath(t *testing.T) {
 				  apiService: pinniped-api
 				  impersonationLoadBalancerService: impersonationLoadBalancerService-value
 				  impersonationSignerSecret: impersonationSignerSecret-value
-				  serviceAccount: serviceAccount-value
+				  agentServiceAccount: agentServiceAccount-value
 			`),
 			wantError: "validate names: missing required names: impersonationConfigMap, " +
 				"impersonationTLSCertificateSecret, impersonationCACertificateSecret",

--- a/internal/config/concierge/types.go
+++ b/internal/config/concierge/types.go
@@ -41,7 +41,7 @@ type NamesConfigSpec struct {
 	ImpersonationTLSCertificateSecret string `json:"impersonationTLSCertificateSecret"`
 	ImpersonationCACertificateSecret  string `json:"impersonationCACertificateSecret"`
 	ImpersonationSignerSecret         string `json:"impersonationSignerSecret"`
-	ServiceAccount                    string `json:"serviceAccount"`
+	AgentServiceAccount               string `json:"agentServiceAccount"`
 }
 
 // ServingCertificateConfigSpec contains the configuration knobs for the API's

--- a/internal/config/concierge/types.go
+++ b/internal/config/concierge/types.go
@@ -41,6 +41,7 @@ type NamesConfigSpec struct {
 	ImpersonationTLSCertificateSecret string `json:"impersonationTLSCertificateSecret"`
 	ImpersonationCACertificateSecret  string `json:"impersonationCACertificateSecret"`
 	ImpersonationSignerSecret         string `json:"impersonationSignerSecret"`
+	ServiceAccount                    string `json:"serviceAccount"`
 }
 
 // ServingCertificateConfigSpec contains the configuration knobs for the API's

--- a/internal/controller/kubecertagent/kubecertagent.go
+++ b/internal/controller/kubecertagent/kubecertagent.go
@@ -64,6 +64,9 @@ type AgentConfig struct {
 	// NamePrefix will be prefixed to all agent pod names.
 	NamePrefix string
 
+	// ServiceAccountName is the service account under which to run the agent pods.
+	ServiceAccountName string
+
 	// ContainerImagePullSecrets is a list of names of Kubernetes Secret objects that will be used as
 	// ImagePullSecrets on the kube-cert-agent pods.
 	ContainerImagePullSecrets []string
@@ -472,6 +475,7 @@ func (c *agentController) newAgentDeployment(controllerManagerPod *corev1.Pod) *
 					RestartPolicy:                corev1.RestartPolicyAlways,
 					NodeSelector:                 controllerManagerPod.Spec.NodeSelector,
 					AutomountServiceAccountToken: pointer.BoolPtr(false),
+					ServiceAccountName:           c.cfg.ServiceAccountName,
 					NodeName:                     controllerManagerPod.Spec.NodeName,
 					Tolerations:                  controllerManagerPod.Spec.Tolerations,
 					// We need to run the agent pod as root since the file permissions

--- a/internal/controller/kubecertagent/kubecertagent_test.go
+++ b/internal/controller/kubecertagent/kubecertagent_test.go
@@ -123,6 +123,7 @@ func TestAgentController(t *testing.T) {
 					}},
 					RestartPolicy:                 corev1.RestartPolicyAlways,
 					TerminationGracePeriodSeconds: pointer.Int64Ptr(0),
+					ServiceAccountName:            "test-service-account-name",
 					AutomountServiceAccountToken:  pointer.BoolPtr(false),
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsUser:  pointer.Int64Ptr(0),
@@ -672,6 +673,7 @@ func TestAgentController(t *testing.T) {
 				AgentConfig{
 					Namespace:                 "concierge",
 					ContainerImage:            "pinniped-server-image",
+					ServiceAccountName:        "test-service-account-name",
 					NamePrefix:                "pinniped-concierge-kube-cert-agent-",
 					ContainerImagePullSecrets: []string{"pinniped-image-pull-secret"},
 					CredentialIssuerName:      "pinniped-concierge-config",

--- a/internal/controllermanager/prepare_controllers.go
+++ b/internal/controllermanager/prepare_controllers.go
@@ -121,6 +121,7 @@ func PrepareControllers(c *Config) (func(ctx context.Context), error) {
 
 	agentConfig := kubecertagent.AgentConfig{
 		Namespace:                 c.ServerInstallationInfo.Namespace,
+		ServiceAccountName:        c.NamesConfig.ServiceAccount,
 		ContainerImage:            *c.KubeCertAgentConfig.Image,
 		NamePrefix:                *c.KubeCertAgentConfig.NamePrefix,
 		ContainerImagePullSecrets: c.KubeCertAgentConfig.ImagePullSecrets,

--- a/internal/controllermanager/prepare_controllers.go
+++ b/internal/controllermanager/prepare_controllers.go
@@ -121,7 +121,7 @@ func PrepareControllers(c *Config) (func(ctx context.Context), error) {
 
 	agentConfig := kubecertagent.AgentConfig{
 		Namespace:                 c.ServerInstallationInfo.Namespace,
-		ServiceAccountName:        c.NamesConfig.ServiceAccount,
+		ServiceAccountName:        c.NamesConfig.AgentServiceAccount,
 		ContainerImage:            *c.KubeCertAgentConfig.Image,
 		NamePrefix:                *c.KubeCertAgentConfig.NamePrefix,
 		ContainerImagePullSecrets: c.KubeCertAgentConfig.ImagePullSecrets,


### PR DESCRIPTION
This PR adds a new service account for the kube-cert-agent pods to run under. This service account is never used directly by the pod (since it only ever calls `sleep` and `cat`) but allows the pod to be created by the deployments controller even when restrictive PodSecurityPolicy or SecurityContextConstraints are enforced on the cluster.

This was a regression from #569 when we stopped creating the pods directly from the main Concierge process. We caught this in CI post-merge (we do not have any PSP-enforcing clusters in our pre-merge CI pipeline, but we do have some in the post-merge pipeline).



**Release note**:
No release note since this change only affects otherwise unreleased functionality.

```release-note
NONE
```
