### PR TITLE
cli: prevent browser output from breaking ExecCredential output

### DIFF
--- a/cmd/pinniped/main.go
+++ b/cmd/pinniped/main.go
@@ -3,7 +3,20 @@
 
 package main
 
-import "go.pinniped.dev/cmd/pinniped/cmd"
+import (
+	"os"
+
+	"github.com/pkg/browser"
+
+	"go.pinniped.dev/cmd/pinniped/cmd"
+)
+
+//nolint: gochecknoinits
+func init() {
+	// browsers like chrome like to write to our std out which breaks our JSON ExecCredential output
+	// thus we redirect the browser's std out to our std err
+	browser.Stdout = os.Stderr
+}
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
This change updates the pinniped CLI entrypoint to prevent browser
processes that we spawn from polluting our std out stream.

For example, chrome will print the following message to std out:

Opening in existing browser session.

Which leads to the following incomprehensible error message from
kubectl:

Unable to connect to the server: getting credentials:
decoding stdout: couldn't get version/kind; json parse error:
json: cannot unmarshal string into Go value of type struct
{ APIVersion string "json:\"apiVersion,omitempty\"";
  Kind string "json:\"kind,omitempty\"" }

This would only occur on the initial login when we opened the
browser.  Since credentials would be cached afterwards, kubectl
would work as expected for future invocations as no browser was
opened.

I could not think of a good way to actually test this change.  There
is a clear gap in our integration tests - we never actually launch a
browser in the exact same way a user does - we instead open a chrome
driver at the login URL as a subprocess of the integration test
binary and not the pinniped CLI.  Thus even if the chrome driver was
writing to std out, we would not notice any issues.

It is also unclear if there is a good way to prevent future related
bugs since std out is global to the process.

Signed-off-by: Monis Khan <mok@vmware.com>

**Release note**:

```release-note
Fixed a bug in the pinniped CLI that would sometimes cause the first kubectl command after a browser based login to fail with "Unable to connect to the server: getting credentials: decoding stdout: couldn't get version/kind; json parse error: json: cannot unmarshal string into Go value."  Subsequent commands would run successfully since credentials would be cached.
```