### PR TITLE
Replace one-off usages of busybox and debian images in integration tests

### DIFF
--- a/hack/prepare-for-integration-tests.sh
+++ b/hack/prepare-for-integration-tests.sh
@@ -368,6 +368,8 @@ export PINNIPED_TEST_SUPERVISOR_UPSTREAM_OIDC_USERNAME=pinny@example.com
 export PINNIPED_TEST_SUPERVISOR_UPSTREAM_OIDC_PASSWORD=${dex_test_password}
 export PINNIPED_TEST_SUPERVISOR_UPSTREAM_OIDC_EXPECTED_GROUPS= # Dex's local user store does not let us configure groups.
 export PINNIPED_TEST_API_GROUP_SUFFIX='${api_group_suffix}'
+# PINNIPED_TEST_SHELL_CONTAINER_IMAGE should be a container which includes bash and sleep, used by some tests.
+export PINNIPED_TEST_SHELL_CONTAINER_IMAGE="ghcr.io/pinniped-ci-bot/test-kubectl:latest"
 
 read -r -d '' PINNIPED_TEST_CLUSTER_CAPABILITY_YAML << PINNIPED_TEST_CLUSTER_CAPABILITY_YAML_EOF || true
 ${pinniped_cluster_capability_file_content}

--- a/test/integration/concierge_impersonation_proxy_test.go
+++ b/test/integration/concierge_impersonation_proxy_test.go
@@ -948,9 +948,10 @@ func TestImpersonationProxy(t *testing.T) { //nolint:gocyclo // yeah, it's compl
 				corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:    "ignored-but-required",
-							Image:   "busybox",
-							Command: []string{"sh", "-c", "sleep 3600"},
+							Name:            "sleeper",
+							Image:           env.ShellContainerImage,
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Command:         []string{"sh", "-c", "sleep 3600"},
 						},
 					},
 					ServiceAccountName: saName,
@@ -1064,7 +1065,7 @@ func TestImpersonationProxy(t *testing.T) { //nolint:gocyclo // yeah, it's compl
 			// existing Concierge pod because we need more tools than we can get from a scratch/distroless base image.
 			runningTestPod := testlib.CreatePod(ctx, t, "impersonation-proxy", env.ConciergeNamespace, corev1.PodSpec{Containers: []corev1.Container{{
 				Name:            "impersonation-proxy-test",
-				Image:           "debian:10.10-slim",
+				Image:           env.ShellContainerImage,
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command:         []string{"bash", "-c", `while true; do read VAR; echo "VAR: $VAR"; done`},
 				Stdin:           true,

--- a/test/integration/concierge_kubecertagent_test.go
+++ b/test/integration/concierge_kubecertagent_test.go
@@ -117,9 +117,10 @@ func TestLegacyPodCleaner(t *testing.T) {
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{{
-				Name:    "sleeper",
-				Image:   "debian:10.9-slim",
-				Command: []string{"/bin/sleep", "infinity"},
+				Name:            "sleeper",
+				Image:           env.ShellContainerImage,
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				Command:         []string{"/bin/sleep", "infinity"},
 			}},
 		},
 	}, metav1.CreateOptions{})

--- a/test/integration/whoami_test.go
+++ b/test/integration/whoami_test.go
@@ -134,7 +134,7 @@ func TestWhoAmI_ServiceAccount_Legacy(t *testing.T) {
 }
 
 func TestWhoAmI_ServiceAccount_TokenRequest(t *testing.T) {
-	_ = testlib.IntegrationEnv(t)
+	env := testlib.IntegrationEnv(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
@@ -168,9 +168,10 @@ func TestWhoAmI_ServiceAccount_TokenRequest(t *testing.T) {
 		corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
-					Name:    "ignored-but-required",
-					Image:   "busybox",
-					Command: []string{"sh", "-c", "sleep 3600"},
+					Name:            "sleeper",
+					Image:           env.ShellContainerImage,
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Command:         []string{"sh", "-c", "sleep 3600"},
 				},
 			},
 			ServiceAccountName: sa.Name,

--- a/test/testlib/env.go
+++ b/test/testlib/env.go
@@ -54,6 +54,7 @@ type TestEnv struct {
 	SupervisorHTTPSIngressCABundle string                               `json:"supervisorHttpsIngressCABundle"`
 	Proxy                          string                               `json:"proxy"`
 	APIGroupSuffix                 string                               `json:"apiGroupSuffix"`
+	ShellContainerImage            string                               `json:"shellContainer"`
 
 	TestUser struct {
 		Token            string   `json:"token"`
@@ -224,6 +225,7 @@ func loadEnvVars(t *testing.T, result *TestEnv) {
 
 	result.Proxy = os.Getenv("PINNIPED_TEST_PROXY")
 	result.APIGroupSuffix = wantEnv("PINNIPED_TEST_API_GROUP_SUFFIX", "pinniped.dev")
+	result.ShellContainerImage = needEnv(t, "PINNIPED_TEST_SHELL_CONTAINER_IMAGE")
 
 	result.CLIUpstreamOIDC = TestOIDCUpstream{
 		Issuer:      needEnv(t, "PINNIPED_TEST_CLI_OIDC_ISSUER"),


### PR DESCRIPTION
Those images that are pulled from Dockerhub will cause pull failures on some test clusters due to Dockerhub rate limiting.

Because we already have some images that we use for testing, and because those images are already pre-loaded onto our CI clusters to make the tests faster, use one of those images and always specify PullIfNotPresent to avoid pulling the image again during the integration test.

**Release note**:

None. This PR only changes tests.

```release-note
NONE
```
