### PR TITLE
ran `go mod tidy`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/uuid v1.1.2 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect


### PR DESCRIPTION
Somehow we missed running `go mod tidy` on a previous commit to `main`.

**Release note**:

```release-note
NONE
```
