### PR TITLE
Fix broken "read only" fields added in v0.11.0.

### DIFF
--- a/deploy/concierge/deployment.yaml
+++ b/deploy/concierge/deployment.yaml
@@ -116,7 +116,6 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
       securityContext:
-        readOnlyRootFilesystem: true
         runAsUser: #@ data.values.run_as_user
         runAsGroup: #@ data.values.run_as_group
       serviceAccountName: #@ defaultResourceName()
@@ -132,6 +131,8 @@ spec:
           image: #@ data.values.image_repo + ":" + data.values.image_tag
           #@ end
           imagePullPolicy: IfNotPresent
+          securityContext:
+            readOnlyRootFilesystem: true
           resources:
             requests:
               cpu: "100m"
@@ -148,10 +149,13 @@ spec:
               mountPath: /tmp
             - name: config-volume
               mountPath: /etc/config
+              readOnly: true
             - name: podinfo
               mountPath: /etc/podinfo
+              readOnly: true
             - name: impersonation-proxy
               mountPath: /var/run/secrets/impersonation-proxy.concierge.pinniped.dev/serviceaccount
+              readOnly: true
           env:
             #@ if data.values.https_proxy:
             - name: HTTPS_PROXY
@@ -185,7 +189,6 @@ spec:
             medium: Memory
             sizeLimit: 100Mi
         - name: config-volume
-          readOnly: true
           configMap:
             name: #@ defaultResourceNameWithSuffix("config")
         - name: impersonation-proxy
@@ -195,7 +198,6 @@ spec:
               - key: token
                 path: token
         - name: podinfo
-          readOnly: true
           downwardAPI:
             items:
               - path: "labels"

--- a/deploy/supervisor/deployment.yaml
+++ b/deploy/supervisor/deployment.yaml
@@ -65,7 +65,6 @@ spec:
       labels: #@ defaultLabel()
     spec:
       securityContext:
-        readOnlyRootFilesystem: true
         runAsUser: #@ data.values.run_as_user
         runAsGroup: #@ data.values.run_as_group
       serviceAccountName: #@ defaultResourceName()
@@ -85,6 +84,8 @@ spec:
             - pinniped-supervisor
             - /etc/podinfo
             - /etc/config/pinniped.yaml
+          securityContext:
+            readOnlyRootFilesystem: true
           resources:
             requests:
               cpu: "100m"
@@ -95,8 +96,10 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config
+              readOnly: true
             - name: podinfo
               mountPath: /etc/podinfo
+              readOnly: true
           ports:
             - containerPort: 8080
               protocol: TCP
@@ -131,11 +134,9 @@ spec:
             failureThreshold: 3
       volumes:
         - name: config-volume
-          readOnly: true
           configMap:
             name: #@ defaultResourceNameWithSuffix("static-config")
         - name: podinfo
-          readOnly: true
           downwardAPI:
             items:
               - path: "labels"

--- a/hack/prepare-for-integration-tests.sh
+++ b/hack/prepare-for-integration-tests.sh
@@ -219,8 +219,8 @@ ytt --file . \
   --data-value "image_repo=$registry_repo" \
   --data-value "image_tag=$tag" >"$manifest"
 
-kubectl apply --dry-run=client -f "$manifest" # Validate manifest schema.
 kapp deploy --yes --app local-user-authenticator --diff-changes --file "$manifest"
+kubectl apply --dry-run=client -f "$manifest" # Validate manifest schema.
 
 popd >/dev/null
 
@@ -238,8 +238,8 @@ ytt --file . \
   --data-value "pinny_bcrypt_passwd_hash=$(htpasswd -nbBC 10 x "$dex_test_password" | sed -e "s/^x://")" \
   >"$manifest"
 
-kubectl apply --dry-run=client -f "$manifest" # Validate manifest schema.
 kapp deploy --yes --app tools --diff-changes --file "$manifest"
+kubectl apply --dry-run=client -f "$manifest" # Validate manifest schema.
 
 popd >/dev/null
 
@@ -281,6 +281,7 @@ ytt --file . \
   >"$manifest"
 
 kapp deploy --yes --app "$supervisor_app_name" --diff-changes --file "$manifest"
+kubectl apply --dry-run=client -f "$manifest" # Validate manifest schema.
 
 popd >/dev/null
 
@@ -308,6 +309,7 @@ ytt --file . \
   --data-value "discovery_url=$discovery_url" >"$manifest"
 
 kapp deploy --yes --app "$concierge_app_name" --diff-changes --file "$manifest"
+kubectl apply --dry-run=client -f "$manifest" # Validate manifest schema.
 
 popd >/dev/null
 


### PR DESCRIPTION
These fields were changed as a minor hardening attempt when we switched to Distroless, but I bungled the field names and we never noticed because Kapp doesn't apply API validations.

This change fixes the field names so they act as was originally intended. We should also follow up with a change that validates all of our installation manifest in CI.

Thanks to Jeremy Calcamuggio in Kubernetes Slack for raising this issue.

**Release note**:
```release-note
Fixed incorrect "readOnly" and "readOnlyRootFilesystem" field usage in Supervisor and Concierge deployment manifests. 
```
