### PR TITLE
Fix TestCLILoginOIDC when running against Okta, and lower CLI server shutdown timeout.

### DIFF
--- a/pkg/oidcclient/login.go
+++ b/pkg/oidcclient/login.go
@@ -850,9 +850,9 @@ func (h *handlerState) serve(listener net.Listener) func() {
 	}
 	go func() { _ = srv.Serve(listener) }()
 	return func() {
-		// Gracefully shut down the server, allowing up to 5 seconds for
+		// Gracefully shut down the server, allowing up to 5 00ms for
 		// clients to receive any in-flight responses.
-		shutdownCtx, cancel := context.WithTimeout(h.ctx, 5*time.Second)
+		shutdownCtx, cancel := context.WithTimeout(h.ctx, 500*time.Millisecond)
 		_ = srv.Shutdown(shutdownCtx)
 		cancel()
 	}

--- a/test/integration/cli_test.go
+++ b/test/integration/cli_test.go
@@ -355,7 +355,7 @@ func runPinnipedLoginOIDC(
 
 	// Expect to be redirected to the localhost callback.
 	t.Logf("waiting for redirect to callback")
-	callbackURLPattern := regexp.MustCompile(`\A` + regexp.QuoteMeta(env.CLIUpstreamOIDC.CallbackURL) + `\?.+\z`)
+	callbackURLPattern := regexp.MustCompile(`\A` + regexp.QuoteMeta(env.CLIUpstreamOIDC.CallbackURL) + `(\?.+)?\z`)
 	browsertest.WaitForURL(t, page, callbackURLPattern)
 
 	// Wait for the "pre" element that gets rendered for a `text/plain` page, and


### PR DESCRIPTION
Our actual CLI code behaved correctly, but this test made some invalid assumptions about the "upstream" IDP we're testing. It assumed that the upstream didn't support `response_mode=form_post`, but Okta does. This means that when we end up on the localhost callback page, there are no URL query parameters.

Adjusting this regex makes the test pass as expected.

I also found that there are some situations with `response_mode=form_post` where Chrome will open additional speculative TCP connections. These connections will be idle so they block server shutdown until the (previously 5s) timeout. Lowering this to 500ms should be safe and makes any added latency at login much less noticeable.

More information about Chrome's TCP-level behavior here: https://bugs.chromium.org/p/chromium/issues/detail?id=116982#c5

**Release note**:
```release-note
NONE
```
