### PR TITLE
Create CredentialIssuer at install, not runtime.

### DIFF
--- a/deploy/concierge/deployment.yaml
+++ b/deploy/concierge/deployment.yaml
@@ -247,3 +247,9 @@ spec:
     name: #@ defaultResourceNameWithSuffix("api")
     namespace: #@ namespace()
     port: 443
+---
+apiVersion: #@ pinnipedDevAPIGroupWithPrefix("config.concierge") + "/v1alpha1"
+kind: CredentialIssuer
+metadata:
+  name: #@ defaultResourceNameWithSuffix("config")
+  labels: #@ labels()

--- a/internal/controllermanager/prepare_controllers.go
+++ b/internal/controllermanager/prepare_controllers.go
@@ -204,6 +204,7 @@ func PrepareControllers(c *Config) (func(ctx context.Context), error) {
 				informers.installationNamespaceK8s.Apps().V1().Deployments(),
 				informers.installationNamespaceK8s.Core().V1().Pods(),
 				informers.kubePublicNamespaceK8s.Core().V1().ConfigMaps(),
+				informers.pinniped.Config().V1alpha1().CredentialIssuers(),
 				c.DynamicSigningCertProvider,
 			),
 			singletonWorker,

--- a/test/integration/concierge_credentialissuer_test.go
+++ b/test/integration/concierge_credentialissuer_test.go
@@ -43,22 +43,11 @@ func TestCredentialIssuer(t *testing.T) {
 		}
 		require.Equal(t, env.ConciergeAppName, actualConfig.Labels["app"])
 
-		// verify owner ref is set
-		require.Len(t, actualConfig.OwnerReferences, 1)
-
 		apiService, err := aggregatedClientset.ApiregistrationV1().APIServices().Get(ctx, "v1alpha1.login.concierge."+env.APIGroupSuffix, metav1.GetOptions{})
 		require.NoError(t, err)
 
 		// work around stupid behavior of WithoutVersionDecoder.Decode
 		apiService.APIVersion, apiService.Kind = apiregistrationv1.SchemeGroupVersion.WithKind("APIService").ToAPIVersionAndKind()
-
-		ref := metav1.OwnerReference{
-			APIVersion: apiService.APIVersion,
-			Kind:       apiService.Kind,
-			Name:       apiService.Name,
-			UID:        apiService.UID,
-		}
-		require.Equal(t, ref, actualConfig.OwnerReferences[0])
 
 		// Verify the cluster strategy status based on what's expected of the test cluster's ability to share signing keys.
 		actualStatusStrategies := actualConfigList.Items[0].Status.Strategies


### PR DESCRIPTION
Previously, our controllers would automatically create a CredentialIssuer with a singleton name. The helpers we had for this also used "raw" client access and did not take advantage of the informer cache pattern.

With this change, the CredentialIssuer is always created at install time in the ytt YAML. The controllers now only update the existing CredentialIssuer status, and they do so using the informer cache as much as possible.

This change is targeted at only the kubecertagent controller to start. The impersonatorconfig controller will be updated in a following PR along with other changes.

The overall goal of this change is to simplify the controllers, reduce kube-apiserver load, and eliminate edge cases that will appear when we add `spec` fields to the CredentialIssuer (in #626).

**Release note**:

```release-note
The CredentialIssuer is now created in the install YAML, rather than dynamically by Concierge controllers.
```
