### PR TITLE
Template pinniped.yml as YAML and encode

### DIFF
--- a/deploy/concierge/deployment.yaml
+++ b/deploy/concierge/deployment.yaml
@@ -3,6 +3,7 @@
 
 #@ load("@ytt:data", "data")
 #@ load("@ytt:json", "json")
+#@ load("@ytt:yaml", "yaml")
 #@ load("helpers.lib.yaml", "defaultLabel", "labels", "namespace", "defaultResourceName", "defaultResourceNameWithSuffix", "getAndValidateLogLevel", "pinnipedDevAPIGroupWithPrefix")
 
 #@ if not data.values.into_namespace:
@@ -28,6 +29,49 @@ metadata:
   namespace: #@ namespace()
   labels: #@ labels()
 ---
+#@ def image():
+#@   if data.values.kube_cert_agent_image:
+#@     return data.values.kube_cert_agent_image
+#@   else:
+#@     if data.values.image_digest:
+#@       return data.values.image_repo + "@" + data.values.image_digest
+#@     else:
+#@       return data.values.image_repo + ":" + data.values.image_tag
+#@     end
+#@   end
+#@   return ""
+#@ end
+
+#@ def pinniped_yaml():
+discovery:
+  url: #@ data.values.discovery_url or None
+api:
+  servingCertificate:
+    durationSeconds: #@ data.values.api_serving_certificate_duration_seconds
+    renewBeforeSeconds: #@ data.values.api_serving_certificate_renew_before_seconds
+apiGroupSuffix: #@ data.values.api_group_suffix
+names:
+  servingCertificateSecret: #@ defaultResourceNameWithSuffix("api-tls-serving-certificate")
+  credentialIssuer: #@ defaultResourceNameWithSuffix("config")
+  apiService: #@ defaultResourceNameWithSuffix("api")
+  impersonationConfigMap: #@ defaultResourceNameWithSuffix("impersonation-proxy-config")
+  impersonationLoadBalancerService: #@ defaultResourceNameWithSuffix("impersonation-proxy-load-balancer")
+  impersonationTLSCertificateSecret: #@ defaultResourceNameWithSuffix("impersonation-proxy-tls-serving-certificate")
+  impersonationCACertificateSecret: #@ defaultResourceNameWithSuffix("impersonation-proxy-ca-certificate")
+  impersonationSignerSecret: #@ defaultResourceNameWithSuffix("impersonation-proxy-signer-ca-certificate")
+  agentServiceAccount: #@ defaultResourceNameWithSuffix("kube-cert-agent")
+labels: #@ json.encode(labels()).rstrip()
+kubeCertAgent:
+  namePrefix: #@ defaultResourceNameWithSuffix("kube-cert-agent-")
+  #@ if/end image():
+  image: #@ image()
+  #@ if/end data.values.image_pull_dockerconfigjson:
+  imagePullSecrets:
+    - image-pull-secret
+#@ if/end data.values.log_level:
+logLevel: #@ getAndValidateLogLevel()
+#@ end
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -36,45 +80,8 @@ metadata:
   labels: #@ labels()
 data:
   #! If names.apiService is changed in this ConfigMap, must also change name of the ClusterIP Service resource below.
-  #@yaml/text-templated-strings
-  pinniped.yaml: |
-    discovery:
-      url: (@= data.values.discovery_url or "null" @)
-    api:
-      servingCertificate:
-        durationSeconds: (@= str(data.values.api_serving_certificate_duration_seconds) @)
-        renewBeforeSeconds: (@= str(data.values.api_serving_certificate_renew_before_seconds) @)
-    apiGroupSuffix: (@= data.values.api_group_suffix @)
-    names:
-      servingCertificateSecret: (@= defaultResourceNameWithSuffix("api-tls-serving-certificate") @)
-      credentialIssuer: (@= defaultResourceNameWithSuffix("config") @)
-      apiService: (@= defaultResourceNameWithSuffix("api") @)
-      impersonationConfigMap: (@= defaultResourceNameWithSuffix("impersonation-proxy-config") @)
-      impersonationLoadBalancerService: (@= defaultResourceNameWithSuffix("impersonation-proxy-load-balancer") @)
-      impersonationTLSCertificateSecret: (@= defaultResourceNameWithSuffix("impersonation-proxy-tls-serving-certificate") @)
-      impersonationCACertificateSecret: (@= defaultResourceNameWithSuffix("impersonation-proxy-ca-certificate") @)
-      impersonationSignerSecret: (@= defaultResourceNameWithSuffix("impersonation-proxy-signer-ca-certificate") @)
-      agentServiceAccount: (@= defaultResourceNameWithSuffix("kube-cert-agent") @)
-    labels: (@= json.encode(labels()).rstrip() @)
-    kubeCertAgent:
-      namePrefix: (@= defaultResourceNameWithSuffix("kube-cert-agent-") @)
-      (@ if data.values.kube_cert_agent_image: @)
-      image: (@= data.values.kube_cert_agent_image @)
-      (@ else: @)
-      (@ if data.values.image_digest: @)
-      image: (@= data.values.image_repo + "@" + data.values.image_digest @)
-      (@ else: @)
-      image: (@= data.values.image_repo + ":" + data.values.image_tag @)
-      (@ end @)
-      (@ end @)
-      (@ if data.values.image_pull_dockerconfigjson: @)
-      imagePullSecrets:
-        - image-pull-secret
-      (@ end @)
-    (@ if data.values.log_level: @)
-    logLevel: (@= getAndValidateLogLevel() @)
-    (@ end @)
----
+  pinniped.yaml: #@ yaml.encode(pinniped_yaml())
+--
 #@ if data.values.image_pull_dockerconfigjson and data.values.image_pull_dockerconfigjson != "":
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
This pull request is meant to provide an example rather than directly make a contribution.

It originated in a conversation I had with @cfryanr.

Attempting to illustrate how one can retain the benefits of templating YAML while getting stringified output as needed (here into a `ConfigMap`).

I did note one difference between the original and the output from this approach:

The original (left) renders a JSON formatted value into the file. YAML is a superset of JSON, so it will parse, but (perhaps surprisingly?) to a map item where the _key_ is the entire thing and the value is `null`.

```diff
< labels:
<   \"app\":\"pinniped-concierge\": null
---
> labels: '{"app":"pinniped-concierge"}'
```

I suspect either:
- the value of `labels:` it's meant to be just plain YAML, here.
    ```yaml
    labels:
       app: pinniped-concierge
    ```
- or, it's meant to be a string formatted in YAML?
    ```yaml
    labels: |
       app: pinniped-concierge
    ```