### PR TITLE
Remove `unparam` linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -47,7 +47,6 @@ linters:
   - scopelint
   - sqlclosecheck
   - unconvert
-  - unparam
   - whitespace
 
 issues:

--- a/internal/groupsuffix/groupsuffix_test.go
+++ b/internal/groupsuffix/groupsuffix_test.go
@@ -644,7 +644,6 @@ func authenticatorAPIGroup(apiGroup string) withFunc {
 	}
 }
 
-//nolint:unparam // the apiGroupSuffix parameter might always be the same, but this is nice for test readability
 func replaceGV(t *testing.T, baseGV schema.GroupVersion, apiGroupSuffix string) schema.GroupVersion {
 	t.Helper()
 	groupName, ok := Replace(baseGV.Group, apiGroupSuffix)

--- a/pkg/oidcclient/login_test.go
+++ b/pkg/oidcclient/login_test.go
@@ -238,7 +238,7 @@ func TestLogin(t *testing.T) { // nolint:gocyclo
 	formPostProviderMux.HandleFunc("/.well-known/openid-configuration", discoveryHandler(formPostSuccessServer, []string{"query", "form_post"}))
 	formPostProviderMux.HandleFunc("/token", tokenHandler)
 
-	defaultDiscoveryResponse := func(req *http.Request) (*http.Response, error) { // nolint:unparam
+	defaultDiscoveryResponse := func(req *http.Request) (*http.Response, error) {
 		// Call the handler function from the test server to calculate the response.
 		handler, _ := providerMux.Handler(req)
 		recorder := httptest.NewRecorder()
@@ -246,7 +246,7 @@ func TestLogin(t *testing.T) { // nolint:gocyclo
 		return recorder.Result(), nil
 	}
 
-	defaultLDAPTestOpts := func(t *testing.T, h *handlerState, authResponse *http.Response, authError error) error { // nolint:unparam
+	defaultLDAPTestOpts := func(t *testing.T, h *handlerState, authResponse *http.Response, authError error) error {
 		h.generateState = func() (state.State, error) { return "test-state", nil }
 		h.generatePKCE = func() (pkce.Code, error) { return "test-pkce", nil }
 		h.generateNonce = func() (nonce.Nonce, error) { return "test-nonce", nil }


### PR DESCRIPTION
We decided that this linter does not provide very useful feedback for our project.

**Release note**:

```release-note
NONE
```
