### PR TITLE
Use 65532 instead of 1001 as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,9 @@ COPY --from=build-env /usr/local/bin /usr/local/bin
 EXPOSE 8080 8443
 
 # Run as non-root for security posture
-USER 1001:1001
+# Use the same non-root user as https://github.com/GoogleContainerTools/distroless/blob/fc3c4eaceb0518900f886aae90407c43be0a42d9/base/base.bzl#L9
+# This is a workaround for https://github.com/GoogleContainerTools/distroless/issues/718
+USER 65532:65532
 
 # Set the entrypoint
 ENTRYPOINT ["/usr/local/bin/pinniped-server"]

--- a/deploy/concierge/values.yaml
+++ b/deploy/concierge/values.yaml
@@ -55,8 +55,8 @@ api_serving_certificate_renew_before_seconds: 2160000
 #! information), trace (timing information), all (kitchen sink).
 log_level: #! By default, when this value is left unset, only warnings and errors are printed. There is no way to suppress warning and error logs.
 
-run_as_user: 1001 #! run_as_user specifies the user ID that will own the process
-run_as_group: 1001 #! run_as_group specifies the group ID that will own the process
+run_as_user: 65532 #! run_as_user specifies the user ID that will own the process, see the Dockerfile for the reasoning behind this choice
+run_as_group: 65532 #! run_as_group specifies the group ID that will own the process, see the Dockerfile for the reasoning behind this choice
 
 #! Specify the API group suffix for all Pinniped API groups. By default, this is set to
 #! pinniped.dev, so Pinniped API groups will look like foo.pinniped.dev,

--- a/deploy/local-user-authenticator/values.yaml
+++ b/deploy/local-user-authenticator/values.yaml
@@ -15,5 +15,5 @@ image_tag: latest
 #! Optional.
 image_pull_dockerconfigjson: #! e.g. {"auths":{"https://registry.example.com":{"username":"USERNAME","password":"PASSWORD","auth":"BASE64_ENCODED_USERNAME_COLON_PASSWORD"}}}
 
-run_as_user: 1001 #! run_as_user specifies the user ID that will own the process
-run_as_group: 1001 #! run_as_group specifies the group ID that will own the process
+run_as_user: 65532 #! run_as_user specifies the user ID that will own the process, see the Dockerfile for the reasoning behind this choice
+run_as_group: 65532 #! run_as_group specifies the group ID that will own the process, see the Dockerfile for the reasoning behind this choice

--- a/deploy/supervisor/values.yaml
+++ b/deploy/supervisor/values.yaml
@@ -57,8 +57,8 @@ service_loadbalancer_ip: #! e.g. 1.2.3.4
 #! information), trace (timing information), all (kitchen sink).
 log_level: #! By default, when this value is left unset, only warnings and errors are printed. There is no way to suppress warning and error logs.
 
-run_as_user: 1001 #! run_as_user specifies the user ID that will own the process
-run_as_group: 1001 #! run_as_group specifies the group ID that will own the process
+run_as_user: 65532 #! run_as_user specifies the user ID that will own the process, see the Dockerfile for the reasoning behind this choice
+run_as_group: 65532 #! run_as_group specifies the group ID that will own the process, see the Dockerfile for the reasoning behind this choice
 
 #! Specify the API group suffix for all Pinniped API groups. By default, this is set to
 #! pinniped.dev, so Pinniped API groups will look like foo.pinniped.dev,


### PR DESCRIPTION
Signed-off-by: Monis Khan <mok@vmware.com>

**Release note**:

```release-note
Pinniped components now run as UID/GID 65532 by default instead of 1001.  This is a workaround for an issue caused by certain versions of runc and distroless images.
```