### PR TITLE
dynamiccert: prevent misuse of NewServingCert

### DIFF
--- a/internal/dynamiccert/provider.go
+++ b/internal/dynamiccert/provider.go
@@ -55,7 +55,11 @@ type provider struct {
 // NewServingCert returns a Private that is go routine safe.
 // It can only hold key pairs that have IsCA=false.
 func NewServingCert(name string) Private {
-	return &provider{name: name}
+	return struct {
+		Private
+	}{
+		Private: &provider{name: name},
+	}
 }
 
 // NewCA returns a Provider that is go routine safe.

--- a/internal/dynamiccert/provider_test.go
+++ b/internal/dynamiccert/provider_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/server/dynamiccertificates"
@@ -224,3 +225,19 @@ func poolSubjects(pool *x509.CertPool) [][]byte {
 	}
 	return pool.Subjects()
 }
+
+func TestNewServingCert(t *testing.T) {
+	got := NewServingCert("")
+
+	ok1 := assert.Implements(fakeT{}, (*Private)(nil), got)
+	ok2 := assert.Implements(fakeT{}, (*Public)(nil), got)
+	ok3 := assert.Implements(fakeT{}, (*Provider)(nil), got)
+
+	require.True(t, ok1, "NewServingCert must implement Private")
+	require.False(t, ok2, "NewServingCert must not implement Public")
+	require.False(t, ok3, "NewServingCert must not implement Provider")
+}
+
+type fakeT struct{}
+
+func (fakeT) Errorf(string, ...interface{}) {}


### PR DESCRIPTION
The Kube API server code that we use will cast inputs in an attempt
to see if they implement optional interfaces.  This change adds a
simple wrapper struct to prevent such casts from causing us any
issues.

Signed-off-by: Monis Khan <mok@vmware.com>

**Release note**:

```release-note
NONE
```