### PR TITLE
kubecertagent: fix flakey tests

### DIFF
--- a/internal/controller/kubecertagent/kubecertagent.go
+++ b/internal/controller/kubecertagent/kubecertagent.go
@@ -184,7 +184,6 @@ func newAgentController(
 	clock clock.Clock,
 	execCache *cache.Expiring,
 	log logr.Logger,
-	options ...controllerlib.Option,
 ) controllerlib.Controller {
 	return controllerlib.New(
 		controllerlib.Config{
@@ -204,47 +203,45 @@ func newAgentController(
 				execCache:            execCache,
 			},
 		},
-		append([]controllerlib.Option{
-			controllerlib.WithInformer(
-				kubeSystemPods,
-				pinnipedcontroller.SimpleFilterWithSingletonQueue(func(obj metav1.Object) bool {
-					return controllerManagerLabels.Matches(labels.Set(obj.GetLabels()))
-				}),
-				controllerlib.InformerOption{},
-			),
-			controllerlib.WithInformer(
-				agentDeployments,
-				pinnipedcontroller.SimpleFilterWithSingletonQueue(func(obj metav1.Object) bool {
-					return obj.GetNamespace() == cfg.Namespace && obj.GetName() == cfg.deploymentName()
-				}),
-				controllerlib.InformerOption{},
-			),
-			controllerlib.WithInformer(
-				agentPods,
-				pinnipedcontroller.SimpleFilterWithSingletonQueue(func(obj metav1.Object) bool {
-					return agentLabels.Matches(labels.Set(obj.GetLabels()))
-				}),
-				controllerlib.InformerOption{},
-			),
-			controllerlib.WithInformer(
-				kubePublicConfigMaps,
-				pinnipedcontroller.SimpleFilterWithSingletonQueue(func(obj metav1.Object) bool {
-					return obj.GetNamespace() == ClusterInfoNamespace && obj.GetName() == clusterInfoName
-				}),
-				controllerlib.InformerOption{},
-			),
-			controllerlib.WithInformer(
-				credentialIssuers,
-				pinnipedcontroller.SimpleFilterWithSingletonQueue(func(obj metav1.Object) bool {
-					return obj.GetName() == cfg.CredentialIssuerName
-				}),
-				controllerlib.InformerOption{},
-			),
-			// Be sure to run once even to make sure the CredentialIssuer is updated if there are no controller manager
-			// pods. We should be able to pass an empty key since we don't use the key in the sync (we sync
-			// the world).
-			controllerlib.WithInitialEvent(controllerlib.Key{}),
-		}, options...)...,
+		controllerlib.WithInformer(
+			kubeSystemPods,
+			pinnipedcontroller.SimpleFilterWithSingletonQueue(func(obj metav1.Object) bool {
+				return controllerManagerLabels.Matches(labels.Set(obj.GetLabels()))
+			}),
+			controllerlib.InformerOption{},
+		),
+		controllerlib.WithInformer(
+			agentDeployments,
+			pinnipedcontroller.SimpleFilterWithSingletonQueue(func(obj metav1.Object) bool {
+				return obj.GetNamespace() == cfg.Namespace && obj.GetName() == cfg.deploymentName()
+			}),
+			controllerlib.InformerOption{},
+		),
+		controllerlib.WithInformer(
+			agentPods,
+			pinnipedcontroller.SimpleFilterWithSingletonQueue(func(obj metav1.Object) bool {
+				return agentLabels.Matches(labels.Set(obj.GetLabels()))
+			}),
+			controllerlib.InformerOption{},
+		),
+		controllerlib.WithInformer(
+			kubePublicConfigMaps,
+			pinnipedcontroller.SimpleFilterWithSingletonQueue(func(obj metav1.Object) bool {
+				return obj.GetNamespace() == ClusterInfoNamespace && obj.GetName() == clusterInfoName
+			}),
+			controllerlib.InformerOption{},
+		),
+		controllerlib.WithInformer(
+			credentialIssuers,
+			pinnipedcontroller.SimpleFilterWithSingletonQueue(func(obj metav1.Object) bool {
+				return obj.GetName() == cfg.CredentialIssuerName
+			}),
+			controllerlib.InformerOption{},
+		),
+		// Be sure to run once even to make sure the CredentialIssuer is updated if there are no controller manager
+		// pods. We should be able to pass an empty key since we don't use the key in the sync (we sync
+		// the world).
+		controllerlib.WithInitialEvent(controllerlib.Key{}),
 	)
 }
 

--- a/internal/controller/kubecertagent/legacypodcleaner.go
+++ b/internal/controller/kubecertagent/legacypodcleaner.go
@@ -24,7 +24,6 @@ func NewLegacyPodCleanerController(
 	client *kubeclient.Client,
 	agentPods corev1informers.PodInformer,
 	log logr.Logger,
-	options ...controllerlib.Option,
 ) controllerlib.Controller {
 	// legacyAgentLabels are the Kubernetes labels we previously added to agent pods (the new value is "v2").
 	// We also expect these pods to have the "extra" labels configured on the Concierge.
@@ -67,14 +66,12 @@ func NewLegacyPodCleanerController(
 				return nil
 			}),
 		},
-		append([]controllerlib.Option{
-			controllerlib.WithInformer(
-				agentPods,
-				pinnipedcontroller.SimpleFilter(func(obj metav1.Object) bool {
-					return obj.GetNamespace() == cfg.Namespace && legacyAgentSelector.Matches(labels.Set(obj.GetLabels()))
-				}, nil),
-				controllerlib.InformerOption{},
-			),
-		}, options...)...,
+		controllerlib.WithInformer(
+			agentPods,
+			pinnipedcontroller.SimpleFilter(func(obj metav1.Object) bool {
+				return obj.GetNamespace() == cfg.Namespace && legacyAgentSelector.Matches(labels.Set(obj.GetLabels()))
+			}, nil),
+			controllerlib.InformerOption{},
+		),
 	)
 }

--- a/internal/controller/kubecertagent/legacypodcleaner_test.go
+++ b/internal/controller/kubecertagent/legacypodcleaner_test.go
@@ -18,7 +18,6 @@ import (
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	coretesting "k8s.io/client-go/testing"
 
-	"go.pinniped.dev/internal/controllerlib"
 	"go.pinniped.dev/internal/kubeclient"
 	"go.pinniped.dev/internal/testutil"
 	"go.pinniped.dev/internal/testutil/testlogger"
@@ -175,13 +174,12 @@ func TestLegacyPodCleanerController(t *testing.T) {
 				&kubeclient.Client{Kubernetes: trackDeleteClient},
 				kubeInformers.Core().V1().Pods(),
 				log,
-				controllerlib.WithMaxRetries(1),
 			)
 
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
-			errorMessages := runControllerUntilQuiet(ctx, t, controller, kubeInformers)
+			errorMessages := runControllerUntilQuiet(ctx, t, controller, func(_ context.Context, _ *testing.T) {}, kubeInformers)
 			assert.Equal(t, tt.wantDistinctErrors, deduplicate(errorMessages), "unexpected errors")
 			assert.Equal(t, tt.wantDistinctLogs, deduplicate(log.Lines()), "unexpected logs")
 			assert.Equal(t, tt.wantActions, kubeClientset.Actions()[2:], "unexpected actions")

--- a/internal/controllerinit/controllerinit.go
+++ b/internal/controllerinit/controllerinit.go
@@ -22,8 +22,8 @@ type RunnerWrapper func(context.Context, Runner)
 // It is expected to be called in the main go routine since the construction can fail.
 type RunnerBuilder func(context.Context) (Runner, error)
 
-// informer is the subset of SharedInformerFactory needed for starting an informer cache and waiting for it to sync.
-type informer interface {
+// Informer is the subset of SharedInformerFactory needed for starting an informer cache and waiting for it to sync.
+type Informer interface {
 	Start(stopCh <-chan struct{})
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 }
@@ -31,7 +31,7 @@ type informer interface {
 // Prepare returns RunnerBuilder that, when called:
 //   1. Starts all provided informers and waits for them sync (and fails if they hang)
 //   2. Returns a Runner that combines the Runner and RunnerWrapper passed into Prepare
-func Prepare(controllers Runner, controllersWrapper RunnerWrapper, informers ...informer) RunnerBuilder {
+func Prepare(controllers Runner, controllersWrapper RunnerWrapper, informers ...Informer) RunnerBuilder {
 	return func(ctx context.Context) (Runner, error) {
 		for _, informer := range informers {
 			informer := informer


### PR DESCRIPTION
This commit makes the following changes to the kube cert agent tests:

1. Informers are synced on start using the controllerinit code
2. Deployment client and informer are synced per controller sync loop
3. Controller sync loop exits after two consistent errors
4. Use assert instead of require to avoid ending the test early

Signed-off-by: Monis Khan <mok@vmware.com>

**Release note**:

```release-note
NONE
```