### PR TITLE
DO NOT MERGE: prevent kapp from altering the selector of our services

### DIFF
--- a/deploy/concierge/deployment.yaml
+++ b/deploy/concierge/deployment.yaml
@@ -235,6 +235,9 @@ metadata:
   name: #@ defaultResourceNameWithSuffix("api")
   namespace: #@ namespace()
   labels: #@ labels()
+  #! prevent kapp from altering the selector of our services to match kubectl behavior
+  annotations:
+    kapp.k14s.io/disable-default-label-scoping-rules: ""
 spec:
   type: ClusterIP
   selector: #@ defaultLabel()
@@ -249,6 +252,9 @@ metadata:
   name: #@ defaultResourceNameWithSuffix("proxy")
   namespace: #@ namespace()
   labels: #@ labels()
+  #! prevent kapp from altering the selector of our services to match kubectl behavior
+  annotations:
+    kapp.k14s.io/disable-default-label-scoping-rules: ""
 spec:
   type: ClusterIP
   selector: #@ defaultLabel()

--- a/deploy/local-user-authenticator/deployment.yaml
+++ b/deploy/local-user-authenticator/deployment.yaml
@@ -73,6 +73,9 @@ metadata:
   namespace: local-user-authenticator
   labels:
     app: local-user-authenticator
+  #! prevent kapp from altering the selector of our services to match kubectl behavior
+  annotations:
+    kapp.k14s.io/disable-default-label-scoping-rules: ""
 spec:
   type: ClusterIP
   selector:

--- a/deploy/supervisor/service.yaml
+++ b/deploy/supervisor/service.yaml
@@ -12,6 +12,9 @@ metadata:
   name: #@ defaultResourceNameWithSuffix("nodeport")
   namespace: #@ namespace()
   labels: #@ labels()
+  #! prevent kapp from altering the selector of our services to match kubectl behavior
+  annotations:
+    kapp.k14s.io/disable-default-label-scoping-rules: ""
 spec:
   type: NodePort
   selector:
@@ -45,6 +48,9 @@ metadata:
   name: #@ defaultResourceNameWithSuffix("clusterip")
   namespace: #@ namespace()
   labels: #@ labels()
+  #! prevent kapp from altering the selector of our services to match kubectl behavior
+  annotations:
+    kapp.k14s.io/disable-default-label-scoping-rules: ""
 spec:
   type: ClusterIP
   selector: #@ defaultLabel()
@@ -71,6 +77,9 @@ metadata:
   name: #@ defaultResourceNameWithSuffix("loadbalancer")
   namespace: #@ namespace()
   labels: #@ labels()
+  #! prevent kapp from altering the selector of our services to match kubectl behavior
+  annotations:
+    kapp.k14s.io/disable-default-label-scoping-rules: ""
 spec:
   type: LoadBalancer
   selector: #@ defaultLabel()


### PR DESCRIPTION
Testing to see if things explode like we expect them to.

---

This makes it so that our service selector will match exactly the
YAML we specify instead of including an extra "kapp.k14s.io/app" key.
This will take us closer to the standard kubectl behavior which is
desirable since we want to avoid future bugs that only manifest when
kapp is not used.

Signed-off-by: Monis Khan <mok@vmware.com>

**Release note**:

```release-note
TODO
```