### PR TITLE
Run the LDAP client's integration tests only on Kind

### DIFF
--- a/test/cluster_capabilities/aks.yaml
+++ b/test/cluster_capabilities/aks.yaml
@@ -1,6 +1,9 @@
 # Copyright 2021 the Pinniped contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# The name of the cluster type.
+kubernetesDistribution: AKS
+
 # Describe the capabilities of the cluster against which the integration tests will run.
 capabilities:
 

--- a/test/cluster_capabilities/eks.yaml
+++ b/test/cluster_capabilities/eks.yaml
@@ -1,6 +1,9 @@
 # Copyright 2021 the Pinniped contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# The name of the cluster type.
+kubernetesDistribution: EKS
+
 # Describe the capabilities of the cluster against which the integration tests will run.
 capabilities:
 

--- a/test/cluster_capabilities/gke.yaml
+++ b/test/cluster_capabilities/gke.yaml
@@ -1,6 +1,9 @@
 # Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# The name of the cluster type.
+kubernetesDistribution: GKE
+
 # Describe the capabilities of the cluster against which the integration tests will run.
 capabilities:
 

--- a/test/cluster_capabilities/kind.yaml
+++ b/test/cluster_capabilities/kind.yaml
@@ -1,6 +1,9 @@
 # Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# The name of the cluster type.
+kubernetesDistribution: Kind
+
 # Describe the capabilities of the cluster against which the integration tests will run.
 capabilities:
 

--- a/test/cluster_capabilities/tkgs.yaml
+++ b/test/cluster_capabilities/tkgs.yaml
@@ -1,6 +1,9 @@
 # Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# The name of the cluster type.
+kubernetesDistribution: TKGS
+
 # Describe the capabilities of the cluster against which the integration tests will run.
 capabilities:
 
@@ -15,4 +18,4 @@ capabilities:
   anonymousAuthenticationSupported: true
 
   # Are LDAP ports on the Internet reachable without interference from network firewalls or proxies?
-  canReachInternetLDAPPorts: false
+  canReachInternetLDAPPorts: true

--- a/test/integration/ldap_client_test.go
+++ b/test/integration/ldap_client_test.go
@@ -25,7 +25,11 @@ import (
 )
 
 func TestLDAPSearch(t *testing.T) {
-	env := testlib.IntegrationEnv(t)
+	// This test does not interact with Kubernetes itself. It is a test of our LDAP client code, and only interacts
+	// with our test OpenLDAP server, which is exposed directly to this test via kubectl port-forward.
+	// Theoretically we should always be able to run this test, but something about the kubectl port forwarding
+	// was very flaky on AKS, so we'll get the coverage by only running it on kind.
+	env := testlib.IntegrationEnv(t).WithKubeDistribution(testlib.KindDistro)
 
 	// Note that these tests depend on the values hard-coded in the LDIF file in test/deploy/tools/ldap.yaml.
 	// It requires the test LDAP server from the tools deployment.
@@ -613,7 +617,11 @@ func TestLDAPSearch(t *testing.T) {
 }
 
 func TestSimultaneousLDAPRequestsOnSingleProvider(t *testing.T) {
-	env := testlib.IntegrationEnv(t)
+	// This test does not interact with Kubernetes itself. It is a test of our LDAP client code, and only interacts
+	// with our test OpenLDAP server, which is exposed directly to this test via kubectl port-forward.
+	// Theoretically we should always be able to run this test, but something about the kubectl port forwarding
+	// was very flaky on AKS, so we'll get the coverage by only running it on kind.
+	env := testlib.IntegrationEnv(t).WithKubeDistribution(testlib.KindDistro)
 
 	// Note that these tests depend on the values hard-coded in the LDIF file in test/deploy/tools/ldap.yaml.
 	// It requires the test LDAP server from the tools deployment.


### PR DESCRIPTION
TestSimultaneousLDAPRequestsOnSingleProvider proved to be unreliable on AKS due to some kind of kubectl port-forward issue, so only run the LDAP client's integration tests on Kind. They are testing the integration between the client code and the OpenLDAP test server, not testing anything about Kubernetes, so running only on Kind should give us sufficient test coverage.

**Release note**:

None, this a test-only change.

```release-note
NONE
```
