### PR TITLE
Provide good defaults for NO_PROXY

### DIFF
--- a/deploy/concierge/deployment.yaml
+++ b/deploy/concierge/deployment.yaml
@@ -152,6 +152,15 @@ spec:
               mountPath: /etc/podinfo
             - name: impersonation-proxy
               mountPath: /var/run/secrets/impersonation-proxy.concierge.pinniped.dev/serviceaccount
+          env:
+            #@ if data.values.https_proxy:
+            - name: HTTPS_PROXY
+              value: #@ data.values.https_proxy
+            #@ end
+            #@ if data.values.https_proxy and data.values.no_proxy:
+            - name: NO_PROXY
+              value: #@ data.values.no_proxy
+            #@ end
           livenessProbe:
             httpGet:
               path: /healthz

--- a/deploy/concierge/values.yaml
+++ b/deploy/concierge/values.yaml
@@ -93,3 +93,11 @@ impersonation_proxy_spec:
       {service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "4000"}
     #! When mode LoadBalancer is set, this will set the LoadBalancer Service's Spec.LoadBalancerIP.
     load_balancer_ip:
+
+#! Set the standard golang HTTPS_PROXY and NO_PROXY environment variables on the Concierge containers.
+#! These will be used when the Concierge makes backend-to-backend calls to authenticators using HTTPS,
+#! e.g. when the Concierge fetches discovery documents, JWKS keys, and POSTs to token webhooks.
+#! The Concierge never makes insecure HTTP calls, so there is no reason to set HTTP_PROXY.
+#! Optional.
+https_proxy: #! e.g. http://proxy.example.com
+no_proxy: "$(KUBERNETES_SERVICE_HOST),169.254.169.254,127.0.0.1,localhost,.svc,.cluster.local" #! do not proxy Kubernetes endpoints

--- a/deploy/supervisor/deployment.yaml
+++ b/deploy/supervisor/deployment.yaml
@@ -107,7 +107,7 @@ spec:
             - name: HTTPS_PROXY
               value: #@ data.values.https_proxy
             #@ end
-            #@ if data.values.no_proxy:
+            #@ if data.values.https_proxy and data.values.no_proxy:
             - name: NO_PROXY
               value: #@ data.values.no_proxy
             #@ end

--- a/deploy/supervisor/values.yaml
+++ b/deploy/supervisor/values.yaml
@@ -72,4 +72,4 @@ api_group_suffix: pinniped.dev
 #! The Supervisor never makes insecure HTTP calls, so there is no reason to set HTTP_PROXY.
 #! Optional.
 https_proxy: #! e.g. http://proxy.example.com
-no_proxy: #! e.g. 127.0.0.1
+no_proxy: "$(KUBERNETES_SERVICE_HOST),169.254.169.254,127.0.0.1,localhost,.svc,.cluster.local" #! do not proxy Kubernetes endpoints


### PR DESCRIPTION
This change updates the default NO_PROXY for the supervisor to not
proxy requests to the Kubernetes API and other Kubernetes endpoints
such as Kubernetes services.

It also adds https_proxy and no_proxy settings for the concierge
with the same default.

Signed-off-by: Monis Khan <mok@vmware.com>

**Release note**:

```release-note
Added `https_proxy` and `no_proxy` ytt parameters for the Concierge deployment. See comments in file deploy/concierge/values.yaml for documentation.

`no_proxy` is defaulted to `$(KUBERNETES_SERVICE_HOST),169.254.169.254,127.0.0.1,localhost,.svc,.cluster.local` for both the Concierge and the Supervisor.
```