### PR TITLE
supervisor gc: use singleton queue

### DIFF
--- a/internal/controller/supervisorstorage/garbage_collector.go
+++ b/internal/controller/supervisorstorage/garbage_collector.go
@@ -59,7 +59,7 @@ func GarbageCollectorController(
 					return isSecretWithGCAnnotation(oldObj) || isSecretWithGCAnnotation(newObj)
 				},
 				DeleteFunc: func(obj metav1.Object) bool { return false }, // ignore all deletes
-				ParentFunc: nil,
+				ParentFunc: pinnipedcontroller.SingletonQueue(),
 			},
 			controllerlib.InformerOption{},
 		),
@@ -67,16 +67,20 @@ func GarbageCollectorController(
 }
 
 func (c *garbageCollectorController) Sync(ctx controllerlib.Context) error {
+	// make sure we have a consistent, static meaning for the current time during the sync loop
+	frozenClock := clock.NewFakeClock(c.clock.Now())
+
 	// The Sync method is triggered upon any change to any Secret, which would make this
 	// controller too chatty, so it rate limits itself to a more reasonable interval.
 	// Note that even during a period when no secrets are changing, it will still run
 	// at the informer's full-resync interval (as long as there are some secrets).
-	if c.clock.Now().Sub(c.timeOfMostRecentSweep) < minimumRepeatInterval {
+	if since := frozenClock.Since(c.timeOfMostRecentSweep); since < minimumRepeatInterval {
+		ctx.Queue.AddAfter(ctx.Key, minimumRepeatInterval-since)
 		return nil
 	}
 
 	plog.Info("starting storage garbage collection sweep")
-	c.timeOfMostRecentSweep = c.clock.Now()
+	c.timeOfMostRecentSweep = frozenClock.Now()
 
 	listOfSecrets, err := c.secretInformer.Lister().List(labels.Everything())
 	if err != nil {
@@ -97,7 +101,7 @@ func (c *garbageCollectorController) Sync(ctx controllerlib.Context) error {
 			continue
 		}
 
-		if garbageCollectAfterTime.Before(c.clock.Now()) {
+		if garbageCollectAfterTime.Before(frozenClock.Now()) {
 			err = c.kubeClient.CoreV1().Secrets(secret.Namespace).Delete(ctx.Context, secret.Name, metav1.DeleteOptions{})
 			if err != nil {
 				plog.WarningErr("failed to garbage collect resource", err, logKV(secret))


### PR DESCRIPTION
The supervisor treats all events the same hence it must use a
singleton queue.

Updated the integration test to remove the data race caused by
calling methods on testing.T outside of the main test go routine.

Signed-off-by: Monis Khan <mok@vmware.com>

**Release note**:

```release-note
NONE
```