### PR TITLE
Fix typo in CredentialIssuer ytt template.

### DIFF
--- a/deploy/concierge/deployment.yaml
+++ b/deploy/concierge/deployment.yaml
@@ -260,7 +260,7 @@ spec:
     externalEndpoint: #@ data.values.impersonation_proxy_spec.external_endpoint
     #@ end
     service:
-      mode: #@ data.values.impersonation_proxy_spec.service.mode
+      type: #@ data.values.impersonation_proxy_spec.service.type
       #@ if data.values.impersonation_proxy_spec.service.load_balancer_ip:
       loadBalancerIP: #@ data.values.impersonation_proxy_spec.service.load_balancer_ip
       #@ end

--- a/deploy/concierge/values.yaml
+++ b/deploy/concierge/values.yaml
@@ -87,7 +87,7 @@ impersonation_proxy_spec:
     #! impersonation proxy.
     #! None does not provision either and assumes that you have set the external_endpoint
     #! and set up your own ingress to connect to the impersonation proxy.
-    mode: LoadBalancer
+    type: LoadBalancer
     #! The annotations that should be set on the ClusterIP or LoadBalancer Service.
     annotations:
       {service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "4000"}


### PR DESCRIPTION
This typo wasn't caught in testing because 1) the Kubernetes API ignores the unknown field and 2) the `type` field defaults to `LoadBalancer` anyway, so things behave as expected.

Even though this doesn't cause any large problems, it's quite confusing.

See #659 for more details.

**Release note**:

```release-note
Fixed an incorrect field name in the default CredentialIssuer YAML in the installation manifest.
```
