### PR TITLE
Clear the browser cookies between each TestE2EFullIntegration subtest

### DIFF
--- a/test/integration/e2e_test.go
+++ b/test/integration/e2e_test.go
@@ -57,9 +57,6 @@ func TestE2EFullIntegration(t *testing.T) {
 	pinnipedExe := testlib.PinnipedCLIPath(t)
 	tempDir := testutil.TempDir(t)
 
-	// Start the browser driver.
-	page := browsertest.Open(t)
-
 	// Infer the downstream issuer URL from the callback associated with the upstream test client registration.
 	issuerURL, err := url.Parse(env.SupervisorUpstreamOIDC.CallbackURL)
 	require.NoError(t, err)
@@ -110,6 +107,9 @@ func TestE2EFullIntegration(t *testing.T) {
 
 	// Add an OIDC upstream IDP and try using it to authenticate during kubectl commands.
 	t.Run("with Supervisor OIDC upstream IDP and automatic flow", func(t *testing.T) {
+		// Start a fresh browser driver because we don't want to share cookies between the various tests in this file.
+		page := browsertest.Open(t)
+
 		expectedUsername := env.SupervisorUpstreamOIDC.Username
 		expectedGroups := env.SupervisorUpstreamOIDC.ExpectedGroups
 
@@ -271,6 +271,9 @@ func TestE2EFullIntegration(t *testing.T) {
 	})
 
 	t.Run("with Supervisor OIDC upstream IDP and manual flow", func(t *testing.T) {
+		// Start a fresh browser driver because we don't want to share cookies between the various tests in this file.
+		page := browsertest.Open(t)
+
 		expectedUsername := env.SupervisorUpstreamOIDC.Username
 		expectedGroups := env.SupervisorUpstreamOIDC.ExpectedGroups
 


### PR DESCRIPTION
This is to solve a test failure in CI. The integration test called `TestE2EFullIntegration/with_Supervisor_OIDC_upstream_IDP_and_manual_flow` always fails on our GKE and TKGS clusters when the whole test suite is run. However, when run in isolation, it passes.

I think this is because it was accidentally sharing a browser session with the sibling test that runs just before it, which is called `TestE2EFullIntegration/with_Supervisor_OIDC_upstream_IDP_and_automatic_flow`. Since they shared a browser session, the IDP cookies from the automatic test were polluting the manual test.

This PR ensures that the cookies are not shared between these two tests by making each of these tests use its own browser session.

The third sibling test, `TestE2EFullIntegration/with_Supervisor_LDAP_upstream_IDP`, never needed a web browser, so it makes sense for each test to use its own web browser for that reason too.

**Release note**:

None, this is a test-only change.

```release-note
NONE
```
