### PR TITLE
Force the use of secure TLS config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,11 +114,12 @@ docker build .
    - [`kind`](https://kind.sigs.k8s.io/docs/user/quick-start)
    - [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
    - [`ytt`](https://carvel.dev/#getting-started)
+   - [`nmap`](https://nmap.org/download.html)
 
    On macOS, these tools can be installed with [Homebrew](https://brew.sh/) (assuming you have Chrome installed already):
 
    ```bash
-   brew install kind k14s/tap/ytt k14s/tap/kapp kubectl chromedriver && brew cask install docker
+   brew install kind k14s/tap/ytt k14s/tap/kapp kubectl chromedriver nmap && brew cask install docker
    ```
 
 1. Create a kind cluster, compile, create container images, and install Pinniped and supporting dependencies using:

--- a/hack/prepare-for-integration-tests.sh
+++ b/hack/prepare-for-integration-tests.sh
@@ -132,6 +132,7 @@ check_dependency kubectl "Please install kubectl. e.g. 'brew install kubectl' fo
 check_dependency htpasswd "Please install htpasswd. Should be pre-installed on MacOS. Usually found in 'apache2-utils' package for linux."
 check_dependency openssl "Please install openssl. Should be pre-installed on MacOS."
 check_dependency chromedriver "Please install chromedriver. e.g. 'brew install chromedriver' for MacOS"
+check_dependency nmap "Please install nmap. e.g. 'brew install nmap' for MacOS"
 
 # Check that Chrome and chromedriver versions match. If chromedriver falls a couple versions behind
 # then usually tests start to fail with strange error messages.
@@ -155,6 +156,12 @@ fi
 # Require kubectl >= 1.18.x
 if [ "$(kubectl version --client=true --short | cut -d '.' -f 2)" -lt 18 ]; then
   log_error "kubectl >= 1.18.x is required, you have $(kubectl version --client=true --short | cut -d ':' -f2)"
+  exit 1
+fi
+
+# Require nmap >= 7.92.x
+if [ "$(nmap -V | grep 'Nmap version' | cut -d ' ' -f 3 | cut -d '.' -f 2)" -lt 92 ]; then
+  log_error "nmap >= 7.92.x is required, you have $(nmap -V | grep 'Nmap version' | cut -d ' ' -f 3)"
   exit 1
 fi
 

--- a/internal/controller/authenticator/webhookcachefiller/webhookcachefiller.go
+++ b/internal/controller/authenticator/webhookcachefiller/webhookcachefiller.go
@@ -91,7 +91,7 @@ func newWebhookAuthenticator(
 	defer func() { _ = os.Remove(temp.Name()) }()
 
 	cluster := &clientcmdapi.Cluster{Server: spec.Endpoint}
-	cluster.CertificateAuthorityData, err = pinnipedauthenticator.CABundle(spec.TLS)
+	_, cluster.CertificateAuthorityData, err = pinnipedauthenticator.CABundle(spec.TLS)
 	if err != nil {
 		return nil, fmt.Errorf("invalid TLS configuration: %w", err)
 	}
@@ -118,5 +118,7 @@ func newWebhookAuthenticator(
 	// custom proxy stuff used by the API server.
 	var customDial net.DialFunc
 
+	// this uses a http client that does not honor our TLS config
+	// TODO fix when we pick up https://github.com/kubernetes/kubernetes/pull/106155
 	return webhook.New(temp.Name(), version, implicitAuds, *webhook.DefaultRetryBackoff(), customDial)
 }

--- a/internal/controller/authenticator/webhookcachefiller/webhookcachefiller_test.go
+++ b/internal/controller/authenticator/webhookcachefiller/webhookcachefiller_test.go
@@ -141,7 +141,7 @@ func TestNewWebhookAuthenticator(t *testing.T) {
 			TLS:      &auth1alpha1.TLSSpec{CertificateAuthorityData: base64.StdEncoding.EncodeToString([]byte("bad data"))},
 		}, ioutil.TempFile, clientcmd.WriteToFile)
 		require.Nil(t, res)
-		require.EqualError(t, err, "invalid TLS configuration: certificateAuthorityData is not valid PEM")
+		require.EqualError(t, err, "invalid TLS configuration: certificateAuthorityData is not valid PEM: data does not contain any valid RSA or ECDSA certificates")
 	})
 
 	t.Run("valid config with no TLS spec", func(t *testing.T) {

--- a/internal/controller/kubecertagent/pod_command_executor.go
+++ b/internal/controller/kubecertagent/pod_command_executor.go
@@ -26,6 +26,8 @@ type kubeClientPodCommandExecutor struct {
 // NewPodCommandExecutor returns a PodCommandExecutor that will interact with a pod via the provided
 // kubeConfig and corresponding kubeClient.
 func NewPodCommandExecutor(kubeConfig *restclient.Config, kubeClient kubernetes.Interface) PodCommandExecutor {
+	kubeConfig = restclient.CopyConfig(kubeConfig)
+	kubeConfig.NextProtos = []string{"http/1.1"} // we explicitly need to upgrade from http1 to spdy, exec cannot use http2
 	return &kubeClientPodCommandExecutor{kubeConfig: kubeConfig, kubeClient: kubeClient}
 }
 

--- a/internal/controller/kubecertagent/pod_command_executor_test.go
+++ b/internal/controller/kubecertagent/pod_command_executor_test.go
@@ -1,0 +1,44 @@
+// Copyright 2021 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package kubecertagent
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/rest"
+
+	"go.pinniped.dev/internal/crypto/ptls"
+	"go.pinniped.dev/internal/kubeclient"
+	"go.pinniped.dev/internal/testutil/tlsserver"
+)
+
+func TestSecureTLS(t *testing.T) {
+	var sawRequest bool
+	server := tlsserver.TLSTestServer(t, http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		tlsserver.AssertTLS(t, r, ptls.Secure)
+		sawRequest = true
+	}), tlsserver.RecordTLSHello)
+
+	config := &rest.Config{
+		Host: server.URL,
+		TLSClientConfig: rest.TLSClientConfig{
+			CAData: tlsserver.TLSTestServerCA(server),
+		},
+	}
+
+	client, err := kubeclient.New(kubeclient.WithConfig(config))
+	require.NoError(t, err)
+
+	// build this exactly like our production could does
+	podCommandExecutor := NewPodCommandExecutor(client.JSONConfig, client.Kubernetes)
+
+	got, err := podCommandExecutor.Exec("podNamespace", "podName", "command", "arg1", "arg2")
+	require.Equal(t, &errors.StatusError{}, err)
+	require.Empty(t, got)
+
+	require.True(t, sawRequest)
+}

--- a/internal/crypto/ptls/old.go
+++ b/internal/crypto/ptls/old.go
@@ -1,0 +1,15 @@
+// Copyright 2021 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !go1.17
+// +build !go1.17
+
+package ptls
+
+func init() {
+	// cause compile time failure if an older version of Go is used
+	`Pinniped's TLS configuration makes assumptions about how the Go standard library implementation of TLS works.
+It particular, we rely on the server controlling cipher suite selection.  For these assumptions to hold, Pinniped
+must be compiled with Go 1.17+.  If you are seeing this error message, your attempt to compile Pinniped with an
+older Go compiler was explicitly failed to prevent an unsafe configuration.`
+}

--- a/internal/crypto/ptls/ptls.go
+++ b/internal/crypto/ptls/ptls.go
@@ -1,0 +1,215 @@
+// Copyright 2021 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ptls
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"k8s.io/apiserver/pkg/admission"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/apiserver/pkg/server/options"
+	kubeinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/transport"
+)
+
+// TODO decide if we need to expose the four TLS levels (secure, default, default-ldap, legacy) as config.
+
+type ConfigFunc func(*x509.CertPool) *tls.Config
+
+func Default(rootCAs *x509.CertPool) *tls.Config {
+	return &tls.Config{
+		// Can't use SSLv3 because of POODLE and BEAST
+		// Can't use TLSv1.0 because of POODLE and BEAST using CBC cipher
+		// Can't use TLSv1.1 because of RC4 cipher usage
+		//
+		// The Kubernetes API Server must use TLS 1.2, at a minimum,
+		// to protect the confidentiality of sensitive data during electronic dissemination.
+		// https://stigviewer.com/stig/kubernetes/2021-06-17/finding/V-242378
+		MinVersion: tls.VersionTLS12,
+
+		// the order does not matter in go 1.17+ https://go.dev/blog/tls-cipher-suites
+		// we match crypto/tls.cipherSuitesPreferenceOrder because it makes unit tests easier to write
+		// this list is ignored when TLS 1.3 is used
+		//
+		// as of 2021-10-19, Mozilla Guideline v5.6, Go 1.17.2, intermediate configuration, supports:
+		// - Firefox 27
+		// - Android 4.4.2
+		// - Chrome 31
+		// - Edge
+		// - IE 11 on Windows 7
+		// - Java 8u31
+		// - OpenSSL 1.0.1
+		// - Opera 20
+		// - Safari 9
+		// https://ssl-config.mozilla.org/#server=go&version=1.17.2&config=intermediate&guideline=5.6
+		//
+		// The Kubernetes API server must use approved cipher suites.
+		// https://stigviewer.com/stig/kubernetes/2021-06-17/finding/V-242418
+		CipherSuites: []uint16{
+			// these are all AEADs with ECDHE, some use ChaCha20Poly1305 while others use AES-GCM
+			// this provides forward secrecy, confidentiality and authenticity of data
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305, tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+		},
+
+		// enable HTTP2 for go's 1.7 HTTP Server
+		// setting this explicitly is only required in very specific circumstances
+		// it is simpler to just set it here than to try and determine if we need to
+		NextProtos: []string{"h2", "http/1.1"},
+
+		// optional root CAs, nil means use the host's root CA set
+		RootCAs: rootCAs,
+	}
+}
+
+func Secure(rootCAs *x509.CertPool) *tls.Config {
+	// as of 2021-10-19, Mozilla Guideline v5.6, Go 1.17.2, modern configuration, supports:
+	// - Firefox 63
+	// - Android 10.0
+	// - Chrome 70
+	// - Edge 75
+	// - Java 11
+	// - OpenSSL 1.1.1
+	// - Opera 57
+	// - Safari 12.1
+	// https://ssl-config.mozilla.org/#server=go&version=1.17.2&config=modern&guideline=5.6
+	c := Default(rootCAs)
+	c.MinVersion = tls.VersionTLS13 // max out the security
+	c.CipherSuites = []uint16{
+		// TLS 1.3 ciphers are not configurable, but we need to explicitly set them here to make our client hello behave correctly
+		// See https://github.com/golang/go/pull/49293
+		tls.TLS_AES_128_GCM_SHA256,
+		tls.TLS_AES_256_GCM_SHA384,
+		tls.TLS_CHACHA20_POLY1305_SHA256,
+	}
+	return c
+}
+
+func DefaultLDAP(rootCAs *x509.CertPool) *tls.Config {
+	c := Default(rootCAs)
+	// add less secure ciphers to support the default AWS Active Directory config
+	c.CipherSuites = append(c.CipherSuites,
+		// CBC with ECDHE
+		// this provides forward secrecy and confidentiality of data but not authenticity
+		// MAC-then-Encrypt CBC ciphers are susceptible to padding oracle attacks
+		// See https://crypto.stackexchange.com/a/205 and https://crypto.stackexchange.com/a/224
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA, tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA, tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+	)
+	return c
+}
+
+func Legacy(rootCAs *x509.CertPool) *tls.Config {
+	c := Default(rootCAs)
+	// add all the ciphers (even the crappy ones) except the ones that Go considers to be outright broken like 3DES
+	c.CipherSuites = suitesToIDs(tls.CipherSuites())
+	return c
+}
+
+func suitesToIDs(suites []*tls.CipherSuite) []uint16 {
+	out := make([]uint16, 0, len(suites))
+	for _, suite := range suites {
+		suite := suite
+		out = append(out, suite.ID)
+	}
+	return out
+}
+
+func Merge(tlsConfigFunc ConfigFunc, tlsConfig *tls.Config) {
+	secureTLSConfig := tlsConfigFunc(nil)
+
+	// override the core security knobs of the TLS config
+	// note that these have to be kept in sync with Default / Secure above
+	tlsConfig.MinVersion = secureTLSConfig.MinVersion
+	tlsConfig.CipherSuites = secureTLSConfig.CipherSuites
+
+	// if the TLS config already states what protocols it wants to use, honor that instead of overriding
+	if len(tlsConfig.NextProtos) == 0 {
+		tlsConfig.NextProtos = secureTLSConfig.NextProtos
+	}
+}
+
+// RestConfigFunc allows this package to not depend on the kubeclient package.
+type RestConfigFunc func(*rest.Config) (kubernetes.Interface, *rest.Config, error)
+
+func DefaultRecommendedOptions(opts *options.RecommendedOptions, f RestConfigFunc) error {
+	defaultServing(opts.SecureServing)
+	return secureClient(opts, f)
+}
+
+func SecureRecommendedOptions(opts *options.RecommendedOptions, f RestConfigFunc) error {
+	secureServing(opts.SecureServing)
+	return secureClient(opts, f)
+}
+
+func defaultServing(opts *options.SecureServingOptionsWithLoopback) {
+	c := Default(nil)
+	cipherSuites := make([]string, 0, len(c.CipherSuites))
+	for _, id := range c.CipherSuites {
+		cipherSuites = append(cipherSuites, tls.CipherSuiteName(id))
+	}
+	opts.CipherSuites = cipherSuites
+
+	opts.MinTLSVersion = "VersionTLS12"
+}
+
+func secureServing(opts *options.SecureServingOptionsWithLoopback) {
+	opts.MinTLSVersion = "VersionTLS13"
+	opts.CipherSuites = nil
+}
+
+func secureClient(opts *options.RecommendedOptions, f RestConfigFunc) error {
+	inClusterClient, inClusterConfig, err := f(nil)
+	if err != nil {
+		return fmt.Errorf("failed to build in cluster client: %w", err)
+	}
+
+	if n, z := opts.Authentication.RemoteKubeConfigFile, opts.Authorization.RemoteKubeConfigFile; len(n) > 0 || len(z) > 0 {
+		return fmt.Errorf("delgating auth is not using in-cluster config:\nauthentication=%s\nauthorization=%s", n, z)
+	}
+
+	// delegated authn and authz provide easy hooks for us to set the TLS config.
+	// however, the underlying clients use client-go's global TLS cache with an
+	// in-cluster config.  to make this safe, we simply do the mutation once.
+	wrapperFunc := wrapTransportOnce(inClusterConfig.WrapTransport)
+	opts.Authentication.CustomRoundTripperFn = wrapperFunc
+	opts.Authorization.CustomRoundTripperFn = wrapperFunc
+
+	opts.CoreAPI = nil // set this to nil to make sure our ExtraAdmissionInitializers is used
+	baseExtraAdmissionInitializers := opts.ExtraAdmissionInitializers
+	opts.ExtraAdmissionInitializers = func(c *genericapiserver.RecommendedConfig) ([]admission.PluginInitializer, error) {
+		// abuse this closure to rewrite how we load admission plugins
+		c.ClientConfig = inClusterConfig
+		c.SharedInformerFactory = kubeinformers.NewSharedInformerFactory(inClusterClient, 0)
+
+		// abuse this closure to rewrite our loopback config
+		// this is mostly future proofing for post start hooks
+		_, loopbackConfig, err := f(c.LoopbackClientConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build loopback config: %w", err)
+		}
+		c.LoopbackClientConfig = loopbackConfig
+
+		return baseExtraAdmissionInitializers(c)
+	}
+
+	return nil
+}
+
+func wrapTransportOnce(f transport.WrapperFunc) transport.WrapperFunc {
+	var once sync.Once
+	return func(rt http.RoundTripper) http.RoundTripper {
+		once.Do(func() {
+			_ = f(rt) // assume in-place mutation
+		})
+		return rt
+	}
+}

--- a/internal/crypto/ptls/ptls_test.go
+++ b/internal/crypto/ptls/ptls_test.go
@@ -1,0 +1,253 @@
+// Copyright 2021 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ptls
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apiserver/pkg/server/options"
+)
+
+func TestDefaultServing(t *testing.T) {
+	t.Parallel()
+
+	opts := &options.SecureServingOptionsWithLoopback{SecureServingOptions: &options.SecureServingOptions{}}
+	defaultServing(opts)
+	require.Equal(t, options.SecureServingOptionsWithLoopback{
+		SecureServingOptions: &options.SecureServingOptions{
+			CipherSuites: []string{
+				"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+				"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+				"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+				"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+				"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+				"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+			},
+			MinTLSVersion: "VersionTLS12",
+		},
+	}, *opts)
+}
+
+func TestSecureServing(t *testing.T) {
+	t.Parallel()
+
+	opts := &options.SecureServingOptionsWithLoopback{SecureServingOptions: &options.SecureServingOptions{}}
+	secureServing(opts)
+	require.Equal(t, options.SecureServingOptionsWithLoopback{
+		SecureServingOptions: &options.SecureServingOptions{
+			MinTLSVersion: "VersionTLS13",
+		},
+	}, *opts)
+}
+
+func TestMerge(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		tlsConfigFunc ConfigFunc
+		tlsConfig     *tls.Config
+		want          *tls.Config
+	}{
+		{
+			name:          "default no protos",
+			tlsConfigFunc: Default,
+			tlsConfig: &tls.Config{
+				ServerName: "something-to-check-passthrough",
+			},
+			want: &tls.Config{
+				ServerName: "something-to-check-passthrough",
+				MinVersion: tls.VersionTLS12,
+				CipherSuites: []uint16{
+					tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+					tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+				},
+				NextProtos: []string{"h2", "http/1.1"},
+			},
+		},
+		{
+			name:          "default with protos",
+			tlsConfigFunc: Default,
+			tlsConfig: &tls.Config{
+				ServerName: "a different thing for passthrough",
+				NextProtos: []string{"panda"},
+			},
+			want: &tls.Config{
+				ServerName: "a different thing for passthrough",
+				MinVersion: tls.VersionTLS12,
+				CipherSuites: []uint16{
+					tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+					tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+				},
+				NextProtos: []string{"panda"},
+			},
+		},
+		{
+			name:          "secure no protos",
+			tlsConfigFunc: Secure,
+			tlsConfig: &tls.Config{
+				ServerName: "something-to-check-passthrough",
+			},
+			want: &tls.Config{
+				ServerName: "something-to-check-passthrough",
+				MinVersion: tls.VersionTLS13,
+				CipherSuites: []uint16{
+					tls.TLS_AES_128_GCM_SHA256,
+					tls.TLS_AES_256_GCM_SHA384,
+					tls.TLS_CHACHA20_POLY1305_SHA256,
+				},
+				NextProtos: []string{"h2", "http/1.1"},
+			},
+		},
+		{
+			name:          "secure with protos",
+			tlsConfigFunc: Secure,
+			tlsConfig: &tls.Config{
+				ServerName: "a different thing for passthrough",
+				NextProtos: []string{"panda"},
+			},
+			want: &tls.Config{
+				ServerName: "a different thing for passthrough",
+				MinVersion: tls.VersionTLS13,
+				CipherSuites: []uint16{
+					tls.TLS_AES_128_GCM_SHA256,
+					tls.TLS_AES_256_GCM_SHA384,
+					tls.TLS_CHACHA20_POLY1305_SHA256,
+				},
+				NextProtos: []string{"panda"},
+			},
+		},
+		{
+			name:          "default ldap no protos",
+			tlsConfigFunc: DefaultLDAP,
+			tlsConfig: &tls.Config{
+				ServerName: "something-to-check-passthrough",
+			},
+			want: &tls.Config{
+				ServerName: "something-to-check-passthrough",
+				MinVersion: tls.VersionTLS12,
+				CipherSuites: []uint16{
+					tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+					tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA, //nolint: gosec  // yeah, I know it is a bad cipher, but AD sucks
+					tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+					tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+				},
+				NextProtos: []string{"h2", "http/1.1"},
+			},
+		},
+		{
+			name:          "default ldap with protos",
+			tlsConfigFunc: DefaultLDAP,
+			tlsConfig: &tls.Config{
+				ServerName: "a different thing for passthrough",
+				NextProtos: []string{"panda"},
+			},
+			want: &tls.Config{
+				ServerName: "a different thing for passthrough",
+				MinVersion: tls.VersionTLS12,
+				CipherSuites: []uint16{
+					tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+					tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA, //nolint: gosec  // yeah, I know it is a bad cipher, but AD sucks
+					tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+					tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+				},
+				NextProtos: []string{"panda"},
+			},
+		},
+		{
+			name:          "legacy no protos",
+			tlsConfigFunc: Legacy,
+			tlsConfig: &tls.Config{
+				ServerName: "something-to-check-passthrough",
+			},
+			want: &tls.Config{
+				ServerName: "something-to-check-passthrough",
+				MinVersion: tls.VersionTLS12,
+				CipherSuites: []uint16{
+					tls.TLS_RSA_WITH_AES_128_CBC_SHA, //nolint: gosec  // yeah, I know it is a bad cipher, this is the legacy config
+					tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+					tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_AES_128_GCM_SHA256,
+					tls.TLS_AES_256_GCM_SHA384,
+					tls.TLS_CHACHA20_POLY1305_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+					tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+					tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+				},
+				NextProtos: []string{"h2", "http/1.1"},
+			},
+		},
+		{
+			name:          "legacy with protos",
+			tlsConfigFunc: Legacy,
+			tlsConfig: &tls.Config{
+				ServerName: "a different thing for passthrough",
+				NextProtos: []string{"panda"},
+			},
+			want: &tls.Config{
+				ServerName: "a different thing for passthrough",
+				MinVersion: tls.VersionTLS12,
+				CipherSuites: []uint16{
+					tls.TLS_RSA_WITH_AES_128_CBC_SHA, //nolint: gosec  // yeah, I know it is a bad cipher, this is the legacy config
+					tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+					tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_AES_128_GCM_SHA256,
+					tls.TLS_AES_256_GCM_SHA384,
+					tls.TLS_CHACHA20_POLY1305_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+					tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+					tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+				},
+				NextProtos: []string{"panda"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			Merge(tt.tlsConfigFunc, tt.tlsConfig)
+			require.Equal(t, tt.want, tt.tlsConfig)
+		})
+	}
+}

--- a/internal/dynamiccert/provider_test.go
+++ b/internal/dynamiccert/provider_test.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/names"
 
 	"go.pinniped.dev/internal/certauthority"
+	"go.pinniped.dev/internal/crypto/ptls"
 	"go.pinniped.dev/test/testlib"
 )
 
@@ -160,11 +161,8 @@ func TestProviderWithDynamicServingCertificateController(t *testing.T) {
 			err = certKeyContent.SetCertKeyContent(cert, key)
 			require.NoError(t, err)
 
-			tlsConfig := &tls.Config{
-				MinVersion: tls.VersionTLS12,
-				NextProtos: []string{"h2", "http/1.1"},
-				ClientAuth: tls.RequestClientCert,
-			}
+			tlsConfig := ptls.Default(nil)
+			tlsConfig.ClientAuth = tls.RequestClientCert
 
 			dynamicCertificateController := dynamiccertificates.NewDynamicServingCertificateController(
 				tlsConfig,

--- a/internal/httputil/roundtripper/roundtripper.go
+++ b/internal/httputil/roundtripper/roundtripper.go
@@ -3,7 +3,11 @@
 
 package roundtripper
 
-import "net/http"
+import (
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/util/net"
+)
 
 var _ http.RoundTripper = Func(nil)
 
@@ -11,4 +15,23 @@ type Func func(*http.Request) (*http.Response, error)
 
 func (f Func) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
+}
+
+var _ net.RoundTripperWrapper = &wrapper{}
+
+type wrapper struct {
+	delegate http.RoundTripper
+	f        Func
+}
+
+func (w *wrapper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return w.f.RoundTrip(req)
+}
+
+func (w *wrapper) WrappedRoundTripper() http.RoundTripper {
+	return w.delegate
+}
+
+func WrapFunc(delegate http.RoundTripper, f Func) net.RoundTripperWrapper {
+	return &wrapper{delegate: delegate, f: f}
 }

--- a/internal/kubeclient/roundtrip.go
+++ b/internal/kubeclient/roundtrip.go
@@ -20,6 +20,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/transport"
 
+	"go.pinniped.dev/internal/httputil/roundtripper"
 	"go.pinniped.dev/internal/plog"
 )
 
@@ -78,7 +79,7 @@ func newWrapper(
 	middlewares []Middleware,
 ) transport.WrapperFunc {
 	return func(rt http.RoundTripper) http.RoundTripper {
-		return roundTripperFunc(func(req *http.Request) (bool, *http.Response, error) {
+		return roundtripper.WrapFunc(rt, roundTripperFunc(func(req *http.Request) (bool, *http.Response, error) {
 			reqInfo, err := resolver.NewRequestInfo(reqWithoutPrefix(req, hostURL, apiPathPrefix))
 			if err != nil || !reqInfo.IsResourceRequest {
 				resp, err := rt.RoundTrip(req) // we only handle kube resource requests
@@ -120,7 +121,7 @@ func newWrapper(
 				resp, err := rt.RoundTrip(req) // we only handle certain verbs
 				return false, resp, err
 			}
-		})
+		}).RoundTrip)
 	}
 }
 

--- a/internal/net/phttp/debug.go
+++ b/internal/net/phttp/debug.go
@@ -1,0 +1,118 @@
+// Copyright 2021 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package phttp
+
+import (
+	"net/http"
+	"net/url"
+
+	"k8s.io/client-go/transport"
+
+	"go.pinniped.dev/internal/httputil/roundtripper"
+)
+
+func safeDebugWrappers(rt http.RoundTripper, f transport.WrapperFunc, shouldLog func() bool) http.RoundTripper {
+	return roundtripper.WrapFunc(rt, func(req *http.Request) (*http.Response, error) {
+		// minor optimization to avoid the cleaning logic when the debug wrappers are unused
+		// note: do not make this entire wrapper conditional on shouldLog() - the output is allowed to change at runtime
+		if !shouldLog() {
+			return rt.RoundTrip(req)
+		}
+
+		var (
+			resp *http.Response
+			err  error
+		)
+		debugRT := f(roundtripper.Func(func(_ *http.Request) (*http.Response, error) {
+			// this call needs to be inside this closure so that the debug wrappers can time it
+			// note also that it takes the original (real) request
+			resp, err = rt.RoundTrip(req)
+
+			cleanedResp := cleanResp(resp) // do not leak the user's password during the password grant
+
+			return cleanedResp, err
+		}))
+
+		// run the debug wrappers for their side effects (i.e. logging)
+		// the output is ignored because the input is not the real request
+		cleanedReq := cleanReq(req) // do not leak the user's password during the password grant
+		_, _ = debugRT.RoundTrip(cleanedReq)
+
+		return resp, err
+	})
+}
+
+func cleanReq(req *http.Request) *http.Request {
+	// only pass back things we know to be safe to log
+	return &http.Request{
+		Method: req.Method,
+		URL:    cleanURL(req.URL),
+		Header: cleanHeader(req.Header),
+	}
+}
+
+func cleanResp(resp *http.Response) *http.Response {
+	if resp == nil {
+		return nil
+	}
+
+	// only pass back things we know to be safe to log
+	return &http.Response{
+		Status: resp.Status,
+		Header: cleanHeader(resp.Header),
+	}
+}
+
+func cleanURL(u *url.URL) *url.URL {
+	var user *url.Userinfo
+	if len(u.User.Username()) > 0 {
+		user = url.User("masked_username")
+	}
+
+	var opaque string
+	if len(u.Opaque) > 0 {
+		opaque = "masked_opaque_data"
+	}
+
+	var fragment string
+	if len(u.Fragment) > 0 || len(u.RawFragment) > 0 {
+		fragment = "masked_fragment"
+	}
+
+	// only pass back things we know to be safe to log
+	return &url.URL{
+		Scheme:     u.Scheme,
+		Opaque:     opaque,
+		User:       user,
+		Host:       u.Host,
+		Path:       u.Path,
+		RawPath:    u.RawPath,
+		ForceQuery: u.ForceQuery,
+		RawQuery:   cleanQuery(u.Query()),
+		Fragment:   fragment,
+	}
+}
+
+func cleanQuery(query url.Values) string {
+	if len(query) == 0 {
+		return ""
+	}
+
+	out := url.Values(cleanHeader(http.Header(query))) // cast so we can re-use logic
+	return out.Encode()
+}
+
+func cleanHeader(header http.Header) http.Header {
+	if len(header) == 0 {
+		return nil
+	}
+
+	mask := []string{"masked_value"}
+	out := make(http.Header, len(header))
+	for key := range header {
+		out[key] = mask // only copy the keys
+	}
+
+	return out
+}

--- a/internal/net/phttp/debug_test.go
+++ b/internal/net/phttp/debug_test.go
@@ -1,0 +1,340 @@
+// Copyright 2021 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package phttp
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.pinniped.dev/internal/constable"
+	"go.pinniped.dev/internal/httputil/roundtripper"
+)
+
+func Test_safeDebugWrappers_shouldLog(t *testing.T) {
+	t.Parallel()
+
+	var rtFuncCalled, wrapFuncCalled, innerRTCalled int
+	var shouldLog, skipInnerRT bool
+
+	shouldLogFunc := func() bool { return shouldLog }
+
+	rtFunc := roundtripper.Func(func(_ *http.Request) (*http.Response, error) {
+		rtFuncCalled++
+		return nil, nil
+	})
+
+	wrapFunc := func(rt http.RoundTripper) http.RoundTripper {
+		wrapFuncCalled++
+		return roundtripper.Func(func(r *http.Request) (*http.Response, error) {
+			innerRTCalled++
+			if skipInnerRT {
+				return nil, nil
+			}
+			return rt.RoundTrip(r)
+		})
+	}
+
+	r := testReq(t, nil, nil)
+
+	out := safeDebugWrappers(rtFunc, wrapFunc, shouldLogFunc)
+
+	// assert that shouldLogFunc is dynamically honored
+
+	_, _ = out.RoundTrip(r) //nolint:bodyclose
+
+	require.Equal(t, 1, rtFuncCalled)
+	require.Equal(t, 0, wrapFuncCalled)
+	require.Equal(t, 0, innerRTCalled)
+
+	shouldLog = true
+
+	_, _ = out.RoundTrip(r) //nolint:bodyclose
+
+	require.Equal(t, 2, rtFuncCalled)
+	require.Equal(t, 1, wrapFuncCalled)
+	require.Equal(t, 1, innerRTCalled)
+
+	shouldLog = false
+
+	_, _ = out.RoundTrip(r) //nolint:bodyclose
+
+	require.Equal(t, 3, rtFuncCalled)
+	require.Equal(t, 1, wrapFuncCalled)
+	require.Equal(t, 1, innerRTCalled)
+
+	shouldLog = true
+
+	_, _ = out.RoundTrip(r) //nolint:bodyclose
+
+	require.Equal(t, 4, rtFuncCalled)
+	require.Equal(t, 2, wrapFuncCalled)
+	require.Equal(t, 2, innerRTCalled)
+
+	// assert that wrapFunc controls rtFunc being called
+
+	skipInnerRT = true
+
+	_, _ = out.RoundTrip(r) //nolint:bodyclose
+
+	require.Equal(t, 4, rtFuncCalled)
+	require.Equal(t, 3, wrapFuncCalled)
+	require.Equal(t, 3, innerRTCalled)
+
+	skipInnerRT = false
+
+	_, _ = out.RoundTrip(r) //nolint:bodyclose
+
+	require.Equal(t, 5, rtFuncCalled)
+	require.Equal(t, 4, wrapFuncCalled)
+	require.Equal(t, 4, innerRTCalled)
+}
+
+func Test_safeDebugWrappers_clean(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		shouldLog        bool
+		inReq, wantReq   *http.Request
+		inResp, wantResp *http.Response
+		inErr            error
+	}{
+		{
+			name:      "header cleaned",
+			shouldLog: true,
+			inReq:     testReq(t, http.Header{"hello": {"from", "earth"}}, nil),
+			wantReq:   testCleanReq(http.Header{"hello": {"masked_value"}}, nil),
+			inResp:    testResp(t, http.Header{"bye": {"for", "now"}}),     //nolint:bodyclose
+			wantResp:  testCleanResp(http.Header{"bye": {"masked_value"}}), //nolint:bodyclose
+			inErr:     nil,
+		},
+		{
+			name:      "header cleaned error",
+			shouldLog: true,
+			inReq:     testReq(t, http.Header{"see": {"from", "mars"}}, nil),
+			wantReq:   testCleanReq(http.Header{"see": {"masked_value"}}, nil),
+			inResp:    testResp(t, http.Header{"bear": {"is", "a"}}),        //nolint:bodyclose
+			wantResp:  testCleanResp(http.Header{"bear": {"masked_value"}}), //nolint:bodyclose
+			inErr:     constable.Error("some error"),
+		},
+		{
+			name:      "header cleaned error nil resp",
+			shouldLog: true,
+			inReq:     testReq(t, http.Header{"see": {"from", "mars"}}, nil),
+			wantReq:   testCleanReq(http.Header{"see": {"masked_value"}}, nil),
+			inResp:    nil,
+			wantResp:  nil,
+			inErr:     constable.Error("some other error"),
+		},
+		{
+			name:      "header cleaned no log",
+			shouldLog: false,
+			inReq:     testReq(t, http.Header{"sky": {"is", "blue"}}, nil),
+			wantReq:   nil,
+			inResp:    testResp(t, http.Header{"night": {"is", "dark"}}), //nolint:bodyclose
+			wantResp:  nil,
+			inErr:     nil,
+		},
+		{
+			name:      "url cleaned, all fields",
+			shouldLog: true,
+			inReq: testReq(t, nil, &url.URL{
+				Scheme:      "sc",
+				Opaque:      "op",
+				User:        url.UserPassword("us", "pa"),
+				Host:        "ho",
+				Path:        "pa",
+				RawPath:     "rap",
+				ForceQuery:  true,
+				RawQuery:    "key1=val1&key2=val2",
+				Fragment:    "fra",
+				RawFragment: "rawf",
+			}),
+			wantReq: testCleanReq(nil, &url.URL{
+				Scheme:      "sc",
+				Opaque:      "masked_opaque_data",
+				User:        url.User("masked_username"),
+				Host:        "ho",
+				Path:        "pa",
+				RawPath:     "rap",
+				ForceQuery:  true,
+				RawQuery:    "key1=masked_value&key2=masked_value",
+				Fragment:    "masked_fragment",
+				RawFragment: "",
+			}),
+			inResp:   testResp(t, http.Header{"sun": {"yellow"}}),         //nolint:bodyclose
+			wantResp: testCleanResp(http.Header{"sun": {"masked_value"}}), //nolint:bodyclose
+			inErr:    nil,
+		},
+		{
+			name:      "url cleaned, some fields",
+			shouldLog: true,
+			inReq: testReq(t, nil, &url.URL{
+				Scheme:      "sc",
+				Opaque:      "",
+				User:        nil,
+				Host:        "ho",
+				Path:        "pa",
+				RawPath:     "rap",
+				ForceQuery:  false,
+				RawQuery:    "key3=val3&key4=val4",
+				Fragment:    "",
+				RawFragment: "",
+			}),
+			wantReq: testCleanReq(nil, &url.URL{
+				Scheme:      "sc",
+				Opaque:      "",
+				User:        nil,
+				Host:        "ho",
+				Path:        "pa",
+				RawPath:     "rap",
+				ForceQuery:  false,
+				RawQuery:    "key3=masked_value&key4=masked_value",
+				Fragment:    "",
+				RawFragment: "",
+			}),
+			inResp:   testResp(t, http.Header{"sun": {"yellow"}}),         //nolint:bodyclose
+			wantResp: testCleanResp(http.Header{"sun": {"masked_value"}}), //nolint:bodyclose
+			inErr:    nil,
+		},
+		{
+			name:      "header and url cleaned, all fields with error",
+			shouldLog: true,
+			inReq: testReq(t, http.Header{"zone": {"of", "the", "enders"}, "welcome": {"home"}}, &url.URL{
+				Scheme:      "sc2",
+				Opaque:      "op2",
+				User:        url.UserPassword("us2", "pa2"),
+				Host:        "ho2",
+				Path:        "pa2",
+				RawPath:     "rap2",
+				ForceQuery:  true,
+				RawQuery:    "a=b&c=d&e=f&a=1&a=2",
+				Fragment:    "fra2",
+				RawFragment: "rawf2",
+			}),
+			wantReq: testCleanReq(http.Header{"zone": {"masked_value"}, "welcome": {"masked_value"}}, &url.URL{
+				Scheme:      "sc2",
+				Opaque:      "masked_opaque_data",
+				User:        url.User("masked_username"),
+				Host:        "ho2",
+				Path:        "pa2",
+				RawPath:     "rap2",
+				ForceQuery:  true,
+				RawQuery:    "a=masked_value&c=masked_value&e=masked_value",
+				Fragment:    "masked_fragment",
+				RawFragment: "",
+			}),
+			inResp:   testResp(t, http.Header{"moon": {"white"}}),          //nolint:bodyclose
+			wantResp: testCleanResp(http.Header{"moon": {"masked_value"}}), //nolint:bodyclose
+			inErr:    constable.Error("yay pandas"),
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var rtCalled, wrapCalled, innerCalled bool
+
+			rtFunc := roundtripper.Func(func(r *http.Request) (*http.Response, error) {
+				rtCalled = true
+				require.Equal(t, tt.inReq, r)
+				return tt.inResp, tt.inErr
+			})
+
+			var gotReq *http.Request
+			var gotResp *http.Response
+			var gotErr error
+
+			wrapFunc := func(rt http.RoundTripper) http.RoundTripper {
+				wrapCalled = true
+				return roundtripper.Func(func(r *http.Request) (*http.Response, error) {
+					innerCalled = true
+
+					gotReq = r
+
+					resp, err := rt.RoundTrip(r) //nolint:bodyclose
+
+					gotResp = resp
+					gotErr = err
+
+					return resp, err
+				})
+			}
+
+			out := safeDebugWrappers(rtFunc, wrapFunc, func() bool { return tt.shouldLog })
+
+			resp, err := out.RoundTrip(tt.inReq) //nolint:bodyclose
+
+			require.Equal(t, tt.inResp, resp)
+			require.Equal(t, tt.inErr, err)
+			require.True(t, rtCalled)
+			require.Equal(t, tt.shouldLog, wrapCalled)
+			require.Equal(t, tt.shouldLog, innerCalled)
+
+			require.Equal(t, tt.wantReq, gotReq)
+			require.Equal(t, tt.wantResp, gotResp)
+			require.Equal(t, tt.inErr, gotErr)
+		})
+	}
+}
+
+func testReq(t *testing.T, header http.Header, u *url.URL) *http.Request {
+	t.Helper()
+
+	r, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://overwritten.com", nil)
+	require.NoError(t, err)
+
+	if u == nil {
+		u = &url.URL{}
+	}
+
+	r.URL = u
+	r.Header = header
+
+	// something non-nil for testing
+	r.Body = io.NopCloser(&bytes.Buffer{})
+	r.Form = url.Values{"a": {"b"}}
+	r.PostForm = url.Values{"c": {"d"}}
+
+	return r
+}
+
+func testResp(t *testing.T, header http.Header) *http.Response {
+	t.Helper()
+
+	return &http.Response{
+		Status: "pandas are the best",
+		Header: header,
+
+		// something non-nil for testing
+		Body:    io.NopCloser(&bytes.Buffer{}),
+		Request: testReq(t, header, nil),
+	}
+}
+
+func testCleanReq(header http.Header, u *url.URL) *http.Request {
+	if u == nil {
+		u = &url.URL{}
+	}
+
+	return &http.Request{
+		Method: http.MethodGet,
+		URL:    u,
+		Header: header,
+	}
+}
+
+func testCleanResp(header http.Header) *http.Response {
+	return &http.Response{
+		Status: "pandas are the best",
+		Header: header,
+	}
+}

--- a/internal/net/phttp/phttp.go
+++ b/internal/net/phttp/phttp.go
@@ -1,0 +1,48 @@
+// Copyright 2021 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package phttp
+
+import (
+	"crypto/x509"
+	"net/http"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/transport"
+
+	"go.pinniped.dev/internal/crypto/ptls"
+	"go.pinniped.dev/internal/plog"
+)
+
+func Default(rootCAs *x509.CertPool) *http.Client {
+	return buildClient(ptls.Default, rootCAs)
+}
+
+func Secure(rootCAs *x509.CertPool) *http.Client {
+	return buildClient(ptls.Secure, rootCAs)
+}
+
+func buildClient(tlsConfigFunc ptls.ConfigFunc, rootCAs *x509.CertPool) *http.Client {
+	baseRT := defaultTransport()
+	baseRT.TLSClientConfig = tlsConfigFunc(rootCAs)
+
+	return &http.Client{
+		Transport: defaultWrap(baseRT),
+		Timeout:   3 * time.Hour, // make it impossible for requests to hang indefinitely
+	}
+}
+
+func defaultTransport() *http.Transport {
+	baseRT := http.DefaultTransport.(*http.Transport).Clone()
+	net.SetTransportDefaults(baseRT)
+	baseRT.MaxIdleConnsPerHost = 25 // copied from client-go
+	return baseRT
+}
+
+func defaultWrap(rt http.RoundTripper) http.RoundTripper {
+	rt = safeDebugWrappers(rt, transport.DebugWrappers, func() bool { return plog.Enabled(plog.LevelTrace) })
+	rt = transport.NewUserAgentRoundTripper(rest.DefaultKubernetesUserAgent(), rt)
+	return rt
+}

--- a/internal/net/phttp/phttp_test.go
+++ b/internal/net/phttp/phttp_test.go
@@ -1,0 +1,116 @@
+// Copyright 2021 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package phttp
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/client-go/util/cert"
+
+	"go.pinniped.dev/internal/crypto/ptls"
+	"go.pinniped.dev/internal/testutil/tlsserver"
+)
+
+// TestUnwrap ensures that the http.Client structs returned by this package contain
+// a transport that can be fully unwrapped to get access to the underlying TLS config.
+func TestUnwrap(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		f    func(*x509.CertPool) *http.Client
+	}{
+		{
+			name: "default",
+			f:    Default,
+		},
+		{
+			name: "secure",
+			f:    Secure,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			p, err := x509.SystemCertPool()
+			require.NoError(t, err)
+
+			c := tt.f(p)
+
+			tlsConfig, err := net.TLSClientConfig(c.Transport)
+			require.NoError(t, err)
+			require.NotNil(t, tlsConfig)
+
+			require.NotEmpty(t, tlsConfig.NextProtos)
+			require.GreaterOrEqual(t, tlsConfig.MinVersion, uint16(tls.VersionTLS12))
+			require.Equal(t, p, tlsConfig.RootCAs)
+		})
+	}
+}
+
+func TestClient(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		clientFunc func(*x509.CertPool) *http.Client
+		configFunc ptls.ConfigFunc
+	}{
+		{
+			name:       "default",
+			clientFunc: Default,
+			configFunc: ptls.Default,
+		},
+		{
+			name:       "secure",
+			clientFunc: Secure,
+			configFunc: ptls.Secure,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var sawRequest bool
+			server := tlsserver.TLSTestServer(t, http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				tlsserver.AssertTLS(t, r, tt.configFunc)
+				assertUserAgent(t, r)
+				sawRequest = true
+			}), tlsserver.RecordTLSHello)
+
+			rootCAs, err := cert.NewPoolFromBytes(tlsserver.TLSTestServerCA(server))
+			require.NoError(t, err)
+
+			c := tt.clientFunc(rootCAs)
+
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
+			require.NoError(t, err)
+
+			resp, err := c.Do(req)
+			require.NoError(t, err)
+			require.NoError(t, resp.Body.Close())
+
+			require.True(t, sawRequest)
+		})
+	}
+}
+
+func assertUserAgent(t *testing.T, r *http.Request) {
+	t.Helper()
+
+	ua := r.Header.Get("user-agent")
+
+	// use assert instead of require to not break the http.Handler with a panic
+	assert.Contains(t, ua, ") kubernetes/")
+}

--- a/internal/oidc/downstreamsession/downstream_session.go
+++ b/internal/oidc/downstreamsession/downstream_session.go
@@ -9,7 +9,7 @@ import (
 	"net/url"
 	"time"
 
-	oidc2 "github.com/coreos/go-oidc/v3/oidc"
+	coreosoidc "github.com/coreos/go-oidc/v3/oidc"
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/handler/openid"
 	"github.com/ory/fosite/token/jwt"
@@ -60,8 +60,8 @@ func MakeDownstreamSession(subject string, username string, groups []string, cus
 
 // GrantScopesIfRequested auto-grants the scopes for which we do not require end-user approval, if they were requested.
 func GrantScopesIfRequested(authorizeRequester fosite.AuthorizeRequester) {
-	oidc.GrantScopeIfRequested(authorizeRequester, oidc2.ScopeOpenID)
-	oidc.GrantScopeIfRequested(authorizeRequester, oidc2.ScopeOfflineAccess)
+	oidc.GrantScopeIfRequested(authorizeRequester, coreosoidc.ScopeOpenID)
+	oidc.GrantScopeIfRequested(authorizeRequester, coreosoidc.ScopeOfflineAccess)
 	oidc.GrantScopeIfRequested(authorizeRequester, "pinniped:request-audience")
 }
 

--- a/internal/plog/klog.go
+++ b/internal/plog/klog.go
@@ -33,7 +33,7 @@ func RemoveKlogGlobalFlags() {
 	}
 }
 
-// KRef is (mostly) copied from klog - it is a standard way to represent a a metav1.Object in logs
+// KRef is (mostly) copied from klog - it is a standard way to represent a metav1.Object in logs
 // when you only have access to the namespace and name of the object.
 func KRef(namespace, name string) string {
 	return fmt.Sprintf("%s/%s", namespace, name)
@@ -44,33 +44,19 @@ func KObj(obj klog.KMetadata) string {
 	return fmt.Sprintf("%s/%s", obj.GetNamespace(), obj.GetName())
 }
 
-func klogLevelForPlogLevel(plogLevel LogLevel) (klogLevel klog.Level) {
+func klogLevelForPlogLevel(plogLevel LogLevel) klog.Level {
 	switch plogLevel {
 	case LevelWarning:
-		klogLevel = klogLevelWarning // unset means minimal logs (Error and Warning)
+		return klogLevelWarning // unset means minimal logs (Error and Warning)
 	case LevelInfo:
-		klogLevel = klogLevelInfo
+		return klogLevelInfo
 	case LevelDebug:
-		klogLevel = klogLevelDebug
+		return klogLevelDebug
 	case LevelTrace:
-		klogLevel = klogLevelTrace
+		return klogLevelTrace
 	case LevelAll:
-		klogLevel = klogLevelAll + 100 // make all really mean all
+		return klogLevelAll + 100 // make all really mean all
 	default:
-		klogLevel = -1
+		return -1
 	}
-
-	return
-}
-
-func getKlogLevel() klog.Level {
-	// hack around klog not exposing a Get method
-	for i := klog.Level(0); i < 256; i++ {
-		if klog.V(i).Enabled() {
-			continue
-		}
-		return i - 1
-	}
-
-	return -1
 }

--- a/internal/plog/level.go
+++ b/internal/plog/level.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"k8s.io/component-base/logs"
+	"k8s.io/klog/v2"
 
 	"go.pinniped.dev/internal/constable"
 )
@@ -54,5 +55,5 @@ func ValidateAndSetLogLevelGlobally(level LogLevel) error {
 // Enabled returns whether the provided plog level is enabled, i.e., whether print statements at the
 // provided level will show up.
 func Enabled(level LogLevel) bool {
-	return getKlogLevel() >= klogLevelForPlogLevel(level)
+	return klog.V(klogLevelForPlogLevel(level)).Enabled()
 }

--- a/internal/plog/level_test.go
+++ b/internal/plog/level_test.go
@@ -114,3 +114,15 @@ func undoGlobalLogLevelChanges(t *testing.T, originalLogLevel klog.Level) {
 	_, err := logs.GlogSetter(strconv.Itoa(int(originalLogLevel)))
 	require.NoError(t, err)
 }
+
+func getKlogLevel() klog.Level {
+	// hack around klog not exposing a Get method
+	for i := klog.Level(0); i < 256; i++ {
+		if klog.V(i).Enabled() {
+			continue
+		}
+		return i - 1
+	}
+
+	return -1
+}

--- a/internal/testutil/tlsserver/tlsserver.go
+++ b/internal/testutil/tlsserver/tlsserver.go
@@ -1,0 +1,110 @@
+// Copyright 2021 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package tlsserver
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/pem"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+
+	"go.pinniped.dev/internal/crypto/ptls"
+)
+
+type ctxKey int
+
+const (
+	mapKey ctxKey = iota + 1
+	helloKey
+)
+
+func TLSTestServer(t *testing.T, handler http.Handler, f func(*httptest.Server)) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewUnstartedServer(handler)
+	server.TLS = ptls.Default(nil) // mimic API server config
+	if f != nil {
+		f(server)
+	}
+	server.StartTLS()
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TLSTestServerCA(server *httptest.Server) []byte {
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: server.Certificate().Raw,
+	})
+}
+
+func RecordTLSHello(server *httptest.Server) {
+	server.Config.ConnContext = func(ctx context.Context, _ net.Conn) context.Context {
+		return context.WithValue(ctx, mapKey, &sync.Map{})
+	}
+
+	server.TLS.GetConfigForClient = func(info *tls.ClientHelloInfo) (*tls.Config, error) {
+		m, ok := getCtxMap(info.Context())
+		if !ok {
+			return nil, fmt.Errorf("could not find ctx map")
+		}
+		if actual, loaded := m.LoadOrStore(helloKey, info); loaded && !reflect.DeepEqual(info, actual) {
+			return nil, fmt.Errorf("different client hello seen")
+		}
+		return nil, nil
+	}
+}
+
+func AssertTLS(t *testing.T, r *http.Request, tlsConfigFunc ptls.ConfigFunc) {
+	t.Helper()
+
+	m, ok := getCtxMap(r.Context())
+	require.True(t, ok)
+
+	h, ok := m.Load(helloKey)
+	require.True(t, ok)
+
+	info, ok := h.(*tls.ClientHelloInfo)
+	require.True(t, ok)
+
+	tlsConfig := tlsConfigFunc(nil)
+
+	supportedVersions := []uint16{tlsConfig.MinVersion}
+	ciphers := tlsConfig.CipherSuites
+
+	if secureTLSConfig := ptls.Secure(nil); tlsConfig.MinVersion != secureTLSConfig.MinVersion {
+		supportedVersions = append([]uint16{secureTLSConfig.MinVersion}, supportedVersions...)
+		ciphers = append(ciphers, secureTLSConfig.CipherSuites...)
+	}
+
+	protos := tlsConfig.NextProtos
+	if httpstream.IsUpgradeRequest(r) {
+		protos = tlsConfig.NextProtos[1:]
+	}
+
+	// use assert instead of require to not break the http.Handler with a panic
+	ok1 := assert.Equal(t, supportedVersions, info.SupportedVersions)
+	ok2 := assert.Equal(t, ciphers, info.CipherSuites)
+	ok3 := assert.Equal(t, protos, info.SupportedProtos)
+
+	if all := ok1 && ok2 && ok3; !all {
+		t.Errorf("insecure TLS detected for %q %q %q upgrade=%v supportedVersions=%v ciphers=%v protos=%v",
+			r.Proto, r.Method, r.URL.String(), httpstream.IsUpgradeRequest(r), ok1, ok2, ok3)
+	}
+}
+
+func getCtxMap(ctx context.Context) (*sync.Map, bool) {
+	m, ok := ctx.Value(mapKey).(*sync.Map)
+	return m, ok
+}

--- a/internal/upstreamldap/upstreamldap.go
+++ b/internal/upstreamldap/upstreamldap.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/utils/trace"
 
 	"go.pinniped.dev/internal/authenticators"
+	"go.pinniped.dev/internal/crypto/ptls"
 	"go.pinniped.dev/internal/endpointaddr"
 	"go.pinniped.dev/internal/oidc/downstreamsession"
 	"go.pinniped.dev/internal/oidc/provider"
@@ -328,7 +329,7 @@ func (p *Provider) tlsConfig() (*tls.Config, error) {
 			return nil, fmt.Errorf("could not parse CA bundle")
 		}
 	}
-	return &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: rootCAs}, nil
+	return ptls.DefaultLDAP(rootCAs), nil
 }
 
 // A name for this upstream provider.

--- a/pkg/oidcclient/login.go
+++ b/pkg/oidcclient/login.go
@@ -31,6 +31,7 @@ import (
 	supervisoroidc "go.pinniped.dev/generated/latest/apis/supervisor/oidc"
 	"go.pinniped.dev/internal/httputil/httperr"
 	"go.pinniped.dev/internal/httputil/securityheader"
+	"go.pinniped.dev/internal/net/phttp"
 	"go.pinniped.dev/internal/oidc/provider"
 	"go.pinniped.dev/internal/upstreamoidc"
 	"go.pinniped.dev/pkg/oidcclient/nonce"
@@ -274,7 +275,7 @@ func Login(issuer string, clientID string, opts ...Option) (*oidctypes.Token, er
 		ctx:          context.Background(),
 		logger:       logr.Discard(), // discard logs unless a logger is specified
 		callbacks:    make(chan callbackResult, 2),
-		httpClient:   http.DefaultClient,
+		httpClient:   phttp.Default(nil),
 
 		// Default implementations of external dependencies (to be mocked in tests).
 		generateState: state.Generate,

--- a/test/integration/cli_test.go
+++ b/test/integration/cli_test.go
@@ -108,7 +108,14 @@ func TestCLIGetKubeconfigStaticToken_Parallel(t *testing.T) {
 	})
 }
 
-func runPinnipedCLI(t *testing.T, envVars []string, pinnipedExe string, args ...string) (string, string) {
+type testingT interface {
+	Helper()
+	Errorf(format string, args ...interface{})
+	FailNow()
+	Logf(format string, args ...interface{})
+}
+
+func runPinnipedCLI(t testingT, envVars []string, pinnipedExe string, args ...string) (string, string) {
 	t.Helper()
 	start := time.Now()
 	var stdout, stderr bytes.Buffer

--- a/test/integration/concierge_credentialrequest_test.go
+++ b/test/integration/concierge_credentialrequest_test.go
@@ -45,8 +45,10 @@ func TestUnsuccessfulCredentialRequest_Parallel(t *testing.T) {
 	require.Equal(t, "authentication failed", *response.Status.Message)
 }
 
-// TCRs are non-mutating and safe to run in parallel with serial tests, see main_test.go.
-func TestSuccessfulCredentialRequest_Parallel(t *testing.T) {
+// TestSuccessfulCredentialRequest cannot run in parallel because runPinnipedLoginOIDC uses a fixed port
+// for its localhost listener via --listen-port=env.CLIUpstreamOIDC.CallbackURL.Port() per oidcLoginCommand.
+// Since ports are global to the process, tests using oidcLoginCommand must be run serially.
+func TestSuccessfulCredentialRequest(t *testing.T) {
 	env := testlib.IntegrationEnv(t).WithCapability(testlib.ClusterSigningKeyIsAvailable)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)

--- a/test/integration/concierge_impersonation_proxy_test.go
+++ b/test/integration/concierge_impersonation_proxy_test.go
@@ -65,6 +65,7 @@ import (
 	identityv1alpha1 "go.pinniped.dev/generated/latest/apis/concierge/identity/v1alpha1"
 	loginv1alpha1 "go.pinniped.dev/generated/latest/apis/concierge/login/v1alpha1"
 	pinnipedconciergeclientset "go.pinniped.dev/generated/latest/client/concierge/clientset/versioned"
+	"go.pinniped.dev/internal/crypto/ptls"
 	"go.pinniped.dev/internal/httputil/roundtripper"
 	"go.pinniped.dev/internal/kubeclient"
 	"go.pinniped.dev/internal/testutil"
@@ -305,20 +306,18 @@ func TestImpersonationProxy(t *testing.T) { //nolint:gocyclo // yeah, it's compl
 			Verb: "get", Group: "", Version: "v1", Resource: "namespaces",
 		})
 
-		// Get pods in concierge namespace and pick one.
-		// this is for tests that require performing actions against a running pod. We use the concierge pod because we already have it handy.
-		// We want to make sure it's a concierge pod (not cert agent), because we need to be able to port-forward a running port.
-		pods, err := adminClient.CoreV1().Pods(env.ConciergeNamespace).List(ctx, metav1.ListOptions{})
+		// Get pods in supervisor namespace and pick one.
+		// this is for tests that require performing actions against a running pod.
+		// We use the supervisor pod because we already have it handy and need to port-forward a running port.
+		// We avoid using the concierge for this because it requires TLS 1.3 which is not support by older versions of curl.
+		supervisorPods, err := adminClient.CoreV1().Pods(env.SupervisorNamespace).List(ctx,
+			metav1.ListOptions{LabelSelector: "deployment.pinniped.dev=supervisor"})
 		require.NoError(t, err)
-		require.Greater(t, len(pods.Items), 0)
-		var conciergePod *corev1.Pod
-		for _, pod := range pods.Items {
-			pod := pod
-			if !strings.Contains(pod.Name, "kube-cert-agent") {
-				conciergePod = &pod
-			}
-		}
-		require.NotNil(t, conciergePod, "could not find a concierge pod")
+		require.NotEmpty(t, supervisorPods.Items, "could not find supervisor pods")
+		supervisorPod := supervisorPods.Items[0]
+
+		// make sure the supervisor has a default TLS cert during this test so that it can handle a TLS connection
+		_ = createTLSCertificateSecret(ctx, t, env.SupervisorNamespace, "cert-hostname-doesnt-matter", nil, defaultTLSCertSecretName(env), adminClient)
 
 		// Test that the user can perform basic actions through the client with their username and group membership
 		// influencing RBAC checks correctly.
@@ -346,7 +345,7 @@ func TestImpersonationProxy(t *testing.T) { //nolint:gocyclo // yeah, it's compl
 			// Run the kubectl port-forward command.
 			timeout, cancelFunc := context.WithTimeout(ctx, 2*time.Minute)
 			defer cancelFunc()
-			portForwardCmd, _, portForwardStderr := kubectlCommand(timeout, t, kubeconfigPath, envVarsWithProxy, "port-forward", "--namespace", env.ConciergeNamespace, conciergePod.Name, "10443:8443")
+			portForwardCmd, _, portForwardStderr := kubectlCommand(timeout, t, kubeconfigPath, envVarsWithProxy, "port-forward", "--namespace", supervisorPod.Namespace, supervisorPod.Name, "10443:8443")
 			portForwardCmd.Env = envVarsWithProxy
 
 			// Start, but don't wait for the command to finish.
@@ -366,7 +365,7 @@ func TestImpersonationProxy(t *testing.T) { //nolint:gocyclo // yeah, it's compl
 			defer cancelFunc()
 			startTime := time.Now()
 			for time.Now().Before(startTime.Add(70 * time.Second)) {
-				curlCmd := exec.CommandContext(timeout, "curl", "-k", "-sS", "https://127.0.0.1:10443") // -sS turns off the progressbar but still prints errors
+				curlCmd := exec.CommandContext(timeout, "curl", "-k", "-sS", "https://127.0.0.1:10443/healthz") // -sS turns off the progressbar but still prints errors
 				curlCmd.Stdout = &curlStdOut
 				curlCmd.Stderr = &curlStdErr
 				curlErr := curlCmd.Run()
@@ -382,7 +381,7 @@ func TestImpersonationProxy(t *testing.T) { //nolint:gocyclo // yeah, it's compl
 			// curl the endpoint once more, once 70 seconds has elapsed, to make sure the connection is still open.
 			timeout, cancelFunc = context.WithTimeout(ctx, 30*time.Second)
 			defer cancelFunc()
-			curlCmd := exec.CommandContext(timeout, "curl", "-k", "-sS", "https://127.0.0.1:10443") // -sS turns off the progressbar but still prints errors
+			curlCmd := exec.CommandContext(timeout, "curl", "-k", "-sS", "https://127.0.0.1:10443/healthz") // -sS turns off the progressbar but still prints errors
 			curlCmd.Stdout = &curlStdOut
 			curlCmd.Stderr = &curlStdErr
 			curlErr := curlCmd.Run()
@@ -392,9 +391,8 @@ func TestImpersonationProxy(t *testing.T) { //nolint:gocyclo // yeah, it's compl
 				t.Log("curlStdErr: " + curlStdErr.String())
 				t.Log("stdout: " + curlStdOut.String())
 			}
-			// We expect this to 403, but all we care is that it gets through.
 			require.NoError(t, curlErr)
-			require.Contains(t, curlStdOut.String(), `"forbidden: User \"system:anonymous\" cannot get path \"/\""`)
+			require.Contains(t, curlStdOut.String(), "okokokokok") // a few successful healthz responses
 		})
 
 		t.Run("kubectl port-forward and keeping the connection open for over a minute (idle)", func(t *testing.T) {
@@ -404,7 +402,7 @@ func TestImpersonationProxy(t *testing.T) { //nolint:gocyclo // yeah, it's compl
 			// Run the kubectl port-forward command.
 			timeout, cancelFunc := context.WithTimeout(ctx, 2*time.Minute)
 			defer cancelFunc()
-			portForwardCmd, _, portForwardStderr := kubectlCommand(timeout, t, kubeconfigPath, envVarsWithProxy, "port-forward", "--namespace", env.ConciergeNamespace, conciergePod.Name, "10444:8443")
+			portForwardCmd, _, portForwardStderr := kubectlCommand(timeout, t, kubeconfigPath, envVarsWithProxy, "port-forward", "--namespace", supervisorPod.Namespace, supervisorPod.Name, "10444:8443")
 			portForwardCmd.Env = envVarsWithProxy
 
 			// Start, but don't wait for the command to finish.
@@ -414,13 +412,13 @@ func TestImpersonationProxy(t *testing.T) { //nolint:gocyclo // yeah, it's compl
 				assert.EqualErrorf(t, portForwardCmd.Wait(), "signal: killed", `wanted "kubectl port-forward" to get signaled because context was cancelled (stderr: %q)`, portForwardStderr.String())
 			}()
 
-			// Wait to see if we time out. The default timeout is 60 seconds, but the server should recognize this this
+			// Wait to see if we time out. The default timeout is 60 seconds, but the server should recognize that this
 			// is going to be a long-running command and keep the connection open as long as the client stays connected.
 			time.Sleep(70 * time.Second)
 
 			timeout, cancelFunc = context.WithTimeout(ctx, 2*time.Minute)
 			defer cancelFunc()
-			curlCmd := exec.CommandContext(timeout, "curl", "-k", "-sS", "https://127.0.0.1:10444") // -sS turns off the progressbar but still prints errors
+			curlCmd := exec.CommandContext(timeout, "curl", "-k", "-sS", "https://127.0.0.1:10444/healthz") // -sS turns off the progressbar but still prints errors
 			var curlStdOut, curlStdErr bytes.Buffer
 			curlCmd.Stdout = &curlStdOut
 			curlCmd.Stderr = &curlStdErr
@@ -430,9 +428,8 @@ func TestImpersonationProxy(t *testing.T) { //nolint:gocyclo // yeah, it's compl
 				t.Log("curlStdErr: " + curlStdErr.String())
 				t.Log("stdout: " + curlStdOut.String())
 			}
-			// We expect this to 403, but all we care is that it gets through.
 			require.NoError(t, err)
-			require.Contains(t, curlStdOut.String(), `"forbidden: User \"system:anonymous\" cannot get path \"/\""`)
+			require.Equal(t, curlStdOut.String(), "ok")
 		})
 
 		t.Run("using and watching all the basic verbs", func(t *testing.T) {
@@ -760,7 +757,7 @@ func TestImpersonationProxy(t *testing.T) { //nolint:gocyclo // yeah, it's compl
 				clusterAdminCredentials, impersonationProxyURL, impersonationProxyCACertPEM, nil,
 			)
 			nestedImpersonationUIDOnly.Wrap(func(rt http.RoundTripper) http.RoundTripper {
-				return roundtripper.Func(func(r *http.Request) (*http.Response, error) {
+				return roundtripper.WrapFunc(rt, func(r *http.Request) (*http.Response, error) {
 					r.Header.Set("iMperSONATE-uid", "some-awesome-uid")
 					return rt.RoundTrip(r)
 				})
@@ -798,7 +795,7 @@ func TestImpersonationProxy(t *testing.T) { //nolint:gocyclo // yeah, it's compl
 				},
 			)
 			nestedImpersonationUID.Wrap(func(rt http.RoundTripper) http.RoundTripper {
-				return roundtripper.Func(func(r *http.Request) (*http.Response, error) {
+				return roundtripper.WrapFunc(rt, func(r *http.Request) (*http.Response, error) {
 					r.Header.Set("imperSONate-uiD", "some-fancy-uid")
 					return rt.RoundTrip(r)
 				})
@@ -1115,7 +1112,7 @@ func TestImpersonationProxy(t *testing.T) { //nolint:gocyclo // yeah, it's compl
 
 			// run the kubectl logs command
 			logLinesCount := 10
-			stdout, err = runKubectl(t, kubeconfigPath, envVarsWithProxy, "logs", "--namespace", conciergePod.Namespace, conciergePod.Name, fmt.Sprintf("--tail=%d", logLinesCount))
+			stdout, err = runKubectl(t, kubeconfigPath, envVarsWithProxy, "logs", "--namespace", supervisorPod.Namespace, supervisorPod.Name, fmt.Sprintf("--tail=%d", logLinesCount))
 			require.NoError(t, err, `"kubectl logs" failed`)
 			// Expect _approximately_ logLinesCount lines in the output
 			// (we can't match 100% exactly due to https://github.com/kubernetes/kubernetes/issues/72628).
@@ -1499,6 +1496,20 @@ func TestImpersonationProxy(t *testing.T) { //nolint:gocyclo // yeah, it's compl
 					require.Equal(t, &identityv1alpha1.WhoAmIRequest{}, whoAmI)
 				})
 			})
+		})
+
+		t.Run("assert impersonator runs with secure TLS config", func(t *testing.T) {
+			parallelIfNotEKS(t)
+
+			cancelCtx, cancel := context.WithCancel(ctx)
+			t.Cleanup(cancel)
+
+			startKubectlPortForward(cancelCtx, t, "10445", "443", env.ConciergeAppName+"-proxy", env.ConciergeNamespace)
+
+			stdout, stderr := runNmapSSLEnum(t, "127.0.0.1", 10445)
+
+			require.Empty(t, stderr)
+			require.Contains(t, stdout, getExpectedCiphers(ptls.Default), "stdout:\n%s", stdout)
 		})
 	})
 
@@ -1956,7 +1967,7 @@ func performImpersonatorDiscovery(ctx context.Context, t *testing.T, env *testli
 	// probe each pod directly for readiness since the concierge status is a lie - it just means a single pod is ready
 	testlib.RequireEventually(t, func(requireEventually *require.Assertions) {
 		pods, err := adminClient.CoreV1().Pods(env.ConciergeNamespace).List(ctx,
-			metav1.ListOptions{LabelSelector: "app=" + env.ConciergeAppName + ",!kube-cert-agent.pinniped.dev"}) // TODO replace with deployment.pinniped.dev=concierge
+			metav1.ListOptions{LabelSelector: "deployment.pinniped.dev=concierge"})
 		requireEventually.NoError(err)
 		requireEventually.Len(pods.Items, 2) // has to stay in sync with the defaults in our YAML
 
@@ -2373,7 +2384,7 @@ func getCredForConfig(t *testing.T, config *rest.Config) *loginv1alpha1.ClusterC
 	config = rest.CopyConfig(config)
 
 	config.Wrap(func(rt http.RoundTripper) http.RoundTripper {
-		return roundtripper.Func(func(req *http.Request) (*http.Response, error) {
+		return roundtripper.WrapFunc(rt, func(req *http.Request) (*http.Response, error) {
 			resp, err := rt.RoundTrip(req)
 
 			r := req

--- a/test/integration/ldap_client_test.go
+++ b/test/integration/ldap_client_test.go
@@ -759,8 +759,6 @@ func startLongRunningCommandAndWaitForInitialOutput(
 	cmd := exec.CommandContext(ctx, command, args...)
 
 	var stdoutBuf, stderrBuf syncBuffer
-	cmd.Stdout = &stdoutBuf
-	cmd.Stderr = &stderrBuf
 	cmd.Stdout = io.MultiWriter(os.Stdout, &stdoutBuf)
 	cmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
 

--- a/test/integration/securetls_test.go
+++ b/test/integration/securetls_test.go
@@ -1,0 +1,257 @@
+// Copyright 2021 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"go.pinniped.dev/internal/crypto/ptls"
+	"go.pinniped.dev/internal/testutil/tlsserver"
+	"go.pinniped.dev/test/testlib"
+)
+
+// TLS checks safe to run in parallel with serial tests, see main_test.go.
+func TestSecureTLSPinnipedCLIToKAS_Parallel(t *testing.T) {
+	_ = testlib.IntegrationEnv(t)
+
+	server := tlsserver.TLSTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tlsserver.AssertTLS(t, r, ptls.Secure) // pinniped CLI uses ptls.Secure when talking to KAS
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{"kind":"TokenCredentialRequest","apiVersion":"login.concierge.pinniped.dev/v1alpha1",`+
+			`"status":{"credential":{"token":"some-fancy-token"}}}`)
+	}), tlsserver.RecordTLSHello)
+
+	ca := tlsserver.TLSTestServerCA(server)
+
+	pinnipedExe := testlib.PinnipedCLIPath(t)
+
+	stdout, stderr := runPinnipedCLI(t, nil, pinnipedExe, "login", "static",
+		"--token", "does-not-matter",
+		"--concierge-authenticator-type", "webhook",
+		"--concierge-authenticator-name", "does-not-matter",
+		"--concierge-ca-bundle-data", base64.StdEncoding.EncodeToString(ca),
+		"--concierge-endpoint", server.URL,
+		"--enable-concierge",
+		"--credential-cache", "",
+	)
+
+	require.Empty(t, stderr)
+	require.Equal(t, `{"kind":"ExecCredential","apiVersion":"client.authentication.k8s.io/v1beta1",`+
+		`"spec":{"interactive":false},"status":{"expirationTimestamp":null,"token":"some-fancy-token"}}
+`, stdout)
+}
+
+// TLS checks safe to run in parallel with serial tests, see main_test.go.
+func TestSecureTLSPinnipedCLIToSupervisor_Parallel(t *testing.T) {
+	_ = testlib.IntegrationEnv(t)
+
+	server := tlsserver.TLSTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tlsserver.AssertTLS(t, r, ptls.Default) // pinniped CLI uses ptls.Default when talking to supervisor
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{"issuer":"https://not-a-good-issuer"}`)
+	}), tlsserver.RecordTLSHello)
+
+	ca := tlsserver.TLSTestServerCA(server)
+
+	pinnipedExe := testlib.PinnipedCLIPath(t)
+
+	stdout, stderr := runPinnipedCLI(&fakeT{T: t}, nil, pinnipedExe, "login", "oidc",
+		"--ca-bundle-data", base64.StdEncoding.EncodeToString(ca),
+		"--issuer", server.URL,
+		"--credential-cache", "",
+		"--upstream-identity-provider-flow", "cli_password",
+		"--upstream-identity-provider-name", "does-not-matter",
+		"--upstream-identity-provider-type", "oidc",
+	)
+
+	require.Equal(t, `Error: could not complete Pinniped login: could not perform OIDC discovery for "`+
+		server.URL+`": oidc: issuer did not match the issuer returned by provider, expected "`+
+		server.URL+`" got "https://not-a-good-issuer"
+`, stderr)
+	require.Empty(t, stdout)
+}
+
+// TLS checks safe to run in parallel with serial tests, see main_test.go.
+func TestSecureTLSConciergeAggregatedAPI_Parallel(t *testing.T) {
+	env := testlib.IntegrationEnv(t)
+
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	startKubectlPortForward(cancelCtx, t, "10446", "443", env.ConciergeAppName+"-api", env.ConciergeNamespace)
+
+	stdout, stderr := runNmapSSLEnum(t, "127.0.0.1", 10446)
+
+	require.Empty(t, stderr)
+	require.Contains(t, stdout, getExpectedCiphers(ptls.Secure), "stdout:\n%s", stdout)
+}
+
+func TestSecureTLSSupervisor(t *testing.T) { // does not run in parallel because of the createTLSCertificateSecret call
+	env := testlib.IntegrationEnv(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	adminClient := testlib.NewKubernetesClientset(t)
+	// make sure the supervisor has a default TLS cert during this test so that it can handle a TLS connection
+	_ = createTLSCertificateSecret(ctx, t, env.SupervisorNamespace, "cert-hostname-doesnt-matter", nil, defaultTLSCertSecretName(env), adminClient)
+
+	startKubectlPortForward(ctx, t, "10447", "443", env.SupervisorAppName+"-clusterip", env.SupervisorNamespace)
+
+	stdout, stderr := runNmapSSLEnum(t, "127.0.0.1", 10447)
+
+	// supervisor's cert is ECDSA
+	defaultECDSAOnly := func(rootCAs *x509.CertPool) *tls.Config {
+		c := ptls.Default(rootCAs)
+		ciphers := make([]uint16, 0, len(c.CipherSuites)/2)
+		for _, id := range c.CipherSuites {
+			id := id
+			if !strings.Contains(tls.CipherSuiteName(id), "_ECDSA_") {
+				continue
+			}
+			ciphers = append(ciphers, id)
+		}
+		c.CipherSuites = ciphers
+		return c
+	}
+
+	require.Empty(t, stderr)
+	require.Contains(t, stdout, getExpectedCiphers(defaultECDSAOnly), "stdout:\n%s", stdout)
+}
+
+type fakeT struct {
+	*testing.T
+}
+
+func (t *fakeT) FailNow() {
+	t.Errorf("fakeT ignored FailNow")
+}
+
+func (t *fakeT) Errorf(format string, args ...interface{}) {
+	t.Cleanup(func() {
+		if !t.Failed() {
+			return
+		}
+		t.Logf("reporting previously ignored errors since main test failed:\n"+format, args...)
+	})
+}
+
+func runNmapSSLEnum(t *testing.T, host string, port uint16) (string, string) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	version, err := exec.CommandContext(ctx, "nmap", "-V").CombinedOutput()
+	require.NoError(t, err)
+
+	versionMatches := regexp.MustCompile(`Nmap version 7\.(?P<minor>\d+)`).FindStringSubmatch(string(version))
+	require.Len(t, versionMatches, 2)
+	minorVersion, err := strconv.Atoi(versionMatches[1])
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, minorVersion, 92, "nmap >= 7.92.x is required")
+
+	var stdout, stderr bytes.Buffer
+	//nolint:gosec // we are not performing malicious argument injection against ourselves
+	cmd := exec.CommandContext(ctx, "nmap", "--script", "ssl-enum-ciphers",
+		"-p", strconv.FormatUint(uint64(port), 10),
+		host,
+	)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	require.NoErrorf(t, cmd.Run(), "stderr:\n%s\n\nstdout:\n%s\n\n", stderr.String(), stdout.String())
+
+	return stdout.String(), stderr.String()
+}
+
+func getExpectedCiphers(configFunc ptls.ConfigFunc) string {
+	config := configFunc(nil)
+	secureConfig := ptls.Secure(nil)
+
+	skip12 := config.MinVersion == secureConfig.MinVersion
+
+	var tls12Bit, tls13Bit string
+
+	if !skip12 {
+		sort.SliceStable(config.CipherSuites, func(i, j int) bool {
+			a := tls.CipherSuiteName(config.CipherSuites[i])
+			b := tls.CipherSuiteName(config.CipherSuites[j])
+
+			ok1 := strings.Contains(a, "_ECDSA_")
+			ok2 := strings.Contains(b, "_ECDSA_")
+
+			if ok1 && ok2 {
+				return false
+			}
+
+			return ok1
+		})
+
+		var s strings.Builder
+		for i, id := range config.CipherSuites {
+			s.WriteString(fmt.Sprintf(tls12Item, tls.CipherSuiteName(id)))
+			if i == len(config.CipherSuites)-1 {
+				break
+			}
+			s.WriteString("\n")
+		}
+		tls12Bit = fmt.Sprintf(tls12Base, s.String())
+	}
+
+	var s strings.Builder
+	for i, id := range secureConfig.CipherSuites {
+		s.WriteString(fmt.Sprintf(tls13Item, strings.Replace(tls.CipherSuiteName(id), "TLS_", "TLS_AKE_WITH_", 1)))
+		if i == len(secureConfig.CipherSuites)-1 {
+			break
+		}
+		s.WriteString("\n")
+	}
+	tls13Bit = fmt.Sprintf(tls13Base, s.String())
+
+	return fmt.Sprintf(baseItem, tls12Bit, tls13Bit)
+}
+
+const (
+	// this surrounds the tls 1.2 and 1.3 text in a way that guarantees that other TLS versions are not supported.
+	baseItem = `/tcp open  unknown
+| ssl-enum-ciphers: %s%s
+|_  least strength: A
+
+Nmap done: 1 IP address (1 host up) scanned in`
+
+	// the "cipher preference: client" bit a bug in nmap.
+	// https://github.com/nmap/nmap/issues/1691#issuecomment-536919978
+	tls12Base = `
+|   TLSv1.2: 
+|     ciphers: 
+%s
+|     compressors: 
+|       NULL
+|     cipher preference: client`
+
+	tls13Base = `
+|   TLSv1.3: 
+|     ciphers: 
+%s
+|     cipher preference: server`
+
+	tls12Item = `|       %s (secp256r1) - A`
+	tls13Item = `|       %s (ecdh_x25519) - A`
+)

--- a/test/testlib/client.go
+++ b/test/testlib/client.go
@@ -132,7 +132,7 @@ func newClientsetWithConfig(t *testing.T, config *rest.Config) kubernetes.Interf
 func NewAnonymousClientRestConfig(t *testing.T) *rest.Config {
 	t.Helper()
 
-	return rest.AnonymousClientConfig(NewClientConfig(t))
+	return kubeclient.SecureAnonymousClientConfig(NewClientConfig(t))
 }
 
 // Starting with an anonymous client config, add a cert and key to use for authentication in the API server.


### PR DESCRIPTION
This change updates the TLS config used by all pinniped components.
There are no configuration knobs associated with this change.  Thus
this change tightens our static defaults.

There are four TLS config levels:

1. Secure (TLS 1.3 only)
2. Default (TLS 1.2+ best ciphers that are well supported)
3. Default LDAP (TLS 1.2+ with less good ciphers)
4. Legacy (currently unused, TLS 1.2+ with all non-broken ciphers)

Highlights per component:

1. pinniped CLI
   - uses "secure" config against KAS
   - uses "default" for all other connections
2. concierge
   - uses "secure" config as an aggregated API server
   - uses "default" config as a impersonation proxy API server
   - uses "secure" config against KAS
   - uses "default" config for JWT authenticater (mostly, see code)
   - no changes to webhook authenticater (see code)
3. supervisor
   - uses "default" config as a server
   - uses "secure" config against KAS
   - uses "default" config against OIDC IDPs
   - uses "default LDAP" config against LDAP IDPs

Signed-off-by: Monis Khan <mok@vmware.com>

**Release note**:

```release-note
TLS 1.2+ with a modern set of TLS ciphers is now required for all connections coming into or going out of all pinniped components.
```