### PR TITLE
Switch to GHCR tools images for local tests, with `imagePullPolicy: IfNotPresent`.

### DIFF
--- a/test/deploy/tools/cert-issuer.yaml
+++ b/test/deploy/tools/cert-issuer.yaml
@@ -54,6 +54,7 @@ spec:
       initContainers:
       - name: generate-certs
         image: #@ data.values.cfssl_image
+        imagePullPolicy: IfNotPresent
         command: ["/bin/bash"]
         args:
         - -c
@@ -111,6 +112,7 @@ spec:
       containers:
       - name: save-certs
         image: #@ data.values.kubectl_image
+        imagePullPolicy: IfNotPresent
         command: ["/bin/bash"]
         args:
         - -c

--- a/test/deploy/tools/dex.yaml
+++ b/test/deploy/tools/dex.yaml
@@ -69,6 +69,7 @@ spec:
       containers:
       - name: dex
         image: #@ data.values.dex_image
+        imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/dex
         - serve

--- a/test/deploy/tools/ldap.yaml
+++ b/test/deploy/tools/ldap.yaml
@@ -210,6 +210,7 @@ spec:
           #! LDAP_SERVER_CONFIG_BEFORE_CUSTOM_LDIF_DIR and LDAP_SERVER_CONFIG_AFTER_CUSTOM_LDIF_DIR options.
           #! See https://github.com/pinniped-ci-bot/bitnami-docker-openldap/tree/pinniped
           image: #@ data.values.ldap_image
+          imagePullPolicy: IfNotPresent
           ports:
             - name: ldap
               containerPort: 1389

--- a/test/deploy/tools/proxy.yaml
+++ b/test/deploy/tools/proxy.yaml
@@ -26,6 +26,7 @@ spec:
       containers:
         - name: proxy
           image: #@ data.values.proxy_image
+          imagePullPolicy: IfNotPresent
           ports:
           - name: http
             containerPort: 3128
@@ -48,6 +49,7 @@ spec:
             failureThreshold: 2
         - name: accesslogs
           image: #@ data.values.proxy_image
+          imagePullPolicy: IfNotPresent
           command:
             - "/bin/sh"
             - "-c"

--- a/test/deploy/tools/values.yaml
+++ b/test/deploy/tools/values.yaml
@@ -27,8 +27,8 @@ pinny_bcrypt_passwd_hash:
 pinny_ldap_password:
 
 #! Images for each of the deployed test components.
-dex_image: ghcr.io/dexidp/dex:v2.27.0
-ldap_image: projects.registry.vmware.com/pinniped/test-ldap:latest
-proxy_image: projects.registry.vmware.com/pinniped/test-forward-proxy:latest
-cfssl_image: cfssl/cfssl:1.5.0
-kubectl_image: bitnami/kubectl:latest
+dex_image: ghcr.io/pinniped-ci-bot/test-dex:latest
+ldap_image: ghcr.io/pinniped-ci-bot/test-ldap:latest
+proxy_image: ghcr.io/pinniped-ci-bot/test-forward-proxy:latest
+cfssl_image: ghcr.io/pinniped-ci-bot/test-cfssl:latest
+kubectl_image: ghcr.io/pinniped-ci-bot/test-kubectl:latest


### PR DESCRIPTION
This is more consistent with our CI environment and should fix issues that some people had pulling the images. Using an explicit `IfNotPresent` prevents Kubernetes from defaulting to [always pulling `:latest` tags](https://kubernetes.io/docs/concepts/containers/images/#updating-images).

**Release note**:

```release-note
NONE
```
