### PR TITLE
Refactor "endpoint address" parsing code into shared package.

### DIFF
--- a/internal/controller/supervisorconfig/ldapupstreamwatcher/ldap_upstream_watcher_test.go
+++ b/internal/controller/supervisorconfig/ldapupstreamwatcher/ldap_upstream_watcher_test.go
@@ -26,6 +26,7 @@ import (
 	pinnipedinformers "go.pinniped.dev/generated/latest/client/supervisor/informers/externalversions"
 	"go.pinniped.dev/internal/certauthority"
 	"go.pinniped.dev/internal/controllerlib"
+	"go.pinniped.dev/internal/endpointaddr"
 	"go.pinniped.dev/internal/mocks/mockldapconn"
 	"go.pinniped.dev/internal/oidc/provider"
 	"go.pinniped.dev/internal/testutil"
@@ -871,9 +872,9 @@ func TestLDAPUpstreamWatcherControllerSync(t *testing.T) {
 				tt.setupMocks(conn)
 			}
 
-			dialer := &comparableDialer{upstreamldap.LDAPDialerFunc(func(ctx context.Context, hostAndPort string) (upstreamldap.Conn, error) {
+			dialer := &comparableDialer{upstreamldap.LDAPDialerFunc(func(ctx context.Context, addr endpointaddr.HostPort) (upstreamldap.Conn, error) {
 				if tt.dialErrors != nil {
-					dialErr := tt.dialErrors[hostAndPort]
+					dialErr := tt.dialErrors[addr.Endpoint()]
 					if dialErr != nil {
 						return nil, dialErr
 					}

--- a/internal/endpointaddr/endpointaddr.go
+++ b/internal/endpointaddr/endpointaddr.go
@@ -1,0 +1,71 @@
+// Copyright 2021 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package endpointaddr implements parsing and validation of "<host>[:<port>]" strings for Pinniped APIs.
+package endpointaddr
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+type HostPort struct {
+	// Host is the validated host part of the input, which may be a hostname or IP.
+	//
+	// This string can be be used as an x509 certificate SAN.
+	Host string
+
+	// Port is the validated port number, which may be defaulted.
+	Port uint16
+}
+
+// Endpoint is the host:port validated from the input, where port may be a default value.
+//
+// This string can be passed to net.Dial.
+func (h *HostPort) Endpoint() string {
+	return net.JoinHostPort(h.Host, strconv.Itoa(int(h.Port)))
+}
+
+// Parse an "endpoint address" string, providing a default port. The input can be in several valid formats:
+//
+// - "<hostname>"        (DNS hostname)
+// - "<IPv4>"            (IPv4 address)
+// - "<IPv6>"            (IPv6 address)
+// - "<hostname>:<port>" (DNS hostname with port)
+// - "<IPv4>:<port>"     (IPv4 address with port)
+// - "[<IPv6>]:<port>"   (IPv6 address with port, brackets are required)
+//
+// If the input does not not specify a port number, then defaultPort will be used.
+func Parse(endpoint string, defaultPort uint16) (HostPort, error) {
+	// Try parsing it both with and without an implicit port 443 at the end.
+	host, port, err := net.SplitHostPort(endpoint)
+
+	// If we got an error parsing the raw input, try adding the default port.
+	if err != nil {
+		host, port, err = net.SplitHostPort(net.JoinHostPort(endpoint, strconv.Itoa(int(defaultPort))))
+	}
+
+	// Give up if there's still an error splitting the host and port.
+	if err != nil {
+		return HostPort{}, err
+	}
+
+	// Parse the port number is an integer in the range of valid ports.
+	integerPort, _ := strconv.Atoi(port)
+	if len(validation.IsValidPortNum(integerPort)) > 0 {
+		return HostPort{}, fmt.Errorf("invalid port %q", port)
+	}
+
+	// Check if the host part is a IPv4 or IPv6 address or a valid hostname according to RFC 1123.
+	switch {
+	case len(validation.IsValidIP(host)) == 0:
+	case len(validation.IsDNS1123Subdomain(host)) == 0:
+	default:
+		return HostPort{}, fmt.Errorf("host %q is not a valid hostname or IP address", host)
+	}
+
+	return HostPort{Host: host, Port: uint16(integerPort)}, nil
+}

--- a/internal/endpointaddr/endpointaddr_test.go
+++ b/internal/endpointaddr/endpointaddr_test.go
@@ -1,0 +1,182 @@
+// Copyright 2021 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package endpointaddr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name           string
+		input          string
+		defaultPort    uint16
+		expectErr      string
+		expect         HostPort
+		expectEndpoint string
+	}{
+		{
+			name:           "plain IPv4",
+			input:          "127.0.0.1",
+			defaultPort:    443,
+			expect:         HostPort{Host: "127.0.0.1", Port: 443},
+			expectEndpoint: "127.0.0.1:443",
+		},
+		{
+			name:           "IPv4 with port",
+			input:          "127.0.0.1:8443",
+			defaultPort:    443,
+			expect:         HostPort{Host: "127.0.0.1", Port: 8443},
+			expectEndpoint: "127.0.0.1:8443",
+		},
+		{
+			name:           "IPv4 in brackets with port",
+			input:          "[127.0.0.1]:8443",
+			defaultPort:    443,
+			expect:         HostPort{Host: "127.0.0.1", Port: 8443},
+			expectEndpoint: "127.0.0.1:8443",
+		},
+		{
+			name:           "IPv4 as IPv6 in brackets with port",
+			input:          "[::127.0.0.1]:8443",
+			defaultPort:    443,
+			expect:         HostPort{Host: "::127.0.0.1", Port: 8443},
+			expectEndpoint: "[::127.0.0.1]:8443",
+		},
+		{
+			name:           "IPv4 as IPv6 without port",
+			input:          "::127.0.0.1",
+			defaultPort:    443,
+			expect:         HostPort{Host: "::127.0.0.1", Port: 443},
+			expectEndpoint: "[::127.0.0.1]:443",
+		},
+		{
+			name:           "plain IPv6 without port",
+			input:          "2001:db8::ffff",
+			defaultPort:    443,
+			expect:         HostPort{Host: "2001:db8::ffff", Port: 443},
+			expectEndpoint: "[2001:db8::ffff]:443",
+		},
+		{
+			name:           "IPv6 with port",
+			input:          "[2001:db8::ffff]:8443",
+			defaultPort:    443,
+			expect:         HostPort{Host: "2001:db8::ffff", Port: 8443},
+			expectEndpoint: "[2001:db8::ffff]:8443",
+		},
+		{
+			name:           "plain hostname",
+			input:          "host.example.com",
+			defaultPort:    443,
+			expect:         HostPort{Host: "host.example.com", Port: 443},
+			expectEndpoint: "host.example.com:443",
+		},
+		{
+			name:           "plain hostname with dash",
+			input:          "host-dev.example.com",
+			defaultPort:    443,
+			expect:         HostPort{Host: "host-dev.example.com", Port: 443},
+			expectEndpoint: "host-dev.example.com:443",
+		},
+		{
+			name:           "hostname with port",
+			input:          "host.example.com:8443",
+			defaultPort:    443,
+			expect:         HostPort{Host: "host.example.com", Port: 8443},
+			expectEndpoint: "host.example.com:8443",
+		},
+		{
+			name:           "hostname in brackets with port",
+			input:          "[host.example.com]:8443",
+			defaultPort:    443,
+			expect:         HostPort{Host: "host.example.com", Port: 8443},
+			expectEndpoint: "host.example.com:8443",
+		},
+		{
+			name:           "hostname without dots",
+			input:          "localhost",
+			defaultPort:    443,
+			expect:         HostPort{Host: "localhost", Port: 443},
+			expectEndpoint: "localhost:443",
+		},
+		{
+			name:           "hostname and port without dots",
+			input:          "localhost:8443",
+			defaultPort:    443,
+			expect:         HostPort{Host: "localhost", Port: 8443},
+			expectEndpoint: "localhost:8443",
+		},
+		{
+			name:        "invalid empty string",
+			input:       "",
+			defaultPort: 443,
+			expectErr:   `host "" is not a valid hostname or IP address`,
+		},
+		{
+			// IPv6 zone index specifiers are not yet supported.
+			name:        "IPv6 with port and zone index",
+			input:       "[2001:db8::ffff%lo0]:8443",
+			defaultPort: 443,
+			expectErr:   `host "2001:db8::ffff%lo0" is not a valid hostname or IP address`,
+		},
+		{
+			name:        "IPv6 in brackets without port",
+			input:       "[2001:db8::ffff]",
+			defaultPort: 443,
+			expectErr:   `address [[2001:db8::ffff]]:443: missing port in address`,
+		},
+		{
+			name:        "invalid HTTPS URL",
+			input:       "https://host.example.com",
+			defaultPort: 443,
+			expectErr:   `invalid port "//host.example.com"`,
+		},
+		{
+			name:        "invalid host with URL path",
+			input:       "host.example.com/some/path",
+			defaultPort: 443,
+			expectErr:   `host "host.example.com/some/path" is not a valid hostname or IP address`,
+		},
+		{
+			name:        "invalid host with mismatched brackets",
+			input:       "[host.example.com",
+			defaultPort: 443,
+			expectErr:   "address [host.example.com:443: missing ']' in address",
+		},
+		{
+			name:        "invalid host with underscores",
+			input:       "___.example.com:1234",
+			defaultPort: 443,
+			expectErr:   `host "___.example.com" is not a valid hostname or IP address`,
+		},
+		{
+			name:        "invalid host with uppercase",
+			input:       "HOST.EXAMPLE.COM",
+			defaultPort: 443,
+			expectErr:   `host "HOST.EXAMPLE.COM" is not a valid hostname or IP address`,
+		},
+		{
+			name:        "invalid host with extra port",
+			input:       "host.example.com:port1:port2",
+			defaultPort: 443,
+			expectErr:   `host "host.example.com:port1:port2" is not a valid hostname or IP address`,
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Parse(tt.input, tt.defaultPort)
+			if tt.expectErr == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expect, got)
+				assert.Equal(t, tt.expectEndpoint, got.Endpoint())
+			} else {
+				assert.EqualError(t, err, tt.expectErr)
+				assert.Equal(t, HostPort{}, got)
+			}
+		})
+	}
+}

--- a/internal/upstreamldap/upstreamldap_test.go
+++ b/internal/upstreamldap/upstreamldap_test.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 
 	"go.pinniped.dev/internal/certauthority"
+	"go.pinniped.dev/internal/endpointaddr"
 	"go.pinniped.dev/internal/mocks/mockldapconn"
 	"go.pinniped.dev/internal/testutil"
 )
@@ -926,9 +927,9 @@ func TestEndUserAuthentication(t *testing.T) {
 			}
 
 			dialWasAttempted := false
-			tt.providerConfig.Dialer = LDAPDialerFunc(func(ctx context.Context, hostAndPort string) (Conn, error) {
+			tt.providerConfig.Dialer = LDAPDialerFunc(func(ctx context.Context, addr endpointaddr.HostPort) (Conn, error) {
 				dialWasAttempted = true
-				require.Equal(t, tt.providerConfig.Host, hostAndPort)
+				require.Equal(t, tt.providerConfig.Host, addr.Endpoint())
 				if tt.dialError != nil {
 					return nil, tt.dialError
 				}
@@ -1061,9 +1062,9 @@ func TestTestConnection(t *testing.T) {
 			}
 
 			dialWasAttempted := false
-			tt.providerConfig.Dialer = LDAPDialerFunc(func(ctx context.Context, hostAndPort string) (Conn, error) {
+			tt.providerConfig.Dialer = LDAPDialerFunc(func(ctx context.Context, addr endpointaddr.HostPort) (Conn, error) {
 				dialWasAttempted = true
-				require.Equal(t, tt.providerConfig.Host, hostAndPort)
+				require.Equal(t, tt.providerConfig.Host, addr.Endpoint())
 				if tt.dialError != nil {
 					return nil, tt.dialError
 				}
@@ -1185,7 +1186,7 @@ func TestRealTLSDialing(t *testing.T) {
 			caBundle:  []byte(testServerCABundle),
 			connProto: TLS,
 			context:   context.Background(),
-			wantError: `LDAP Result Code 200 "Network Error": address this:is:not:a:valid:hostname: too many colons in address`,
+			wantError: `LDAP Result Code 200 "Network Error": host "this:is:not:a:valid:hostname" is not a valid hostname or IP address`,
 		},
 		{
 			name:      "invalid host with StartTLS",
@@ -1193,7 +1194,7 @@ func TestRealTLSDialing(t *testing.T) {
 			caBundle:  []byte(testServerCABundle),
 			connProto: StartTLS,
 			context:   context.Background(),
-			wantError: `LDAP Result Code 200 "Network Error": address this:is:not:a:valid:hostname: too many colons in address`,
+			wantError: `LDAP Result Code 200 "Network Error": host "this:is:not:a:valid:hostname" is not a valid hostname or IP address`,
 		},
 		{
 			name:      "missing CA bundle when it is required because the host is not using a trusted CA",
@@ -1258,126 +1259,6 @@ func TestRealTLSDialing(t *testing.T) {
 				err := conn.(*ldap.Conn).StartTLS(&tls.Config{})
 				require.EqualError(t, err, `LDAP Result Code 200 "Network Error": ldap: already encrypted`)
 			}
-		})
-	}
-}
-
-// Test various cases of host and port parsing.
-func TestHostAndPortWithDefaultPort(t *testing.T) {
-	tests := []struct {
-		name            string
-		hostAndPort     string
-		defaultPort     string
-		wantError       string
-		wantHostAndPort string
-	}{
-		{
-			name:            "host already has port",
-			hostAndPort:     "host.example.com:99",
-			defaultPort:     "42",
-			wantHostAndPort: "host.example.com:99",
-		},
-		{
-			name:            "host does not have port",
-			hostAndPort:     "host.example.com",
-			defaultPort:     "42",
-			wantHostAndPort: "host.example.com:42",
-		},
-		{
-			name:            "host does not have port and default port is empty",
-			hostAndPort:     "host.example.com",
-			defaultPort:     "",
-			wantHostAndPort: "host.example.com",
-		},
-		{
-			name:            "host has port and default port is empty",
-			hostAndPort:     "host.example.com:42",
-			defaultPort:     "",
-			wantHostAndPort: "host.example.com:42",
-		},
-		{
-			name:            "IPv6 host already has port",
-			hostAndPort:     "[::1%lo0]:80",
-			defaultPort:     "42",
-			wantHostAndPort: "[::1%lo0]:80",
-		},
-		{
-			name:            "IPv6 host does not have port",
-			hostAndPort:     "[::1%lo0]",
-			defaultPort:     "42",
-			wantHostAndPort: "[::1%lo0]:42",
-		},
-		{
-			name:            "IPv6 host does not have port and default port is empty",
-			hostAndPort:     "[::1%lo0]",
-			defaultPort:     "",
-			wantHostAndPort: "[::1%lo0]",
-		},
-		{
-			name:        "host is not valid",
-			hostAndPort: "host.example.com:port1:port2",
-			defaultPort: "42",
-			wantError:   "address host.example.com:port1:port2: too many colons in address",
-		},
-	}
-	for _, test := range tests {
-		tt := test
-		t.Run(tt.name, func(t *testing.T) {
-			hostAndPort, err := hostAndPortWithDefaultPort(tt.hostAndPort, tt.defaultPort)
-			if tt.wantError != "" {
-				require.EqualError(t, err, tt.wantError)
-			} else {
-				require.NoError(t, err)
-			}
-			require.Equal(t, tt.wantHostAndPort, hostAndPort)
-		})
-	}
-}
-
-// Test various cases of host and port parsing.
-func TestHostWithoutPort(t *testing.T) {
-	tests := []struct {
-		name            string
-		hostAndPort     string
-		wantError       string
-		wantHostAndPort string
-	}{
-		{
-			name:            "host already has port",
-			hostAndPort:     "host.example.com:99",
-			wantHostAndPort: "host.example.com",
-		},
-		{
-			name:            "host does not have port",
-			hostAndPort:     "host.example.com",
-			wantHostAndPort: "host.example.com",
-		},
-		{
-			name:            "IPv6 host already has port",
-			hostAndPort:     "[::1%lo0]:80",
-			wantHostAndPort: "[::1%lo0]",
-		},
-		{
-			name:            "IPv6 host does not have port",
-			hostAndPort:     "[::1%lo0]",
-			wantHostAndPort: "[::1%lo0]",
-		},
-		{
-			name:        "host is not valid",
-			hostAndPort: "host.example.com:port1:port2",
-			wantError:   "address host.example.com:port1:port2: too many colons in address",
-		},
-	}
-	for _, test := range tests {
-		tt := test
-		t.Run(tt.name, func(t *testing.T) {
-			hostAndPort, err := hostWithoutPort(tt.hostAndPort)
-			if tt.wantError != "" {
-				require.EqualError(t, err, tt.wantError)
-			} else {
-				require.NoError(t, err)
-			}
-			require.Equal(t, tt.wantHostAndPort, hostAndPort)
 		})
 	}
 }

--- a/test/integration/ldap_client_test.go
+++ b/test/integration/ldap_client_test.go
@@ -344,7 +344,7 @@ func TestLDAPSearch(t *testing.T) {
 			username:  "pinny",
 			password:  pinnyPassword,
 			provider:  upstreamldap.New(*providerConfig(func(p *upstreamldap.ProviderConfig) { p.Host = "too:many:ports" })),
-			wantError: `error dialing host "too:many:ports": LDAP Result Code 200 "Network Error": address too:many:ports: too many colons in address`,
+			wantError: `error dialing host "too:many:ports": LDAP Result Code 200 "Network Error": host "too:many:ports" is not a valid hostname or IP address`,
 		},
 		{
 			name:     "when the server is not parsable with StartTLS",
@@ -355,7 +355,7 @@ func TestLDAPSearch(t *testing.T) {
 				p.ConnectionProtocol = upstreamldap.StartTLS
 				p.Host = "too:many:ports"
 			})),
-			wantError: `error dialing host "too:many:ports": LDAP Result Code 200 "Network Error": address too:many:ports: too many colons in address`,
+			wantError: `error dialing host "too:many:ports": LDAP Result Code 200 "Network Error": host "too:many:ports" is not a valid hostname or IP address`,
 		},
 		{
 			name:      "when the CA bundle is not parsable with TLS",


### PR DESCRIPTION
This change factors out the "endpoint address" parsing code from the `internal/upstreamldap` package and pulls it into a new shared package `internal/endpointaddr`. The new code does not handle all inputs exactly the same as the previous code, because IPv6 zone index support is tricky in other use cases from #626.

The supported input formats are shown as examples in the new unit test. In summary, they are:

- `<hostname>`        (DNS hostname)
- `<IPv4>`            (IPv4 address)
- `<IPv6>`            (IPv6 address)
- `<hostname>:<port>` (DNS hostname with port)
- `<IPv4>:<port>`     (IPv4 address with port)
- `[<IPv6>]:<port>`   (IPv6 address with port, brackets are required)


For example, these are valid inputs:
- `127.0.0.1` (plain IPv4)
- `127.0.0.1:8443` (IPv4 with port)
- `[127.0.0.1]:8443` (IPv4 in brackets with port)
- `[::127.0.0.1]:8443` (IPv4 as IPv6 in brackets with port)
- `::127.0.0.1` (IPv4 as IPv6 without port)
- `2001:db8::ffff` (plain IPv6 without port)
- `[2001:db8::ffff]:8443` (IPv6 with port)
- `host.example.com` (plain hostname)
- `host-dev.example.com` (plain hostname with dash)
- `host.example.com:8443` (hostname with port)
- `[host.example.com]:8443` (hostname in brackets with port)

These inputs are considered invalid:
- ` ` (invalid empty string)
- `[2001:db8::ffff%lo0]:8443` (IPv6 with port and zone index)
- `[2001:db8::ffff]` (IPv6 in brackets without port)
- `https://host.example.com` (invalid HTTPS URL)
- `host.example.com/some/path` (invalid host with URL path)
- `[host.example.com` (invalid host with mismatched brackets)
- `___.example.com:1234` (invalid host with underscores)
- `HOST.EXAMPLE.COM` (invalid host with uppercase)
- `host.example.com:port1:port2` (invalid host with extra port)

The result is now returned as a `HostPort` struct with an `Endpoint() string` method. Keeping the input parsed makes it easier to work with in subsequent operations.

**Release note**:

```release-note
NONE
```
