### PR TITLE
Remove an invalid test assertion in TestCredentialIssuer.

### DIFF
--- a/test/integration/concierge_credentialissuer_test.go
+++ b/test/integration/concierge_credentialissuer_test.go
@@ -87,16 +87,6 @@ func TestCredentialIssuer(t *testing.T) {
 				},
 				actualStatusKubeConfigInfo,
 			)
-
-			// Only validate LastUpdateTime when cluster signing key is available. The last update time
-			// will be set every time our controllers resync, but only when there exists controller
-			// manager pods (all other pods will be filtered out), hence why this assertion is in this
-			// if branch.
-			//
-			// This behavior is up for debate. We should eventually discuss the contract for this
-			// LastUpdateTime field and ensure that the implementation is the same for when the cluster
-			// signing key is available and not available.
-			require.WithinDuration(t, time.Now(), actualStatusStrategy.LastUpdateTime.Local(), 10*time.Minute)
 		} else {
 			require.Equal(t, configv1alpha1.ErrorStrategyStatus, actualStatusStrategy.Status)
 			require.Equal(t, configv1alpha1.CouldNotFetchKeyStrategyReason, actualStatusStrategy.Reason)


### PR DESCRIPTION
The LastUpdateTime is no longer updated on every resync. It only changes if the underlying status has changed, so that it effectively shows when the transition happened.

This change happened in ab750f48aa002504a18602e29f18af561b52cfe0, but we missed this test. It only fails when it has been more than ten minutes since the CredentialIssuer transitioned into a healthy state, but that can happen in our long-running CI environments.

**Release note**:

```release-note
NONE
```
