### PR TITLE
Ensure concierge and supervisor gracefully exit

### DIFF
--- a/internal/controllerinit/controllerinit.go
+++ b/internal/controllerinit/controllerinit.go
@@ -1,0 +1,87 @@
+// Copyright 2021 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllerinit
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+	"time"
+)
+
+// Runner is something that can be run such as a series of controllers.  Blocks until context is canceled.
+type Runner func(context.Context)
+
+// RunnerWrapper takes a Runner and wraps its execution with other logic.  Blocks until context is canceled.
+// RunnerWrapper is responsible for the lifetime of the passed in Runner.
+type RunnerWrapper func(context.Context, Runner)
+
+// RunnerBuilder is a function that can be used to construct a Runner.
+// It is expected to be called in the main go routine since the construction can fail.
+type RunnerBuilder func(context.Context) (Runner, error)
+
+// informer is the subset of SharedInformerFactory needed for starting an informer cache and waiting for it to sync.
+type informer interface {
+	Start(stopCh <-chan struct{})
+	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
+}
+
+// Prepare returns RunnerBuilder that, when called:
+//   1. Starts all provided informers and waits for them sync (and fails if they hang)
+//   2. Returns a Runner that combines the Runner and RunnerWrapper passed into Prepare
+func Prepare(controllers Runner, controllersWrapper RunnerWrapper, informers ...informer) RunnerBuilder {
+	return func(ctx context.Context) (Runner, error) {
+		for _, informer := range informers {
+			informer := informer
+
+			informer.Start(ctx.Done())
+
+			// prevent us from blocking forever due to a broken informer
+			waitCtx, waitCancel := context.WithTimeout(ctx, time.Minute)
+			defer waitCancel()
+
+			// wait until the caches are synced before returning
+			status := informer.WaitForCacheSync(waitCtx.Done())
+
+			if unsynced := unsyncedInformers(status); len(unsynced) > 0 {
+				return nil, fmt.Errorf("failed to sync informers of %s: %v", anyToFullname(informer), unsynced)
+			}
+		}
+
+		return func(controllerCtx context.Context) {
+			controllersWrapper(controllerCtx, controllers)
+		}, nil
+	}
+}
+
+func unsyncedInformers(status map[reflect.Type]bool) []string {
+	if len(status) == 0 {
+		return []string{"all:empty"}
+	}
+
+	var names []string
+
+	for typ, synced := range status {
+		if !synced {
+			names = append(names, typeToFullname(typ))
+		}
+	}
+
+	sort.Strings(names)
+
+	return names
+}
+
+func anyToFullname(any interface{}) string {
+	typ := reflect.TypeOf(any)
+	return typeToFullname(typ)
+}
+
+func typeToFullname(typ reflect.Type) string {
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
+	return typ.PkgPath() + "." + typ.Name()
+}

--- a/test/integration/controllerinit_test.go
+++ b/test/integration/controllerinit_test.go
@@ -1,0 +1,81 @@
+// Copyright 2021 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	kubeinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"go.pinniped.dev/internal/controllerinit"
+	"go.pinniped.dev/test/testlib"
+)
+
+// this just makes some slow read requests which are safe to run in parallel with serial tests, see main_test.go.
+func TestControllerInitPrepare_Parallel(t *testing.T) {
+	_ = testlib.IntegrationEnv(t)
+
+	t.Run("with parent context that is never canceled", func(t *testing.T) {
+		t.Parallel()
+
+		// the nil params should never be used in this case
+		buildControllers := controllerinit.Prepare(nil, nil, buildBrokenInformer(t))
+
+		start := time.Now()
+		runControllers, err := buildControllers(context.Background()) // we expect this to not block forever even with a context.Background()
+		delta := time.Since(start)
+
+		require.EqualError(t, err,
+			"failed to sync informers of k8s.io/client-go/informers.sharedInformerFactory: "+
+				"[k8s.io/api/core/v1.Namespace k8s.io/api/core/v1.Node]")
+		require.Nil(t, runControllers)
+
+		require.InDelta(t, time.Minute, delta, float64(30*time.Second))
+	})
+
+	t.Run("with parent context that is canceled early", func(t *testing.T) {
+		t.Parallel()
+
+		// the nil params should never be used in this case
+		buildControllers := controllerinit.Prepare(nil, nil, buildBrokenInformer(t))
+
+		// we expect this to exit sooner because the parent context is shorter
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		t.Cleanup(cancel)
+
+		start := time.Now()
+		runControllers, err := buildControllers(ctx)
+		delta := time.Since(start)
+
+		require.EqualError(t, err,
+			"failed to sync informers of k8s.io/client-go/informers.sharedInformerFactory: "+
+				"[k8s.io/api/core/v1.Namespace k8s.io/api/core/v1.Node]")
+		require.Nil(t, runControllers)
+
+		require.InDelta(t, 10*time.Second, delta, float64(15*time.Second))
+	})
+}
+
+func buildBrokenInformer(t *testing.T) kubeinformers.SharedInformerFactory {
+	t.Helper()
+
+	config := testlib.NewClientConfig(t)
+	config = rest.CopyConfig(config)
+	config.Impersonate.UserName = "user-with-no-rbac" // so we can test that we correctly detect a cache sync failure
+
+	client := kubernetes.NewForConfigOrDie(config)
+
+	informers := kubeinformers.NewSharedInformerFactoryWithOptions(client, 0)
+
+	// make sure some informers gets lazily loaded
+	_ = informers.Core().V1().Nodes().Informer()
+	_ = informers.Core().V1().Namespaces().Informer()
+
+	return informers
+}


### PR DESCRIPTION
Changes made to both components:

1. Logs are always flushed on process exit
2. Informer cache sync can no longer hang process start up forever

Changes made to concierge:

1. Add pre-shutdown hook that waits for controllers to exit cleanly
2. Informer caches are synced in post-start hook

Changes made to supervisor:

1. Add shutdown code that waits for controllers to exit cleanly
2. Add shutdown code that waits for active connections to become idle

Waiting for controllers to exit cleanly is critical as this allows
the leader election logic to release the lock on exit.  This reduces
the time needed for the next leader to be elected.

Signed-off-by: Monis Khan <mok@vmware.com>

Fixes #654
xref #828

**Release note**:

```release-note
The pinniped supervisor now waits for up to a minute for active connections to become idle before exiting when told to terminate by the kubelet.
```