### PR TITLE
test/integration: ignore restarts associated with test pods

### DIFF
--- a/test/integration/concierge_impersonation_proxy_test.go
+++ b/test/integration/concierge_impersonation_proxy_test.go
@@ -944,21 +944,17 @@ func TestImpersonationProxy(t *testing.T) { //nolint:gocyclo // yeah, it's compl
 				return // stop test early since the token request API is not enabled on this cluster - other errors are caught below
 			}
 
-			pod, err := kubeClient.Pods(namespaceName).Create(ctx, &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "test-impersonation-proxy-",
-				},
-				Spec: corev1.PodSpec{
+			pod := testlib.CreatePod(ctx, t, "impersonation-proxy", namespaceName,
+				corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:  "ignored-but-required",
-							Image: "does-not-matter",
+							Name:    "ignored-but-required",
+							Image:   "busybox",
+							Command: []string{"sh", "-c", "sleep 3600"},
 						},
 					},
 					ServiceAccountName: saName,
-				},
-			}, metav1.CreateOptions{})
-			require.NoError(t, err)
+				})
 
 			tokenRequestBadAudience, err := kubeClient.ServiceAccounts(namespaceName).CreateToken(ctx, saName, &authenticationv1.TokenRequest{
 				Spec: authenticationv1.TokenRequestSpec{

--- a/test/integration/whoami_test.go
+++ b/test/integration/whoami_test.go
@@ -164,21 +164,17 @@ func TestWhoAmI_ServiceAccount_TokenRequest(t *testing.T) {
 		return // stop test early since the token request API is not enabled on this cluster - other errors are caught below
 	}
 
-	pod, err := kubeClient.Pods(ns.Name).Create(ctx, &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "test-whoami-",
-		},
-		Spec: corev1.PodSpec{
+	pod := testlib.CreatePod(ctx, t, "whoami", ns.Name,
+		corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
-					Name:  "ignored-but-required",
-					Image: "does-not-matter",
+					Name:    "ignored-but-required",
+					Image:   "busybox",
+					Command: []string{"sh", "-c", "sleep 3600"},
 				},
 			},
 			ServiceAccountName: sa.Name,
-		},
-	}, metav1.CreateOptions{})
-	require.NoError(t, err)
+		})
 
 	tokenRequestBadAudience, err := kubeClient.ServiceAccounts(ns.Name).CreateToken(ctx, sa.Name, &authenticationv1.TokenRequest{
 		Spec: authenticationv1.TokenRequestSpec{

--- a/test/testlib/env.go
+++ b/test/testlib/env.go
@@ -142,8 +142,8 @@ func IntegrationEnv(t *testing.T) *TestEnv {
 	memoizedTestEnvsByTest.Store(t, &result)
 
 	// In every integration test, assert that no pods in our namespaces restart during the test.
-	assertNoRestartsDuringTest(t, result.ConciergeNamespace, "")
-	assertNoRestartsDuringTest(t, result.SupervisorNamespace, "")
+	assertNoRestartsDuringTest(t, result.ConciergeNamespace, "!pinniped.dev/test")
+	assertNoRestartsDuringTest(t, result.SupervisorNamespace, "!pinniped.dev/test")
 	return &result
 }
 


### PR DESCRIPTION
Signed-off-by: Monis Khan <mok@vmware.com>

Addresses test [flake](https://hush-house.pivotal.io/teams/tanzu-user-auth/pipelines/pinniped-pull-requests/jobs/integration-test-1.20/builds/687#L610f28c6:1165:1173).

**Release note**:

```release-note
NONE
```