### PR TITLE
Improve our integration test "Eventually" assertions.

### DIFF
--- a/test/library/browsertest/browsertest.go
+++ b/test/library/browsertest/browsertest.go
@@ -59,15 +59,13 @@ func Open(t *testing.T) *agouti.Page {
 func WaitForVisibleElements(t *testing.T, page *agouti.Page, selectors ...string) {
 	t.Helper()
 
-	require.Eventuallyf(t,
-		func() bool {
+	library.RequireEventuallyf(t,
+		func(requireEventually *require.Assertions) {
 			for _, sel := range selectors {
 				vis, err := page.First(sel).Visible()
-				if !(err == nil && vis) {
-					return false
-				}
+				requireEventually.NoError(err)
+				requireEventually.Truef(vis, "expected element %q to be visible", sel)
 			}
-			return true
 		},
 		operationTimeout,
 		operationPollingInterval,
@@ -80,17 +78,15 @@ func WaitForVisibleElements(t *testing.T, page *agouti.Page, selectors ...string
 // to occur and times out, failing the test, if it never does.
 func WaitForURL(t *testing.T, page *agouti.Page, pat *regexp.Regexp) {
 	var lastURL string
-	require.Eventuallyf(t,
-		func() bool {
+	library.RequireEventuallyf(t,
+		func(requireEventually *require.Assertions) {
 			url, err := page.URL()
-			if err == nil && pat.MatchString(url) {
-				return true
-			}
 			if url != lastURL {
 				t.Logf("saw URL %s", url)
 				lastURL = url
 			}
-			return false
+			requireEventually.NoError(err)
+			requireEventually.Regexp(pat, url)
 		},
 		operationTimeout,
 		operationPollingInterval,


### PR DESCRIPTION
This fixes some rare test flakes caused by a data race inherent in the way we use `assert.Eventually()` with extra variables for followup assertions. This function is tricky to use correctly because it runs the passed function in a separate goroutine, and you have no guarantee that any shared variables are in a coherent state when the `assert.Eventually()` call returns. Even if you add manual mutexes, it's tricky to get the semantics right. This has been a recurring pain point and the cause of several test flakes.

This change introduces a new `library.RequireEventually()` that works by internally constructing a per-loop `*require.Assertions` and running everything on a single goroutine (using `wait.PollImmediate()`). This makes it very easy to write eventual assertions.

~~The first assertions I switched over to the new function are those in `access.go`, which were causing flakes when I ran integration tests locally.~~ Edit: I did more refactoring and switched the rest of our integration tests.

**Release note**:

```release-note
NONE
```
