### PR TITLE
Add `https_proxy` and `no_proxy` settings for the Supervisor

### DIFF
--- a/deploy/supervisor/deployment.yaml
+++ b/deploy/supervisor/deployment.yaml
@@ -102,6 +102,15 @@ spec:
               protocol: TCP
             - containerPort: 8443
               protocol: TCP
+          env:
+            #@ if data.values.https_proxy:
+            - name: HTTPS_PROXY
+              value: #@ data.values.https_proxy
+            #@ end
+            #@ if data.values.no_proxy:
+            - name: NO_PROXY
+              value: #@ data.values.no_proxy
+            #@ end
           livenessProbe:
             httpGet:
               path: /healthz

--- a/deploy/supervisor/values.yaml
+++ b/deploy/supervisor/values.yaml
@@ -65,3 +65,11 @@ run_as_group: 1001 #! run_as_group specifies the group ID that will own the proc
 #! authentication.concierge.pinniped.dev, etc. As an example, if this is set to tuna.io, then
 #! Pinniped API groups will look like foo.tuna.io. authentication.concierge.tuna.io, etc.
 api_group_suffix: pinniped.dev
+
+#! Set the standard golang HTTPS_PROXY and NO_PROXY environment variables on the Supervisor containers.
+#! These will be used when the Supervisor makes backend-to-backend calls to upstream identity providers using HTTPS,
+#! e.g. when the Supervisor fetches discovery documents, JWKS keys, and tokens from an upstream OIDC Provider.
+#! The Supervisor never makes insecure HTTP calls, so there is no reason to set HTTP_PROXY.
+#! Optional.
+https_proxy: #! e.g. http://proxy.example.com
+no_proxy: #! e.g. 127.0.0.1

--- a/internal/controller/supervisorconfig/oidcupstreamwatcher/oidc_upstream_watcher.go
+++ b/internal/controller/supervisorconfig/oidcupstreamwatcher/oidc_upstream_watcher.go
@@ -263,9 +263,13 @@ func (c *oidcWatcherController) validateIssuer(ctx context.Context, upstream *v1
 				Message: err.Error(),
 			}
 		}
-		httpClient = &http.Client{Transport: &http.Transport{TLSClientConfig: tlsConfig}}
 
-		discoveredProvider, err = oidc.NewProvider(oidc.ClientContext(ctx, httpClient), upstream.Spec.Issuer)
+		httpClient = &http.Client{Transport: &http.Transport{Proxy: http.ProxyFromEnvironment, TLSClientConfig: tlsConfig}}
+
+		timeoutCtx, cancelFunc := context.WithTimeout(oidc.ClientContext(ctx, httpClient), time.Minute)
+		defer cancelFunc()
+
+		discoveredProvider, err = oidc.NewProvider(timeoutCtx, upstream.Spec.Issuer)
 		if err != nil {
 			const klogLevelTrace = 6
 			c.log.V(klogLevelTrace).WithValues(

--- a/internal/controller/supervisorconfig/oidcupstreamwatcher/oidc_upstream_watcher_test.go
+++ b/internal/controller/supervisorconfig/oidcupstreamwatcher/oidc_upstream_watcher_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -797,6 +798,15 @@ oidc: issuer did not match the issuer returned by provider, expected "` + testIs
 				require.Equal(t, tt.wantResultingCache[i].GetUsernameClaim(), actualIDP.GetUsernameClaim())
 				require.Equal(t, tt.wantResultingCache[i].GetGroupsClaim(), actualIDP.GetGroupsClaim())
 				require.ElementsMatch(t, tt.wantResultingCache[i].GetScopes(), actualIDP.GetScopes())
+
+				// We always want to use the proxy from env on these clients, so although the following assertions
+				// are a little hacky, this is a cheap way to test that we are using it.
+				actualTransport, ok := actualIDP.Client.Transport.(*http.Transport)
+				require.True(t, ok, "expected cached provider to have client with Transport of type *http.Transport")
+				httpProxyFromEnvFunction := reflect.ValueOf(http.ProxyFromEnvironment).Pointer()
+				actualTransportProxyFunction := reflect.ValueOf(actualTransport.Proxy).Pointer()
+				require.Equal(t, httpProxyFromEnvFunction, actualTransportProxyFunction,
+					"Transport should have used http.ProxyFromEnvironment as its Proxy func")
 			}
 
 			actualUpstreams, err := fakePinnipedClient.IDPV1alpha1().OIDCIdentityProviders(testNamespace).List(ctx, metav1.ListOptions{})


### PR DESCRIPTION
Add `https_proxy` and `no_proxy` settings for the Supervisor

- Add new optional ytt params for the Supervisor deployment.
- When the Supervisor is making calls to an upstream OIDC provider, use these variables if they were provided.
- These settings are integration tested in the main CI pipeline by sometimes setting them on deployments in certain cases, and then letting the existing integration tests (e.g. TestE2EFullIntegration) provide the coverage, so there are no explicit changes to the integration tests themselves in this commit.
- Also add a timeout when making calls from the Supervisor backend to upstream OIDC providers, rather than hanging for a very long time when they are unreachable.

This is related to #698 and is a replacement for only part of #684. This is meant to be a more targeted fix for the issue compared to #684, so it can also be back-ported to `v0.4.x` in the near future.

**Release note**:

```release-note
Added `https_proxy` and `no_proxy` ytt parameters for the Supervisor deployment. See comments in file deploy/supervisor/values.yaml for documentation.
```
