### PR TITLE
Fix backwards condition in E2E test assertion.

### DIFF
--- a/test/integration/e2e_test.go
+++ b/test/integration/e2e_test.go
@@ -594,7 +594,7 @@ func requireKubectlGetNamespaceOutput(t *testing.T, env *testlib.TestEnv, kubect
 	require.Greaterf(t, len(strings.Split(kubectlOutput, "\n")), 2, "expected some namespaces to be returned, got %q", kubectlOutput)
 	require.Contains(t, kubectlOutput, fmt.Sprintf("\n%s ", env.ConciergeNamespace))
 	require.Contains(t, kubectlOutput, fmt.Sprintf("\n%s ", env.SupervisorNamespace))
-	if len(env.ToolsNamespace) == 0 {
+	if len(env.ToolsNamespace) > 0 {
 		require.Contains(t, kubectlOutput, fmt.Sprintf("\n%s ", env.ToolsNamespace))
 	}
 }


### PR DESCRIPTION
This caused the end-to-end test to fail in environments where we don't have the "tools" namespace.

**Release note**:

```release-note
NONE
```
