### PR TITLE
Replace all references to "a specific version" with v0.8.0.

### DIFF
--- a/site/content/docs/howto/install-cli.md
+++ b/site/content/docs/howto/install-cli.md
@@ -44,10 +44,10 @@ Click Open to allow the command to proceed.
 
 ## Install a specific version via script
 
-For example, to install v0.4.1 on Linux/amd64:
+For example, to install v0.8.0 on Linux/amd64:
 
 ```sh
-curl -Lso pinniped https://get.pinniped.dev/v0.4.1/pinniped-cli-linux-amd64 \
+curl -Lso pinniped https://get.pinniped.dev/v0.8.0/pinniped-cli-linux-amd64 \
   && chmod +x pinniped \
   && sudo mv pinniped /usr/local/bin/pinniped
 ```

--- a/site/content/docs/howto/install-concierge.md
+++ b/site/content/docs/howto/install-concierge.md
@@ -24,9 +24,9 @@ You should have a [supported Kubernetes cluster]({{< ref "../reference/supported
 
 1. Install the Concierge into the `pinniped-concierge` namespace with default options:
 
-   - `kubectl apply -f https://get.pinniped.dev/v0.4.1/install-pinniped-concierge.yaml` 
+   - `kubectl apply -f https://get.pinniped.dev/v0.8.0/install-pinniped-concierge.yaml`
 
-      *Replace v0.4.1 with your preferred version number.*
+      *Replace v0.8.0 with your preferred version number.*
   
 ## With custom options
 

--- a/site/content/docs/howto/install-supervisor.md
+++ b/site/content/docs/howto/install-supervisor.md
@@ -25,9 +25,9 @@ You should have a supported Kubernetes cluster with working HTTPS ingress capabi
 
 1. Install the Supervisor into the `pinniped-supervisor` namespace with default options:
 
-   - `kubectl apply -f https://get.pinniped.dev/v0.4.1/install-pinniped-supervisor.yaml`
+   - `kubectl apply -f https://get.pinniped.dev/v0.8.0/install-pinniped-supervisor.yaml`
   
-     *Replace v0.4.1 with your preferred version number.*
+     *Replace v0.8.0 with your preferred version number.*
 
 ## With custom options
 

--- a/site/content/docs/tutorials/concierge-only-demo.md
+++ b/site/content/docs/tutorials/concierge-only-demo.md
@@ -79,7 +79,7 @@ as the authenticator.
    see [deploy/local-user-authenticator/README.md](https://github.com/vmware-tanzu/pinniped/blob/main/deploy/local-user-authenticator/README.md)
    for instructions on how to deploy using `ytt`.
 
-   If you prefer to install a specific version, replace `latest` in the URL with the version number such as `v0.4.1`.
+   If you prefer to install a specific version, replace `latest` in the URL with the version number such as `v0.8.0`.
 
 1. Create a test user named `pinny-the-seal` in the local-user-authenticator namespace.
 


### PR DESCRIPTION
The documentation was a bit confusing before, and it was easy to accidentally install a very outdated version if you weren't reading carefully.

We could consider writing a post-release CI job to update these references automatically (perhaps using a Hugo macro?), but for now a manual update seems sufficient.

**Release note**:

```release-note
NONE
```
