### PR TITLE
Copy hostNetwork field for kube-cert-agent 

### DIFF
--- a/internal/controller/kubecertagent/kubecertagent.go
+++ b/internal/controller/kubecertagent/kubecertagent.go
@@ -501,6 +501,7 @@ func (c *agentController) newAgentDeployment(controllerManagerPod *corev1.Pod) *
 						RunAsUser:  pointer.Int64Ptr(0),
 						RunAsGroup: pointer.Int64Ptr(0),
 					},
+					HostNetwork: controllerManagerPod.Spec.HostNetwork,
 				},
 			},
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request for Pinniped!

Before submitting, please see the guidelines in CONTRIBUTING.md in this repo.

Please note that a project maintainer will need to review and provide an
initial approval on the PR to cause CI tests to automatically start.
Also note that if you push additional commits to the PR, those commits
will need another initial approval before CI will pick them up.

Reminder: Did you remember to run all the linter, unit tests, and integration tests
described in CONTRIBUTING.md on your branch before submitting this PR?

Below is a template to help you describe your PR.
-->

<!--
Provide a summary of your change. Feel free to use paragraphs or a bulleted list, for example:

- Improves performance by 10,000%.
- Fixes all bugs.
- Boils the oceans.

-->

For clusters where the control plane nodes aren't running a CNI, the
kube-cert-agent pods deployed by concierge cannot be scheduled as they
don't know to use `hostNetwork: true`. This change allows embedding the
host network setting in the Concierge configuration. (by copying it from
the kube-controller-manager pod spec when generating the kube-cert-agent
Deployment)

Also fixed a stray double comma in one of the nearby tests.

**Release note**:

<!--
Does this PR introduce a user-facing change?

If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
-->
```release-note
- hostNetwork settings will now be inherited for the kube-cert-agent pod.
```
