### PR TITLE
Fix broken TTY after manual auth code prompt.

### DIFF
--- a/pkg/oidcclient/login_test.go
+++ b/pkg/oidcclient/login_test.go
@@ -251,7 +251,7 @@ func TestLogin(t *testing.T) { // nolint:gocyclo
 		h.generatePKCE = func() (pkce.Code, error) { return "test-pkce", nil }
 		h.generateNonce = func() (nonce.Nonce, error) { return "test-nonce", nil }
 		h.promptForValue = func(_ context.Context, promptLabel string) (string, error) { return "some-upstream-username", nil }
-		h.promptForSecret = func(_ context.Context, _ string) (string, error) { return "some-upstream-password", nil }
+		h.promptForSecret = func(_ string) (string, error) { return "some-upstream-password", nil }
 
 		cache := &mockSessionCache{t: t, getReturnsToken: nil}
 		cacheKey := SessionCacheKey{
@@ -541,7 +541,7 @@ func TestLogin(t *testing.T) { // nolint:gocyclo
 						require.Equal(t, "form_post", parsed.Query().Get("response_mode"))
 						return fmt.Errorf("some browser open error")
 					}
-					h.promptForSecret = func(ctx context.Context, promptLabel string) (string, error) {
+					h.promptForValue = func(_ context.Context, promptLabel string) (string, error) {
 						return "", fmt.Errorf("some prompt error")
 					}
 					return nil
@@ -567,7 +567,7 @@ func TestLogin(t *testing.T) { // nolint:gocyclo
 						require.Equal(t, "form_post", parsed.Query().Get("response_mode"))
 						return nil
 					}
-					h.promptForSecret = func(ctx context.Context, promptLabel string) (string, error) {
+					h.promptForValue = func(_ context.Context, promptLabel string) (string, error) {
 						return "", fmt.Errorf("some prompt error")
 					}
 					return nil
@@ -825,7 +825,7 @@ func TestLogin(t *testing.T) { // nolint:gocyclo
 			opt: func(t *testing.T) Option {
 				return func(h *handlerState) error {
 					_ = defaultLDAPTestOpts(t, h, nil, nil)
-					h.promptForSecret = func(_ context.Context, _ string) (string, error) { return "", errors.New("some prompt error") }
+					h.promptForSecret = func(_ string) (string, error) { return "", errors.New("some prompt error") }
 					return nil
 				}
 			},
@@ -1018,7 +1018,7 @@ func TestLogin(t *testing.T) { // nolint:gocyclo
 						require.Equal(t, "Username: ", promptLabel)
 						return "some-upstream-username", nil
 					}
-					h.promptForSecret = func(_ context.Context, promptLabel string) (string, error) {
+					h.promptForSecret = func(promptLabel string) (string, error) {
 						require.Equal(t, "Password: ", promptLabel)
 						return "some-upstream-password", nil
 					}
@@ -1125,7 +1125,7 @@ func TestLogin(t *testing.T) { // nolint:gocyclo
 						require.FailNow(t, fmt.Sprintf("saw unexpected prompt from the CLI: %q", promptLabel))
 						return "", nil
 					}
-					h.promptForSecret = func(_ context.Context, promptLabel string) (string, error) {
+					h.promptForSecret = func(promptLabel string) (string, error) {
 						require.FailNow(t, fmt.Sprintf("saw unexpected prompt from the CLI: %q", promptLabel))
 						return "", nil
 					}
@@ -1634,8 +1634,8 @@ func TestHandlePasteCallback(t *testing.T) {
 				return func(h *handlerState) error {
 					h.isTTY = func(fd int) bool { return true }
 					h.useFormPost = true
-					h.promptForSecret = func(ctx context.Context, promptLabel string) (string, error) {
-						assert.Equal(t, "    If automatic login fails, paste your authorization code to login manually: ", promptLabel)
+					h.promptForValue = func(_ context.Context, promptLabel string) (string, error) {
+						assert.Equal(t, "    Optionally, paste your authorization code: ", promptLabel)
 						return "", fmt.Errorf("some prompt error")
 					}
 					return nil
@@ -1651,7 +1651,7 @@ func TestHandlePasteCallback(t *testing.T) {
 				return func(h *handlerState) error {
 					h.isTTY = func(fd int) bool { return true }
 					h.useFormPost = true
-					h.promptForSecret = func(ctx context.Context, promptLabel string) (string, error) {
+					h.promptForValue = func(_ context.Context, promptLabel string) (string, error) {
 						return "invalid", nil
 					}
 					h.oauth2Config = &oauth2.Config{RedirectURL: testRedirectURI}
@@ -1675,7 +1675,7 @@ func TestHandlePasteCallback(t *testing.T) {
 				return func(h *handlerState) error {
 					h.isTTY = func(fd int) bool { return true }
 					h.useFormPost = true
-					h.promptForSecret = func(ctx context.Context, promptLabel string) (string, error) {
+					h.promptForValue = func(_ context.Context, promptLabel string) (string, error) {
 						return "valid", nil
 					}
 					h.oauth2Config = &oauth2.Config{RedirectURL: testRedirectURI}

--- a/test/integration/e2e_test.go
+++ b/test/integration/e2e_test.go
@@ -331,9 +331,9 @@ func TestE2EFullIntegration(t *testing.T) {
 
 		// Wait for the subprocess to print the login prompt.
 		t.Logf("waiting for CLI to output login URL and manual prompt")
-		output := readFromFileUntilStringIsSeen(t, ptyFile, "If automatic login fails, paste your authorization code to login manually: ")
+		output := readFromFileUntilStringIsSeen(t, ptyFile, "Optionally, paste your authorization code: ")
 		require.Contains(t, output, "Log in by visiting this link:")
-		require.Contains(t, output, "If automatic login fails, paste your authorization code to login manually: ")
+		require.Contains(t, output, "Optionally, paste your authorization code: ")
 
 		// Find the line with the login URL.
 		var loginURL string


### PR DESCRIPTION
This may be a temporary fix. It switches the manual auth code prompt to use `promptForValue()` instead of `promptForSecret()`. The `promptForSecret()` function no longer supports cancellation (the v0.9.2 behavior) and the method of cancelling in `promptForValue()` is now based on running the blocking read in a background goroutine, which is allowed to block forever or leak (which is not important for our CLI use case).

This means that the authorization code is now visible in the user's terminal, but this is really not a big deal because of PKCE and the limited lifetime of an auth code.

The main goroutine now correctly waits for the "manual prompt" goroutine to clean up, which now includes printing the extra newline that would normally have been entered by the user in the manual flow.

**Release note**:

This functionality with the bug has not yet been released.

```release-note
NONE
```
