### PR TITLE
Do not rotate impersonation proxy signer CA unless necessary

### DIFF
--- a/internal/controller/impersonatorconfig/impersonator_config.go
+++ b/internal/controller/impersonatorconfig/impersonator_config.go
@@ -51,7 +51,7 @@ const (
 	impersonationProxyPort       = 8444
 	defaultHTTPSPort             = 443
 	approximatelyOneHundredYears = 100 * 365 * 24 * time.Hour
-	caCommonName                 = "Pinniped Impersonation Proxy CA"
+	caCommonName                 = "Pinniped Impersonation Proxy Serving CA"
 	caCrtKey                     = "ca.crt"
 	caKeyKey                     = "ca.key"
 	appLabelKey                  = "app"

--- a/internal/controller/impersonatorconfig/impersonator_config_test.go
+++ b/internal/controller/impersonatorconfig/impersonator_config_test.go
@@ -1055,7 +1055,7 @@ func TestImpersonatorConfigControllerSync(t *testing.T) {
 			require.NotNil(t, block)
 			caCert, err := x509.ParseCertificate(block.Bytes)
 			require.NoError(t, err)
-			require.Equal(t, "Pinniped Impersonation Proxy CA", caCert.Subject.CommonName)
+			require.Equal(t, "Pinniped Impersonation Proxy Serving CA", caCert.Subject.CommonName)
 			require.WithinDuration(t, time.Now().Add(-5*time.Minute), caCert.NotBefore, 10*time.Second)
 			require.WithinDuration(t, time.Now().Add(100*time.Hour*24*365), caCert.NotAfter, 10*time.Second)
 			return createdCertPEM

--- a/internal/controllermanager/prepare_controllers.go
+++ b/internal/controllermanager/prepare_controllers.go
@@ -148,7 +148,7 @@ func PrepareControllers(c *Config) (controllerinit.RunnerBuilder, error) {
 				controllerlib.WithInformer,
 				controllerlib.WithInitialEvent,
 				c.ServingCertDuration,
-				"Pinniped CA",
+				"Pinniped Aggregation CA",
 				c.NamesConfig.APIService,
 			),
 			singletonWorker,
@@ -285,7 +285,7 @@ func PrepareControllers(c *Config) (controllerinit.RunnerBuilder, error) {
 				controllerlib.WithInformer,
 				controllerlib.WithInitialEvent,
 				365*24*time.Hour, // 1 year hard coded value
-				"Pinniped Impersonation Proxy CA",
+				"Pinniped Impersonation Proxy Signer CA",
 				"", // optional, means do not give me a serving cert
 			),
 			singletonWorker,
@@ -297,7 +297,7 @@ func PrepareControllers(c *Config) (controllerinit.RunnerBuilder, error) {
 				client.Kubernetes,
 				informers.installationNamespaceK8s.Core().V1().Secrets(),
 				controllerlib.WithInformer,
-				c.ServingCertRenewBefore,
+				365*24*time.Hour-time.Hour, // 1 year minus 1 hour hard coded value (i.e. wait until the last moment to break the signer)
 				apicerts.CACertificateSecretKey,
 			),
 			singletonWorker,


### PR DESCRIPTION
This change fixes a copy paste error that led to the impersonation
proxy signer CA being rotated based on the configuration of the
rotation of the aggregated API serving certificate.  This would lead
to occasional "Unauthorized" flakes in our CI environments that
rotate the serving certificate at a frequent interval.

Updated the certs_expirer controller logs to be more detailed.

Updated CA common names to be more specific (this does not update
any previously generated CAs).

Signed-off-by: Monis Khan <mok@vmware.com>

**Release note**:

```release-note
NONE
```