### PR TITLE
impersonator: honor anonymous authentication being disabled

### DIFF
--- a/internal/concierge/impersonator/doc.go
+++ b/internal/concierge/impersonator/doc.go
@@ -19,6 +19,12 @@ also honor client certs from a CA that is specific to the impersonation proxy.
 This approach allows clients to use the Token Credential Request API even when
 we do not have the cluster's signing key.
 
+The proxy will honor cluster configuration in regards to anonymous authentication.
+When disabled, the proxy will not authenticate these requests. There is one caveat
+in that Pinniped itself provides the Token Credential Request API which is used
+specifically by anonymous users to retrieve credentials.  This API is the single
+API that will remain available even when anonymous authentication is disabled.
+
 In terms of authorization, we rely mostly on the Kubernetes API server.  Since we
 impersonate the user, the proxied request will be authorized against that user.
 Thus for all regular REST verbs, we perform no authorization checks.


### PR DESCRIPTION
When anonymous authentication is disabled, the impersonation proxy
will no longer authenticate anonymous requests other than calls to
the token credential request API (this API is used to retrieve
credentials and thus must be accessed anonymously).

Signed-off-by: Benjamin A. Petersen <ben@benjaminapetersen.me>
Signed-off-by: Monis Khan <mok@vmware.com>

Fixes #611

**Release note**:

```release-note
The concierge impersonation proxy now respects the Kubernetes API server's anonymous authentication configuration.  Thus if anonymous authentication is disabled on the API server, it will automatically be disabled on the impersonation proxy.
```