### PR TITLE
Fix typo in generated API docs (s/mode/type/).

### DIFF
--- a/apis/concierge/config/v1alpha1/types_credentialissuer.go.tmpl
+++ b/apis/concierge/config/v1alpha1/types_credentialissuer.go.tmpl
@@ -96,7 +96,7 @@ type ImpersonationProxySpec struct {
 	// ExternalEndpoint describes the HTTPS endpoint where the proxy will be exposed. If not set, the proxy will
 	// be served using the external name of the LoadBalancer service or the cluster service DNS name.
 	//
-	// This field must be non-empty when spec.impersonationProxy.service.mode is "None".
+	// This field must be non-empty when spec.impersonationProxy.service.type is "None".
 	//
 	// +optional
 	ExternalEndpoint string `json:"externalEndpoint,omitempty"`

--- a/deploy/concierge/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/deploy/concierge/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -47,7 +47,7 @@ spec:
                     description: "ExternalEndpoint describes the HTTPS endpoint where
                       the proxy will be exposed. If not set, the proxy will be served
                       using the external name of the LoadBalancer service or the cluster
-                      service DNS name. \n This field must be non-empty when spec.impersonationProxy.service.mode
+                      service DNS name. \n This field must be non-empty when spec.impersonationProxy.service.type
                       is \"None\"."
                     type: string
                   mode:

--- a/generated/1.17/README.adoc
+++ b/generated/1.17/README.adoc
@@ -411,7 +411,7 @@ ImpersonationProxyServiceSpec describes how the Concierge should provision a Ser
 | *`mode`* __ImpersonationProxyMode__ | Mode configures whether the impersonation proxy should be started: - "disabled" explicitly disables the impersonation proxy. This is the default. - "enabled" explicitly enables the impersonation proxy. - "auto" enables or disables the impersonation proxy based upon the cluster in which it is running.
 | *`service`* __xref:{anchor_prefix}-go-pinniped-dev-generated-1-17-apis-concierge-config-v1alpha1-impersonationproxyservicespec[$$ImpersonationProxyServiceSpec$$]__ | Service describes the configuration of the Service provisioned to expose the impersonation proxy to clients.
 | *`externalEndpoint`* __string__ | ExternalEndpoint describes the HTTPS endpoint where the proxy will be exposed. If not set, the proxy will be served using the external name of the LoadBalancer service or the cluster service DNS name. 
- This field must be non-empty when spec.impersonationProxy.service.mode is "None".
+ This field must be non-empty when spec.impersonationProxy.service.type is "None".
 |===
 
 

--- a/generated/1.17/apis/concierge/config/v1alpha1/types_credentialissuer.go
+++ b/generated/1.17/apis/concierge/config/v1alpha1/types_credentialissuer.go
@@ -96,7 +96,7 @@ type ImpersonationProxySpec struct {
 	// ExternalEndpoint describes the HTTPS endpoint where the proxy will be exposed. If not set, the proxy will
 	// be served using the external name of the LoadBalancer service or the cluster service DNS name.
 	//
-	// This field must be non-empty when spec.impersonationProxy.service.mode is "None".
+	// This field must be non-empty when spec.impersonationProxy.service.type is "None".
 	//
 	// +optional
 	ExternalEndpoint string `json:"externalEndpoint,omitempty"`

--- a/generated/1.17/crds/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/generated/1.17/crds/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -47,7 +47,7 @@ spec:
                     description: "ExternalEndpoint describes the HTTPS endpoint where
                       the proxy will be exposed. If not set, the proxy will be served
                       using the external name of the LoadBalancer service or the cluster
-                      service DNS name. \n This field must be non-empty when spec.impersonationProxy.service.mode
+                      service DNS name. \n This field must be non-empty when spec.impersonationProxy.service.type
                       is \"None\"."
                     type: string
                   mode:

--- a/generated/1.18/README.adoc
+++ b/generated/1.18/README.adoc
@@ -411,7 +411,7 @@ ImpersonationProxyServiceSpec describes how the Concierge should provision a Ser
 | *`mode`* __ImpersonationProxyMode__ | Mode configures whether the impersonation proxy should be started: - "disabled" explicitly disables the impersonation proxy. This is the default. - "enabled" explicitly enables the impersonation proxy. - "auto" enables or disables the impersonation proxy based upon the cluster in which it is running.
 | *`service`* __xref:{anchor_prefix}-go-pinniped-dev-generated-1-18-apis-concierge-config-v1alpha1-impersonationproxyservicespec[$$ImpersonationProxyServiceSpec$$]__ | Service describes the configuration of the Service provisioned to expose the impersonation proxy to clients.
 | *`externalEndpoint`* __string__ | ExternalEndpoint describes the HTTPS endpoint where the proxy will be exposed. If not set, the proxy will be served using the external name of the LoadBalancer service or the cluster service DNS name. 
- This field must be non-empty when spec.impersonationProxy.service.mode is "None".
+ This field must be non-empty when spec.impersonationProxy.service.type is "None".
 |===
 
 

--- a/generated/1.18/apis/concierge/config/v1alpha1/types_credentialissuer.go
+++ b/generated/1.18/apis/concierge/config/v1alpha1/types_credentialissuer.go
@@ -96,7 +96,7 @@ type ImpersonationProxySpec struct {
 	// ExternalEndpoint describes the HTTPS endpoint where the proxy will be exposed. If not set, the proxy will
 	// be served using the external name of the LoadBalancer service or the cluster service DNS name.
 	//
-	// This field must be non-empty when spec.impersonationProxy.service.mode is "None".
+	// This field must be non-empty when spec.impersonationProxy.service.type is "None".
 	//
 	// +optional
 	ExternalEndpoint string `json:"externalEndpoint,omitempty"`

--- a/generated/1.18/crds/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/generated/1.18/crds/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -47,7 +47,7 @@ spec:
                     description: "ExternalEndpoint describes the HTTPS endpoint where
                       the proxy will be exposed. If not set, the proxy will be served
                       using the external name of the LoadBalancer service or the cluster
-                      service DNS name. \n This field must be non-empty when spec.impersonationProxy.service.mode
+                      service DNS name. \n This field must be non-empty when spec.impersonationProxy.service.type
                       is \"None\"."
                     type: string
                   mode:

--- a/generated/1.19/README.adoc
+++ b/generated/1.19/README.adoc
@@ -411,7 +411,7 @@ ImpersonationProxyServiceSpec describes how the Concierge should provision a Ser
 | *`mode`* __ImpersonationProxyMode__ | Mode configures whether the impersonation proxy should be started: - "disabled" explicitly disables the impersonation proxy. This is the default. - "enabled" explicitly enables the impersonation proxy. - "auto" enables or disables the impersonation proxy based upon the cluster in which it is running.
 | *`service`* __xref:{anchor_prefix}-go-pinniped-dev-generated-1-19-apis-concierge-config-v1alpha1-impersonationproxyservicespec[$$ImpersonationProxyServiceSpec$$]__ | Service describes the configuration of the Service provisioned to expose the impersonation proxy to clients.
 | *`externalEndpoint`* __string__ | ExternalEndpoint describes the HTTPS endpoint where the proxy will be exposed. If not set, the proxy will be served using the external name of the LoadBalancer service or the cluster service DNS name. 
- This field must be non-empty when spec.impersonationProxy.service.mode is "None".
+ This field must be non-empty when spec.impersonationProxy.service.type is "None".
 |===
 
 

--- a/generated/1.19/apis/concierge/config/v1alpha1/types_credentialissuer.go
+++ b/generated/1.19/apis/concierge/config/v1alpha1/types_credentialissuer.go
@@ -96,7 +96,7 @@ type ImpersonationProxySpec struct {
 	// ExternalEndpoint describes the HTTPS endpoint where the proxy will be exposed. If not set, the proxy will
 	// be served using the external name of the LoadBalancer service or the cluster service DNS name.
 	//
-	// This field must be non-empty when spec.impersonationProxy.service.mode is "None".
+	// This field must be non-empty when spec.impersonationProxy.service.type is "None".
 	//
 	// +optional
 	ExternalEndpoint string `json:"externalEndpoint,omitempty"`

--- a/generated/1.19/crds/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/generated/1.19/crds/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -47,7 +47,7 @@ spec:
                     description: "ExternalEndpoint describes the HTTPS endpoint where
                       the proxy will be exposed. If not set, the proxy will be served
                       using the external name of the LoadBalancer service or the cluster
-                      service DNS name. \n This field must be non-empty when spec.impersonationProxy.service.mode
+                      service DNS name. \n This field must be non-empty when spec.impersonationProxy.service.type
                       is \"None\"."
                     type: string
                   mode:

--- a/generated/1.20/README.adoc
+++ b/generated/1.20/README.adoc
@@ -411,7 +411,7 @@ ImpersonationProxyServiceSpec describes how the Concierge should provision a Ser
 | *`mode`* __ImpersonationProxyMode__ | Mode configures whether the impersonation proxy should be started: - "disabled" explicitly disables the impersonation proxy. This is the default. - "enabled" explicitly enables the impersonation proxy. - "auto" enables or disables the impersonation proxy based upon the cluster in which it is running.
 | *`service`* __xref:{anchor_prefix}-go-pinniped-dev-generated-1-20-apis-concierge-config-v1alpha1-impersonationproxyservicespec[$$ImpersonationProxyServiceSpec$$]__ | Service describes the configuration of the Service provisioned to expose the impersonation proxy to clients.
 | *`externalEndpoint`* __string__ | ExternalEndpoint describes the HTTPS endpoint where the proxy will be exposed. If not set, the proxy will be served using the external name of the LoadBalancer service or the cluster service DNS name. 
- This field must be non-empty when spec.impersonationProxy.service.mode is "None".
+ This field must be non-empty when spec.impersonationProxy.service.type is "None".
 |===
 
 

--- a/generated/1.20/apis/concierge/config/v1alpha1/types_credentialissuer.go
+++ b/generated/1.20/apis/concierge/config/v1alpha1/types_credentialissuer.go
@@ -96,7 +96,7 @@ type ImpersonationProxySpec struct {
 	// ExternalEndpoint describes the HTTPS endpoint where the proxy will be exposed. If not set, the proxy will
 	// be served using the external name of the LoadBalancer service or the cluster service DNS name.
 	//
-	// This field must be non-empty when spec.impersonationProxy.service.mode is "None".
+	// This field must be non-empty when spec.impersonationProxy.service.type is "None".
 	//
 	// +optional
 	ExternalEndpoint string `json:"externalEndpoint,omitempty"`

--- a/generated/1.20/crds/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/generated/1.20/crds/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -47,7 +47,7 @@ spec:
                     description: "ExternalEndpoint describes the HTTPS endpoint where
                       the proxy will be exposed. If not set, the proxy will be served
                       using the external name of the LoadBalancer service or the cluster
-                      service DNS name. \n This field must be non-empty when spec.impersonationProxy.service.mode
+                      service DNS name. \n This field must be non-empty when spec.impersonationProxy.service.type
                       is \"None\"."
                     type: string
                   mode:

--- a/generated/latest/apis/concierge/config/v1alpha1/types_credentialissuer.go
+++ b/generated/latest/apis/concierge/config/v1alpha1/types_credentialissuer.go
@@ -96,7 +96,7 @@ type ImpersonationProxySpec struct {
 	// ExternalEndpoint describes the HTTPS endpoint where the proxy will be exposed. If not set, the proxy will
 	// be served using the external name of the LoadBalancer service or the cluster service DNS name.
 	//
-	// This field must be non-empty when spec.impersonationProxy.service.mode is "None".
+	// This field must be non-empty when spec.impersonationProxy.service.type is "None".
 	//
 	// +optional
 	ExternalEndpoint string `json:"externalEndpoint,omitempty"`


### PR DESCRIPTION
This CredentialIssuer field is called `spec.impersonationProxy.service.type`, not `spec.impersonationProxy.service.mode`.

Thanks to @enj for spotting this.

**Release note**:
```release-note
NONE
```
