### PR TITLE
Copy .git dir during Docker build; used to bake git sha into binary

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
 ./.*
+# Allow .git to get copied into the container so we can use it in hack/get-ldflags.sh during build.
+!/.git
 ./*.md
 ./*.yaml
 ./apis


### PR DESCRIPTION
This was accidentally broken when we upgraded to Docker BuildKit. We need to allow the .git directory to be copied into the docker build layer so that hack/get-ldflags.sh can use it during build. The Dockerfile will not include it in the final image because it does not get copied from the `build-env` stage.

The code for our `pinniped-concierge` and `pinniped-supervisor` binaries will already print the version info as the first line of the log file.

This PR does not including adding the semver version to the logs. It will always say v0.0.0 currently.

**Release note**:

```release-note
The first line of the server logs for the Supervisor and Concierge containers will include the current git SHA of source code repo at build time. This can help identify what version of the code is running in the container by cross-referencing it back to the GitHub repo.
```
