### PR TITLE
Revoke upstream OIDC refresh tokens during downstream session garbage collection

### DIFF
--- a/internal/controller/supervisorconfig/oidcupstreamwatcher/oidc_upstream_watcher_test.go
+++ b/internal/controller/supervisorconfig/oidcupstreamwatcher/oidc_upstream_watcher_test.go
@@ -114,6 +114,8 @@ func TestOIDCUpstreamWatcherControllerSync(t *testing.T) {
 	testIssuerCABase64 := base64.StdEncoding.EncodeToString([]byte(testIssuerCA))
 	testIssuerAuthorizeURL, err := url.Parse("https://example.com/authorize")
 	require.NoError(t, err)
+	testIssuerRevocationURL, err := url.Parse("https://example.com/revoke")
+	require.NoError(t, err)
 
 	wrongCA, err := certauthority.New("foo", time.Hour)
 	require.NoError(t, err)
@@ -151,7 +153,7 @@ func TestOIDCUpstreamWatcherControllerSync(t *testing.T) {
 		inputSecrets           []runtime.Object
 		wantErr                string
 		wantLogs               []string
-		wantResultingCache     []provider.UpstreamOIDCIdentityProviderI
+		wantResultingCache     []*oidctestutil.TestUpstreamOIDCIdentityProvider
 		wantResultingUpstreams []v1alpha1.OIDCIdentityProvider
 	}{
 		{
@@ -175,7 +177,7 @@ func TestOIDCUpstreamWatcherControllerSync(t *testing.T) {
 				`oidc-upstream-observer "level"=0 "msg"="updated condition" "name"="test-name" "namespace"="test-namespace" "message"="additionalAuthorizeParameters parameter names are allowed" "reason"="Success" "status"="True" "type"="AdditionalAuthorizeParametersValid"`,
 				`oidc-upstream-observer "msg"="found failing condition" "error"="OIDCIdentityProvider has a failing condition" "message"="secret \"test-client-secret\" not found" "name"="test-name" "namespace"="test-namespace" "reason"="SecretNotFound" "type"="ClientCredentialsValid"`,
 			},
-			wantResultingCache: []provider.UpstreamOIDCIdentityProviderI{},
+			wantResultingCache: []*oidctestutil.TestUpstreamOIDCIdentityProvider{},
 			wantResultingUpstreams: []v1alpha1.OIDCIdentityProvider{{
 				ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testName},
 				Status: v1alpha1.OIDCIdentityProviderStatus{
@@ -222,7 +224,7 @@ func TestOIDCUpstreamWatcherControllerSync(t *testing.T) {
 				`oidc-upstream-observer "level"=0 "msg"="updated condition" "name"="test-name" "namespace"="test-namespace" "message"="additionalAuthorizeParameters parameter names are allowed" "reason"="Success" "status"="True" "type"="AdditionalAuthorizeParametersValid"`,
 				`oidc-upstream-observer "msg"="found failing condition" "error"="OIDCIdentityProvider has a failing condition" "message"="referenced Secret \"test-client-secret\" has wrong type \"some-other-type\" (should be \"secrets.pinniped.dev/oidc-client\")" "name"="test-name" "namespace"="test-namespace" "reason"="SecretWrongType" "type"="ClientCredentialsValid"`,
 			},
-			wantResultingCache: []provider.UpstreamOIDCIdentityProviderI{},
+			wantResultingCache: []*oidctestutil.TestUpstreamOIDCIdentityProvider{},
 			wantResultingUpstreams: []v1alpha1.OIDCIdentityProvider{{
 				ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testName},
 				Status: v1alpha1.OIDCIdentityProviderStatus{
@@ -268,7 +270,7 @@ func TestOIDCUpstreamWatcherControllerSync(t *testing.T) {
 				`oidc-upstream-observer "level"=0 "msg"="updated condition" "name"="test-name" "namespace"="test-namespace" "message"="additionalAuthorizeParameters parameter names are allowed" "reason"="Success" "status"="True" "type"="AdditionalAuthorizeParametersValid"`,
 				`oidc-upstream-observer "msg"="found failing condition" "error"="OIDCIdentityProvider has a failing condition" "message"="referenced Secret \"test-client-secret\" is missing required keys [\"clientID\" \"clientSecret\"]" "name"="test-name" "namespace"="test-namespace" "reason"="SecretMissingKeys" "type"="ClientCredentialsValid"`,
 			},
-			wantResultingCache: []provider.UpstreamOIDCIdentityProviderI{},
+			wantResultingCache: []*oidctestutil.TestUpstreamOIDCIdentityProvider{},
 			wantResultingUpstreams: []v1alpha1.OIDCIdentityProvider{{
 				ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testName},
 				Status: v1alpha1.OIDCIdentityProviderStatus{
@@ -317,7 +319,7 @@ func TestOIDCUpstreamWatcherControllerSync(t *testing.T) {
 				`oidc-upstream-observer "level"=0 "msg"="updated condition" "name"="test-name" "namespace"="test-namespace" "message"="additionalAuthorizeParameters parameter names are allowed" "reason"="Success" "status"="True" "type"="AdditionalAuthorizeParametersValid"`,
 				`oidc-upstream-observer "msg"="found failing condition" "error"="OIDCIdentityProvider has a failing condition" "message"="spec.certificateAuthorityData is invalid: illegal base64 data at input byte 7" "name"="test-name" "namespace"="test-namespace" "reason"="InvalidTLSConfig" "type"="OIDCDiscoverySucceeded"`,
 			},
-			wantResultingCache: []provider.UpstreamOIDCIdentityProviderI{},
+			wantResultingCache: []*oidctestutil.TestUpstreamOIDCIdentityProvider{},
 			wantResultingUpstreams: []v1alpha1.OIDCIdentityProvider{{
 				ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testName},
 				Status: v1alpha1.OIDCIdentityProviderStatus{
@@ -366,7 +368,7 @@ func TestOIDCUpstreamWatcherControllerSync(t *testing.T) {
 				`oidc-upstream-observer "level"=0 "msg"="updated condition" "name"="test-name" "namespace"="test-namespace" "message"="additionalAuthorizeParameters parameter names are allowed" "reason"="Success" "status"="True" "type"="AdditionalAuthorizeParametersValid"`,
 				`oidc-upstream-observer "msg"="found failing condition" "error"="OIDCIdentityProvider has a failing condition" "message"="spec.certificateAuthorityData is invalid: no certificates found" "name"="test-name" "namespace"="test-namespace" "reason"="InvalidTLSConfig" "type"="OIDCDiscoverySucceeded"`,
 			},
-			wantResultingCache: []provider.UpstreamOIDCIdentityProviderI{},
+			wantResultingCache: []*oidctestutil.TestUpstreamOIDCIdentityProvider{},
 			wantResultingUpstreams: []v1alpha1.OIDCIdentityProvider{{
 				ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testName},
 				Status: v1alpha1.OIDCIdentityProviderStatus{
@@ -413,7 +415,7 @@ func TestOIDCUpstreamWatcherControllerSync(t *testing.T) {
 				`oidc-upstream-observer "level"=0 "msg"="updated condition" "name"="test-name" "namespace"="test-namespace" "message"="additionalAuthorizeParameters parameter names are allowed" "reason"="Success" "status"="True" "type"="AdditionalAuthorizeParametersValid"`,
 				`oidc-upstream-observer "msg"="found failing condition" "error"="OIDCIdentityProvider has a failing condition" "message"="failed to perform OIDC discovery against \"invalid-url-that-is-really-really-long-nanananananananannanananan-batman-nanananananananananananananana-batman-lalalalalalalalalal-batman-weeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\":\nGet \"invalid-url-that-is-really-really-long-nanananananananannanananan-batman-nanananananananananananananana-batman-lalalalalalalalalal-batman-weeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee/.well-known/openid-configuration\": unsupported protocol  [truncated 9 chars]" "name"="test-name" "namespace"="test-namespace" "reason"="Unreachable" "type"="OIDCDiscoverySucceeded"`,
 			},
-			wantResultingCache: []provider.UpstreamOIDCIdentityProviderI{},
+			wantResultingCache: []*oidctestutil.TestUpstreamOIDCIdentityProvider{},
 			wantResultingUpstreams: []v1alpha1.OIDCIdentityProvider{{
 				ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testName},
 				Status: v1alpha1.OIDCIdentityProviderStatus{
@@ -462,7 +464,7 @@ Get "invalid-url-that-is-really-really-long-nanananananananannanananan-batman-na
 				`oidc-upstream-observer "level"=0 "msg"="updated condition" "name"="test-name" "namespace"="test-namespace" "message"="additionalAuthorizeParameters parameter names are allowed" "reason"="Success" "status"="True" "type"="AdditionalAuthorizeParametersValid"`,
 				`oidc-upstream-observer "msg"="found failing condition" "error"="OIDCIdentityProvider has a failing condition" "message"="failed to perform OIDC discovery against \"` + testIssuerURL + `/valid-url-that-is-really-really-long-nanananananananannanananan-batman-nanananananananananananananana-batman-lalalalalalalalalal-batman-weeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\":\nGet \"` + testIssuerURL + `/valid-url-that-is-really-really-long-nanananananananannanananan-batman-nanananananananananananananana-batman-lalalalalalalalalal-batman-weeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee/.well-known/openid-configuration\": x509: certificate signed by unknown authority" "name"="test-name" "namespace"="test-namespace" "reason"="Unreachable" "type"="OIDCDiscoverySucceeded"`,
 			},
-			wantResultingCache: []provider.UpstreamOIDCIdentityProviderI{},
+			wantResultingCache: []*oidctestutil.TestUpstreamOIDCIdentityProvider{},
 			wantResultingUpstreams: []v1alpha1.OIDCIdentityProvider{{
 				ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testName},
 				Status: v1alpha1.OIDCIdentityProviderStatus{
@@ -510,7 +512,7 @@ Get "` + testIssuerURL + `/valid-url-that-is-really-really-long-nananananananana
 				`oidc-upstream-observer "level"=0 "msg"="updated condition" "name"="test-name" "namespace"="test-namespace" "message"="additionalAuthorizeParameters parameter names are allowed" "reason"="Success" "status"="True" "type"="AdditionalAuthorizeParametersValid"`,
 				`oidc-upstream-observer "msg"="found failing condition" "error"="OIDCIdentityProvider has a failing condition" "message"="failed to parse authorization endpoint URL: parse \"%\": invalid URL escape \"%\"" "name"="test-name" "namespace"="test-namespace" "reason"="InvalidResponse" "type"="OIDCDiscoverySucceeded"`,
 			},
-			wantResultingCache: []provider.UpstreamOIDCIdentityProviderI{},
+			wantResultingCache: []*oidctestutil.TestUpstreamOIDCIdentityProvider{},
 			wantResultingUpstreams: []v1alpha1.OIDCIdentityProvider{{
 				ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testName},
 				Status: v1alpha1.OIDCIdentityProviderStatus{
@@ -530,6 +532,53 @@ Get "` + testIssuerURL + `/valid-url-that-is-really-really-long-nananananananana
 							LastTransitionTime: now,
 							Reason:             "InvalidResponse",
 							Message:            `failed to parse authorization endpoint URL: parse "%": invalid URL escape "%"`,
+						},
+					},
+				},
+			}},
+		},
+		{
+			name: "issuer returns invalid revocation URL",
+			inputUpstreams: []runtime.Object{&v1alpha1.OIDCIdentityProvider{
+				ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testName},
+				Spec: v1alpha1.OIDCIdentityProviderSpec{
+					Issuer: testIssuerURL + "/invalid-revocation-url",
+					TLS:    &v1alpha1.TLSSpec{CertificateAuthorityData: testIssuerCABase64},
+					Client: v1alpha1.OIDCClient{SecretName: testSecretName},
+				},
+			}},
+			inputSecrets: []runtime.Object{&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testSecretName},
+				Type:       "secrets.pinniped.dev/oidc-client",
+				Data:       testValidSecretData,
+			}},
+			wantErr: controllerlib.ErrSyntheticRequeue.Error(),
+			wantLogs: []string{
+				`oidc-upstream-observer "level"=0 "msg"="updated condition" "name"="test-name" "namespace"="test-namespace" "message"="loaded client credentials" "reason"="Success" "status"="True" "type"="ClientCredentialsValid"`,
+				`oidc-upstream-observer "level"=0 "msg"="updated condition" "name"="test-name" "namespace"="test-namespace" "message"="failed to parse revocation endpoint URL: parse \"%\": invalid URL escape \"%\"" "reason"="InvalidResponse" "status"="False" "type"="OIDCDiscoverySucceeded"`,
+				`oidc-upstream-observer "level"=0 "msg"="updated condition" "name"="test-name" "namespace"="test-namespace" "message"="additionalAuthorizeParameters parameter names are allowed" "reason"="Success" "status"="True" "type"="AdditionalAuthorizeParametersValid"`,
+				`oidc-upstream-observer "msg"="found failing condition" "error"="OIDCIdentityProvider has a failing condition" "message"="failed to parse revocation endpoint URL: parse \"%\": invalid URL escape \"%\"" "name"="test-name" "namespace"="test-namespace" "reason"="InvalidResponse" "type"="OIDCDiscoverySucceeded"`,
+			},
+			wantResultingCache: []*oidctestutil.TestUpstreamOIDCIdentityProvider{},
+			wantResultingUpstreams: []v1alpha1.OIDCIdentityProvider{{
+				ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testName},
+				Status: v1alpha1.OIDCIdentityProviderStatus{
+					Phase: "Error",
+					Conditions: []v1alpha1.Condition{
+						happyAdditionalAuthorizeParametersValidCondition,
+						{
+							Type:               "ClientCredentialsValid",
+							Status:             "True",
+							LastTransitionTime: now,
+							Reason:             "Success",
+							Message:            "loaded client credentials",
+						},
+						{
+							Type:               "OIDCDiscoverySucceeded",
+							Status:             "False",
+							LastTransitionTime: now,
+							Reason:             "InvalidResponse",
+							Message:            `failed to parse revocation endpoint URL: parse "%": invalid URL escape "%"`,
 						},
 					},
 				},
@@ -557,7 +606,7 @@ Get "` + testIssuerURL + `/valid-url-that-is-really-really-long-nananananananana
 				`oidc-upstream-observer "level"=0 "msg"="updated condition" "name"="test-name" "namespace"="test-namespace" "message"="additionalAuthorizeParameters parameter names are allowed" "reason"="Success" "status"="True" "type"="AdditionalAuthorizeParametersValid"`,
 				`oidc-upstream-observer "msg"="found failing condition" "error"="OIDCIdentityProvider has a failing condition" "message"="authorization endpoint URL scheme must be \"https\", not \"http\"" "name"="test-name" "namespace"="test-namespace" "reason"="InvalidResponse" "type"="OIDCDiscoverySucceeded"`,
 			},
-			wantResultingCache: []provider.UpstreamOIDCIdentityProviderI{},
+			wantResultingCache: []*oidctestutil.TestUpstreamOIDCIdentityProvider{},
 			wantResultingUpstreams: []v1alpha1.OIDCIdentityProvider{{
 				ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testName},
 				Status: v1alpha1.OIDCIdentityProviderStatus{
@@ -577,6 +626,53 @@ Get "` + testIssuerURL + `/valid-url-that-is-really-really-long-nananananananana
 							LastTransitionTime: now,
 							Reason:             "InvalidResponse",
 							Message:            `authorization endpoint URL scheme must be "https", not "http"`,
+						},
+					},
+				},
+			}},
+		},
+		{
+			name: "issuer returns insecure revocation URL",
+			inputUpstreams: []runtime.Object{&v1alpha1.OIDCIdentityProvider{
+				ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testName},
+				Spec: v1alpha1.OIDCIdentityProviderSpec{
+					Issuer: testIssuerURL + "/insecure-revocation-url",
+					TLS:    &v1alpha1.TLSSpec{CertificateAuthorityData: testIssuerCABase64},
+					Client: v1alpha1.OIDCClient{SecretName: testSecretName},
+				},
+			}},
+			inputSecrets: []runtime.Object{&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testSecretName},
+				Type:       "secrets.pinniped.dev/oidc-client",
+				Data:       testValidSecretData,
+			}},
+			wantErr: controllerlib.ErrSyntheticRequeue.Error(),
+			wantLogs: []string{
+				`oidc-upstream-observer "level"=0 "msg"="updated condition" "name"="test-name" "namespace"="test-namespace" "message"="loaded client credentials" "reason"="Success" "status"="True" "type"="ClientCredentialsValid"`,
+				`oidc-upstream-observer "level"=0 "msg"="updated condition" "name"="test-name" "namespace"="test-namespace" "message"="revocation endpoint URL scheme must be \"https\", not \"http\"" "reason"="InvalidResponse" "status"="False" "type"="OIDCDiscoverySucceeded"`,
+				`oidc-upstream-observer "level"=0 "msg"="updated condition" "name"="test-name" "namespace"="test-namespace" "message"="additionalAuthorizeParameters parameter names are allowed" "reason"="Success" "status"="True" "type"="AdditionalAuthorizeParametersValid"`,
+				`oidc-upstream-observer "msg"="found failing condition" "error"="OIDCIdentityProvider has a failing condition" "message"="revocation endpoint URL scheme must be \"https\", not \"http\"" "name"="test-name" "namespace"="test-namespace" "reason"="InvalidResponse" "type"="OIDCDiscoverySucceeded"`,
+			},
+			wantResultingCache: []*oidctestutil.TestUpstreamOIDCIdentityProvider{},
+			wantResultingUpstreams: []v1alpha1.OIDCIdentityProvider{{
+				ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testName},
+				Status: v1alpha1.OIDCIdentityProviderStatus{
+					Phase: "Error",
+					Conditions: []v1alpha1.Condition{
+						happyAdditionalAuthorizeParametersValidCondition,
+						{
+							Type:               "ClientCredentialsValid",
+							Status:             "True",
+							LastTransitionTime: now,
+							Reason:             "Success",
+							Message:            "loaded client credentials",
+						},
+						{
+							Type:               "OIDCDiscoverySucceeded",
+							Status:             "False",
+							LastTransitionTime: now,
+							Reason:             "InvalidResponse",
+							Message:            `revocation endpoint URL scheme must be "https", not "http"`,
 						},
 					},
 				},
@@ -614,11 +710,12 @@ Get "` + testIssuerURL + `/valid-url-that-is-really-really-long-nananananananana
 				`oidc-upstream-observer "level"=0 "msg"="updated condition" "name"="test-name" "namespace"="test-namespace" "message"="discovered issuer configuration" "reason"="Success" "status"="True" "type"="OIDCDiscoverySucceeded"`,
 				`oidc-upstream-observer "level"=0 "msg"="updated condition" "name"="test-name" "namespace"="test-namespace" "message"="additionalAuthorizeParameters parameter names are allowed" "reason"="Success" "status"="True" "type"="AdditionalAuthorizeParametersValid"`,
 			},
-			wantResultingCache: []provider.UpstreamOIDCIdentityProviderI{
-				&oidctestutil.TestUpstreamOIDCIdentityProvider{
+			wantResultingCache: []*oidctestutil.TestUpstreamOIDCIdentityProvider{
+				{
 					Name:                     testName,
 					ClientID:                 testClientID,
 					AuthorizationURL:         *testIssuerAuthorizeURL,
+					RevocationURL:            testIssuerRevocationURL,
 					Scopes:                   append(testExpectedScopes, "xyz"), // includes openid only once
 					UsernameClaim:            testUsernameClaim,
 					GroupsClaim:              testGroupsClaim,
@@ -668,11 +765,67 @@ Get "` + testIssuerURL + `/valid-url-that-is-really-really-long-nananananananana
 				`oidc-upstream-observer "level"=0 "msg"="updated condition" "name"="test-name" "namespace"="test-namespace" "message"="discovered issuer configuration" "reason"="Success" "status"="True" "type"="OIDCDiscoverySucceeded"`,
 				`oidc-upstream-observer "level"=0 "msg"="updated condition" "name"="test-name" "namespace"="test-namespace" "message"="additionalAuthorizeParameters parameter names are allowed" "reason"="Success" "status"="True" "type"="AdditionalAuthorizeParametersValid"`,
 			},
-			wantResultingCache: []provider.UpstreamOIDCIdentityProviderI{
-				&oidctestutil.TestUpstreamOIDCIdentityProvider{
+			wantResultingCache: []*oidctestutil.TestUpstreamOIDCIdentityProvider{
+				{
 					Name:                     testName,
 					ClientID:                 testClientID,
 					AuthorizationURL:         *testIssuerAuthorizeURL,
+					RevocationURL:            testIssuerRevocationURL,
+					Scopes:                   testDefaultExpectedScopes,
+					UsernameClaim:            testUsernameClaim,
+					GroupsClaim:              testGroupsClaim,
+					AllowPasswordGrant:       false,
+					AdditionalAuthcodeParams: map[string]string{},
+					ResourceUID:              testUID,
+				},
+			},
+			wantResultingUpstreams: []v1alpha1.OIDCIdentityProvider{{
+				ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testName, Generation: 1234, UID: testUID},
+				Status: v1alpha1.OIDCIdentityProviderStatus{
+					Phase: "Ready",
+					Conditions: []v1alpha1.Condition{
+						{Type: "AdditionalAuthorizeParametersValid", Status: "True", LastTransitionTime: earlier, Reason: "Success", Message: "additionalAuthorizeParameters parameter names are allowed", ObservedGeneration: 1234},
+						{Type: "ClientCredentialsValid", Status: "True", LastTransitionTime: earlier, Reason: "Success", Message: "loaded client credentials", ObservedGeneration: 1234},
+						{Type: "OIDCDiscoverySucceeded", Status: "True", LastTransitionTime: earlier, Reason: "Success", Message: "discovered issuer configuration", ObservedGeneration: 1234},
+					},
+				},
+			}},
+		},
+		{
+			name: "existing valid upstream with no revocation endpoint in the discovery document",
+			inputUpstreams: []runtime.Object{&v1alpha1.OIDCIdentityProvider{
+				ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testName, Generation: 1234, UID: testUID},
+				Spec: v1alpha1.OIDCIdentityProviderSpec{
+					Issuer: testIssuerURL + "/valid-without-revocation",
+					TLS:    &v1alpha1.TLSSpec{CertificateAuthorityData: testIssuerCABase64},
+					Client: v1alpha1.OIDCClient{SecretName: testSecretName},
+					Claims: v1alpha1.OIDCClaims{Groups: testGroupsClaim, Username: testUsernameClaim},
+				},
+				Status: v1alpha1.OIDCIdentityProviderStatus{
+					Phase: "Ready",
+					Conditions: []v1alpha1.Condition{
+						happyAdditionalAuthorizeParametersValidConditionEarlier,
+						{Type: "ClientCredentialsValid", Status: "True", LastTransitionTime: earlier, Reason: "Success", Message: "loaded client credentials"},
+						{Type: "OIDCDiscoverySucceeded", Status: "True", LastTransitionTime: earlier, Reason: "Success", Message: "discovered issuer configuration"},
+					},
+				},
+			}},
+			inputSecrets: []runtime.Object{&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testSecretName},
+				Type:       "secrets.pinniped.dev/oidc-client",
+				Data:       testValidSecretData,
+			}},
+			wantLogs: []string{
+				`oidc-upstream-observer "level"=0 "msg"="updated condition" "name"="test-name" "namespace"="test-namespace" "message"="loaded client credentials" "reason"="Success" "status"="True" "type"="ClientCredentialsValid"`,
+				`oidc-upstream-observer "level"=0 "msg"="updated condition" "name"="test-name" "namespace"="test-namespace" "message"="discovered issuer configuration" "reason"="Success" "status"="True" "type"="OIDCDiscoverySucceeded"`,
+				`oidc-upstream-observer "level"=0 "msg"="updated condition" "name"="test-name" "namespace"="test-namespace" "message"="additionalAuthorizeParameters parameter names are allowed" "reason"="Success" "status"="True" "type"="AdditionalAuthorizeParametersValid"`,
+			},
+			wantResultingCache: []*oidctestutil.TestUpstreamOIDCIdentityProvider{
+				{
+					Name:                     testName,
+					ClientID:                 testClientID,
+					AuthorizationURL:         *testIssuerAuthorizeURL,
+					RevocationURL:            nil, // no revocation URL is set in the cached provider because none was returned by discovery
 					Scopes:                   testDefaultExpectedScopes,
 					UsernameClaim:            testUsernameClaim,
 					GroupsClaim:              testGroupsClaim,
@@ -725,11 +878,12 @@ Get "` + testIssuerURL + `/valid-url-that-is-really-really-long-nananananananana
 				`oidc-upstream-observer "level"=0 "msg"="updated condition" "name"="test-name" "namespace"="test-namespace" "message"="discovered issuer configuration" "reason"="Success" "status"="True" "type"="OIDCDiscoverySucceeded"`,
 				`oidc-upstream-observer "level"=0 "msg"="updated condition" "name"="test-name" "namespace"="test-namespace" "message"="additionalAuthorizeParameters parameter names are allowed" "reason"="Success" "status"="True" "type"="AdditionalAuthorizeParametersValid"`,
 			},
-			wantResultingCache: []provider.UpstreamOIDCIdentityProviderI{
-				&oidctestutil.TestUpstreamOIDCIdentityProvider{
+			wantResultingCache: []*oidctestutil.TestUpstreamOIDCIdentityProvider{
+				{
 					Name:                     testName,
 					ClientID:                 testClientID,
 					AuthorizationURL:         *testIssuerAuthorizeURL,
+					RevocationURL:            testIssuerRevocationURL,
 					Scopes:                   testExpectedScopes,
 					UsernameClaim:            testUsernameClaim,
 					GroupsClaim:              testGroupsClaim,
@@ -784,11 +938,12 @@ Get "` + testIssuerURL + `/valid-url-that-is-really-really-long-nananananananana
 				`oidc-upstream-observer "level"=0 "msg"="updated condition" "name"="test-name" "namespace"="test-namespace" "message"="discovered issuer configuration" "reason"="Success" "status"="True" "type"="OIDCDiscoverySucceeded"`,
 				`oidc-upstream-observer "level"=0 "msg"="updated condition" "name"="test-name" "namespace"="test-namespace" "message"="additionalAuthorizeParameters parameter names are allowed" "reason"="Success" "status"="True" "type"="AdditionalAuthorizeParametersValid"`,
 			},
-			wantResultingCache: []provider.UpstreamOIDCIdentityProviderI{
-				&oidctestutil.TestUpstreamOIDCIdentityProvider{
+			wantResultingCache: []*oidctestutil.TestUpstreamOIDCIdentityProvider{
+				{
 					Name:                     testName,
 					ClientID:                 testClientID,
 					AuthorizationURL:         *testIssuerAuthorizeURL,
+					RevocationURL:            testIssuerRevocationURL,
 					Scopes:                   testExpectedScopes, // does not include the default scopes
 					UsernameClaim:            testUsernameClaim,
 					GroupsClaim:              testGroupsClaim,
@@ -845,7 +1000,7 @@ Get "` + testIssuerURL + `/valid-url-that-is-really-really-long-nananananananana
 				`oidc-upstream-observer "level"=0 "msg"="updated condition" "name"="test-name" "namespace"="test-namespace" "message"="the following additionalAuthorizeParameters are not allowed: response_type,scope,client_id,state,nonce,code_challenge,code_challenge_method,redirect_uri,hd" "reason"="DisallowedParameterName" "status"="False" "type"="AdditionalAuthorizeParametersValid"`,
 				`oidc-upstream-observer "msg"="found failing condition" "error"="OIDCIdentityProvider has a failing condition" "message"="the following additionalAuthorizeParameters are not allowed: response_type,scope,client_id,state,nonce,code_challenge,code_challenge_method,redirect_uri,hd" "name"="test-name" "namespace"="test-namespace" "reason"="DisallowedParameterName" "type"="AdditionalAuthorizeParametersValid"`,
 			},
-			wantResultingCache: []provider.UpstreamOIDCIdentityProviderI{},
+			wantResultingCache: []*oidctestutil.TestUpstreamOIDCIdentityProvider{},
 			wantResultingUpstreams: []v1alpha1.OIDCIdentityProvider{{
 				ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testName, Generation: 1234, UID: testUID},
 				Status: v1alpha1.OIDCIdentityProviderStatus{
@@ -883,7 +1038,7 @@ Get "` + testIssuerURL + `/valid-url-that-is-really-really-long-nananananananana
 				`oidc-upstream-observer "level"=0 "msg"="updated condition" "name"="test-name" "namespace"="test-namespace" "message"="additionalAuthorizeParameters parameter names are allowed" "reason"="Success" "status"="True" "type"="AdditionalAuthorizeParametersValid"`,
 				`oidc-upstream-observer "msg"="found failing condition" "error"="OIDCIdentityProvider has a failing condition" "message"="failed to perform OIDC discovery against \"` + testIssuerURL + `/ends-with-slash\":\noidc: issuer did not match the issuer returned by provider, expected \"` + testIssuerURL + `/ends-with-slash\" got \"` + testIssuerURL + `/ends-with-slash/\"" "name"="test-name" "namespace"="test-namespace" "reason"="Unreachable" "type"="OIDCDiscoverySucceeded"`,
 			},
-			wantResultingCache: []provider.UpstreamOIDCIdentityProviderI{},
+			wantResultingCache: []*oidctestutil.TestUpstreamOIDCIdentityProvider{},
 			wantResultingUpstreams: []v1alpha1.OIDCIdentityProvider{{
 				ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testName},
 				Status: v1alpha1.OIDCIdentityProviderStatus{
@@ -932,7 +1087,7 @@ oidc: issuer did not match the issuer returned by provider, expected "` + testIs
 				`oidc-upstream-observer "level"=0 "msg"="updated condition" "name"="test-name" "namespace"="test-namespace" "message"="additionalAuthorizeParameters parameter names are allowed" "reason"="Success" "status"="True" "type"="AdditionalAuthorizeParametersValid"`,
 				`oidc-upstream-observer "msg"="found failing condition" "error"="OIDCIdentityProvider has a failing condition" "message"="failed to perform OIDC discovery against \"` + testIssuerURL + `/\":\noidc: issuer did not match the issuer returned by provider, expected \"` + testIssuerURL + `/\" got \"` + testIssuerURL + `\"" "name"="test-name" "namespace"="test-namespace" "reason"="Unreachable" "type"="OIDCDiscoverySucceeded"`,
 			},
-			wantResultingCache: []provider.UpstreamOIDCIdentityProviderI{},
+			wantResultingCache: []*oidctestutil.TestUpstreamOIDCIdentityProvider{},
 			wantResultingUpstreams: []v1alpha1.OIDCIdentityProvider{{
 				ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testName},
 				Status: v1alpha1.OIDCIdentityProviderStatus{
@@ -1010,6 +1165,7 @@ oidc: issuer did not match the issuer returned by provider, expected "` + testIs
 				require.Equal(t, tt.wantResultingCache[i].AllowsPasswordGrant(), actualIDP.AllowsPasswordGrant())
 				require.Equal(t, tt.wantResultingCache[i].GetAdditionalAuthcodeParams(), actualIDP.GetAdditionalAuthcodeParams())
 				require.Equal(t, tt.wantResultingCache[i].GetResourceUID(), actualIDP.GetResourceUID())
+				require.Equal(t, tt.wantResultingCache[i].GetRevocationURL(), actualIDP.GetRevocationURL())
 				require.ElementsMatch(t, tt.wantResultingCache[i].GetScopes(), actualIDP.GetScopes())
 
 				// We always want to use the proxy from env on these clients, so although the following assertions
@@ -1067,18 +1223,30 @@ func newTestIssuer(t *testing.T) (string, string) {
 	caBundlePEM, testURL := testutil.TLSTestServer(t, mux.ServeHTTP)
 
 	type providerJSON struct {
-		Issuer   string `json:"issuer"`
-		AuthURL  string `json:"authorization_endpoint"`
-		TokenURL string `json:"token_endpoint"`
-		JWKSURL  string `json:"jwks_uri"`
+		Issuer        string `json:"issuer"`
+		AuthURL       string `json:"authorization_endpoint"`
+		TokenURL      string `json:"token_endpoint"`
+		RevocationURL string `json:"revocation_endpoint,omitempty"`
+		JWKSURL       string `json:"jwks_uri"`
 	}
 
 	// At the root of the server, serve an issuer with a valid discovery response.
 	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("content-type", "application/json")
 		_ = json.NewEncoder(w).Encode(&providerJSON{
-			Issuer:  testURL,
-			AuthURL: "https://example.com/authorize",
+			Issuer:        testURL,
+			AuthURL:       "https://example.com/authorize",
+			RevocationURL: "https://example.com/revoke",
+		})
+	})
+
+	// At "/valid-without-revocation", serve an issuer with a valid discovery response which does not have a revocation endpoint.
+	mux.HandleFunc("/valid-without-revocation/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		_ = json.NewEncoder(w).Encode(&providerJSON{
+			Issuer:        testURL + "/valid-without-revocation",
+			AuthURL:       "https://example.com/authorize",
+			RevocationURL: "", // none
 		})
 	})
 
@@ -1091,12 +1259,32 @@ func newTestIssuer(t *testing.T) (string, string) {
 		})
 	})
 
+	// At "/invalid-revocation-url", serve an issuer that returns an invalid revocation URL (not parseable).
+	mux.HandleFunc("/invalid-revocation-url/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		_ = json.NewEncoder(w).Encode(&providerJSON{
+			Issuer:        testURL + "/invalid-revocation-url",
+			AuthURL:       "https://example.com/authorize",
+			RevocationURL: "%",
+		})
+	})
+
 	// At "/insecure", serve an issuer that returns an insecure authorization URL (not https://).
 	mux.HandleFunc("/insecure/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("content-type", "application/json")
 		_ = json.NewEncoder(w).Encode(&providerJSON{
 			Issuer:  testURL + "/insecure",
 			AuthURL: "http://example.com/authorize",
+		})
+	})
+
+	// At "/insecure", serve an issuer that returns an insecure authorization URL (not https://).
+	mux.HandleFunc("/insecure-revocation-url/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		_ = json.NewEncoder(w).Encode(&providerJSON{
+			Issuer:        testURL + "/insecure-revocation-url",
+			AuthURL:       "https://example.com/authorize",
+			RevocationURL: "http://example.com/revoke",
 		})
 	})
 
@@ -1109,8 +1297,9 @@ func newTestIssuer(t *testing.T) (string, string) {
 	mux.HandleFunc("/ends-with-slash/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("content-type", "application/json")
 		_ = json.NewEncoder(w).Encode(&providerJSON{
-			Issuer:  testURL + "/ends-with-slash/",
-			AuthURL: "https://example.com/authorize",
+			Issuer:        testURL + "/ends-with-slash/",
+			AuthURL:       "https://example.com/authorize",
+			RevocationURL: "https://example.com/revoke",
 		})
 	})
 

--- a/internal/controller/supervisorstorage/garbage_collector.go
+++ b/internal/controller/supervisorstorage/garbage_collector.go
@@ -4,6 +4,7 @@
 package supervisorstorage
 
 import (
+	"errors"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -16,19 +17,32 @@ import (
 	pinnipedcontroller "go.pinniped.dev/internal/controller"
 	"go.pinniped.dev/internal/controllerlib"
 	"go.pinniped.dev/internal/crud"
+	"go.pinniped.dev/internal/fositestorage/accesstoken"
+	"go.pinniped.dev/internal/fositestorage/authorizationcode"
+	"go.pinniped.dev/internal/fositestorage/openidconnect"
+	"go.pinniped.dev/internal/fositestorage/pkce"
+	"go.pinniped.dev/internal/fositestorage/refreshtoken"
+	"go.pinniped.dev/internal/oidc/provider"
 	"go.pinniped.dev/internal/plog"
 )
 
 const minimumRepeatInterval = 30 * time.Second
 
 type garbageCollectorController struct {
+	idpCache              UpstreamOIDCIdentityProviderICache
 	secretInformer        corev1informers.SecretInformer
 	kubeClient            kubernetes.Interface
 	clock                 clock.Clock
 	timeOfMostRecentSweep time.Time
 }
 
+// UpstreamOIDCIdentityProviderICache is a thread safe cache that holds a list of validated upstream OIDC IDP configurations.
+type UpstreamOIDCIdentityProviderICache interface {
+	GetOIDCIdentityProviders() []provider.UpstreamOIDCIdentityProviderI
+}
+
 func GarbageCollectorController(
+	idpCache UpstreamOIDCIdentityProviderICache,
 	clock clock.Clock,
 	kubeClient kubernetes.Interface,
 	secretInformer corev1informers.SecretInformer,
@@ -46,6 +60,7 @@ func GarbageCollectorController(
 		controllerlib.Config{
 			Name: "garbage-collector-controller",
 			Syncer: &garbageCollectorController{
+				idpCache:       idpCache,
 				secretInformer: secretInformer,
 				kubeClient:     kubeClient,
 				clock:          clock,
@@ -102,6 +117,15 @@ func (c *garbageCollectorController) Sync(ctx controllerlib.Context) error {
 		}
 
 		if garbageCollectAfterTime.Before(frozenClock.Now()) {
+			storageType, isSessionStorage := secret.Labels[crud.SecretLabelKey]
+			if isSessionStorage {
+				err := c.maybeRevokeUpstreamOIDCRefreshToken(storageType, secret)
+				if err != nil {
+					// Log the error for debugging purposes, but still carry on to delete the Secret despite the error.
+					plog.DebugErr("garbage collector could not revoke upstream refresh token", err, logKV(secret))
+				}
+			}
+
 			err = c.kubeClient.CoreV1().Secrets(secret.Namespace).Delete(ctx.Context, secret.Name, metav1.DeleteOptions{
 				Preconditions: &metav1.Preconditions{
 					UID:             &secret.UID,
@@ -119,11 +143,76 @@ func (c *garbageCollectorController) Sync(ctx controllerlib.Context) error {
 	return nil
 }
 
+//nolint:godot // do not complain about the following to-do comment
+// TODO write unit tests for all of the following cases. Note that there is already a test
+//  double implemented for the RevokeRefreshToken() method on the objects in the idpCache
+//  to help with the test mocking. See RevokeRefreshTokenCallCount() and RevokeRefreshTokenArgs(int)
+//  in TestUpstreamOIDCIdentityProvider (in file oidctestutil.go). This will allowing following
+//  the pattern used in other unit tests that fill the idpCache with mock providers using the builders
+//  from oidctestutil.go.
+func (c *garbageCollectorController) maybeRevokeUpstreamOIDCRefreshToken(storageType string, secret *v1.Secret) error {
+	// All session storage types hold upstream refresh tokens when the upstream IDP is an OIDC provider.
+	// However, some of them will be outdated because they are not updated by fosite after creation.
+	// Our goal below is to always revoke the latest upstream refresh token that we are holding for the
+	// session, and only the latest.
+	switch storageType {
+	case authorizationcode.TypeLabelValue:
+		// For authcode storage, check if the authcode was used. If the authcode was never used, then its
+		// storage must contain the latest upstream refresh token, so revoke it.
+		// TODO Use ReadFromSecret from the authorizationcode package under fositestorage to validate/parse the Secret, return any errors
+		// TODO return nil if the upstream type is not OIDC
+		// TODO return nil if the authcode is *NOT* active (meaning that it was already used)
+		// TODO lookup the idp by name in c.idpCache to get the cached provider interface, return error if not found
+		// TODO use the cached interface to revoke the refresh token, return any error
+		plog.Trace("garbage collector successfully revoked upstream refresh token", logKV(secret))
+		return nil
+	case accesstoken.TypeLabelValue:
+		// For access token storage, check if the "offline_access" scope was granted on the downstream
+		// session. If it was not, then the user could not possibly have performed a downstream refresh.
+		// In this case, the access token storage has the latest version of the upstream refresh token,
+		// so call the upstream issuer to revoke it.
+		// TODO Implement ReadFromSecret in the accesstoken package, similar to how it was done in the authorizationcode package
+		// TODO Use that the new ReadFromSecret func to validate/parse the Secret, return any errors
+		// TODO return nil if the upstream type is not OIDC
+		// TODO return nil if the "offline_access" scope was *NOT* granted on the downstream session
+		// TODO lookup the idp by name in c.idpCache to get the cached provider interface, return error if not found
+		// TODO use the cached interface to revoke the refresh token, return any error
+		plog.Trace("garbage collector successfully revoked upstream refresh token", logKV(secret))
+		return nil
+	case refreshtoken.TypeLabelValue:
+		// For refresh token storage, revoke its upstream refresh token. This refresh token storage could
+		// be the result of the authcode token exchange, or it could be the result of a downstream refresh.
+		// Either way, it always contains the latest upstream refresh token when it exists.
+		// TODO Implement ReadFromSecret in the refreshtoken package, similar to how it was done in the authorizationcode package
+		// TODO Use that new ReadFromSecret func to validate/parse the Secret, return any errors
+		// TODO return nil if the upstream type is not OIDC
+		// TODO lookup the idp by name in c.idpCache to get the cached provider interface, return error if not found
+		// TODO use the cached interface to always revoke the refresh token, return any error
+		plog.Trace("garbage collector successfully revoked upstream refresh token", logKV(secret))
+		return nil
+	case pkce.TypeLabelValue:
+		// For PKCE storage, its very existence means that the authcode was never exchanged, because these
+		// are deleted during authcode exchange. No need to do anything, since the upstream refresh token
+		// revocation is handled by authcode storage case above.
+		return nil
+	case openidconnect.TypeLabelValue:
+		// For OIDC storage, there is no need to do anything for reasons similar to the PKCE storage.
+		// These are not deleted during authcode exchange, probably due to a bug in fosite, even though it
+		// will never be read or updated again. However, the refresh token contained inside will be revoked
+		// by one of the other cases above.
+		return nil
+	default:
+		// There are no other storage types, so this should never happen in practice.
+		return errors.New("garbage collector saw invalid label on Secret when trying to determine if upstream revocation was needed")
+	}
+}
+
 func logKV(secret *v1.Secret) []interface{} {
 	return []interface{}{
 		"secretName", secret.Name,
 		"secretNamespace", secret.Namespace,
 		"secretType", string(secret.Type),
 		"garbageCollectAfter", secret.Annotations[crud.SecretLifetimeAnnotationKey],
+		"storageTypeLabelValue", secret.Labels[crud.SecretLabelKey],
 	}
 }

--- a/internal/controller/supervisorstorage/garbage_collector.go
+++ b/internal/controller/supervisorstorage/garbage_collector.go
@@ -4,15 +4,19 @@
 package supervisorstorage
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"time"
 
+	coreosoidc "github.com/coreos/go-oidc/v3/oidc"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/clock"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/strings/slices"
 
 	pinnipedcontroller "go.pinniped.dev/internal/controller"
 	"go.pinniped.dev/internal/controllerlib"
@@ -24,6 +28,7 @@ import (
 	"go.pinniped.dev/internal/fositestorage/refreshtoken"
 	"go.pinniped.dev/internal/oidc/provider"
 	"go.pinniped.dev/internal/plog"
+	"go.pinniped.dev/internal/psession"
 )
 
 const minimumRepeatInterval = 30 * time.Second
@@ -119,10 +124,10 @@ func (c *garbageCollectorController) Sync(ctx controllerlib.Context) error {
 		if garbageCollectAfterTime.Before(frozenClock.Now()) {
 			storageType, isSessionStorage := secret.Labels[crud.SecretLabelKey]
 			if isSessionStorage {
-				err := c.maybeRevokeUpstreamOIDCRefreshToken(storageType, secret)
+				err := c.maybeRevokeUpstreamOIDCRefreshToken(ctx.Context, storageType, secret)
 				if err != nil {
 					// Log the error for debugging purposes, but still carry on to delete the Secret despite the error.
-					plog.DebugErr("garbage collector could not revoke upstream refresh token", err, logKV(secret))
+					plog.WarningErr("garbage collector could not revoke upstream refresh token", err, logKV(secret))
 				}
 			}
 
@@ -143,68 +148,94 @@ func (c *garbageCollectorController) Sync(ctx controllerlib.Context) error {
 	return nil
 }
 
-//nolint:godot // do not complain about the following to-do comment
-// TODO write unit tests for all of the following cases. Note that there is already a test
-//  double implemented for the RevokeRefreshToken() method on the objects in the idpCache
-//  to help with the test mocking. See RevokeRefreshTokenCallCount() and RevokeRefreshTokenArgs(int)
-//  in TestUpstreamOIDCIdentityProvider (in file oidctestutil.go). This will allowing following
-//  the pattern used in other unit tests that fill the idpCache with mock providers using the builders
-//  from oidctestutil.go.
-func (c *garbageCollectorController) maybeRevokeUpstreamOIDCRefreshToken(storageType string, secret *v1.Secret) error {
+func (c *garbageCollectorController) maybeRevokeUpstreamOIDCRefreshToken(ctx context.Context, storageType string, secret *v1.Secret) error {
 	// All session storage types hold upstream refresh tokens when the upstream IDP is an OIDC provider.
 	// However, some of them will be outdated because they are not updated by fosite after creation.
 	// Our goal below is to always revoke the latest upstream refresh token that we are holding for the
 	// session, and only the latest.
 	switch storageType {
 	case authorizationcode.TypeLabelValue:
-		// For authcode storage, check if the authcode was used. If the authcode was never used, then its
-		// storage must contain the latest upstream refresh token, so revoke it.
-		// TODO Use ReadFromSecret from the authorizationcode package under fositestorage to validate/parse the Secret, return any errors
-		// TODO return nil if the upstream type is not OIDC
-		// TODO return nil if the authcode is *NOT* active (meaning that it was already used)
-		// TODO lookup the idp by name in c.idpCache to get the cached provider interface, return error if not found
-		// TODO use the cached interface to revoke the refresh token, return any error
-		plog.Trace("garbage collector successfully revoked upstream refresh token", logKV(secret))
-		return nil
+		authorizeCodeSession, err := authorizationcode.ReadFromSecret(secret)
+		if err != nil {
+			return err
+		}
+		// Check if this downstream authcode was already used. If it was already used (i.e. not active anymore), then
+		// the latest upstream refresh token can be found in one of the other storage types handled below instead.
+		if !authorizeCodeSession.Active {
+			return nil
+		}
+		// When the downstream authcode was never used, then its storage must contain the latest upstream refresh token.
+		return c.revokeUpstreamOIDCRefreshToken(ctx, authorizeCodeSession.Request.Session.(*psession.PinnipedSession).Custom, secret)
+
 	case accesstoken.TypeLabelValue:
-		// For access token storage, check if the "offline_access" scope was granted on the downstream
-		// session. If it was not, then the user could not possibly have performed a downstream refresh.
-		// In this case, the access token storage has the latest version of the upstream refresh token,
-		// so call the upstream issuer to revoke it.
-		// TODO Implement ReadFromSecret in the accesstoken package, similar to how it was done in the authorizationcode package
-		// TODO Use that the new ReadFromSecret func to validate/parse the Secret, return any errors
-		// TODO return nil if the upstream type is not OIDC
-		// TODO return nil if the "offline_access" scope was *NOT* granted on the downstream session
-		// TODO lookup the idp by name in c.idpCache to get the cached provider interface, return error if not found
-		// TODO use the cached interface to revoke the refresh token, return any error
-		plog.Trace("garbage collector successfully revoked upstream refresh token", logKV(secret))
-		return nil
+		// For access token storage, check if the "offline_access" scope was granted on the downstream session.
+		// If it was granted, then the latest upstream refresh token should be found in the refresh token storage instead.
+		// If it was not granted, then the user could not possibly have performed a downstream refresh, so the
+		// access token storage has the latest version of the upstream refresh token.
+		accessTokenSession, err := accesstoken.ReadFromSecret(secret)
+		if err != nil {
+			return err
+		}
+		pinnipedSession := accessTokenSession.Request.Session.(*psession.PinnipedSession)
+		if slices.Contains(accessTokenSession.Request.GetGrantedScopes(), coreosoidc.ScopeOfflineAccess) {
+			return nil
+		}
+		return c.revokeUpstreamOIDCRefreshToken(ctx, pinnipedSession.Custom, secret)
+
 	case refreshtoken.TypeLabelValue:
-		// For refresh token storage, revoke its upstream refresh token. This refresh token storage could
-		// be the result of the authcode token exchange, or it could be the result of a downstream refresh.
-		// Either way, it always contains the latest upstream refresh token when it exists.
-		// TODO Implement ReadFromSecret in the refreshtoken package, similar to how it was done in the authorizationcode package
-		// TODO Use that new ReadFromSecret func to validate/parse the Secret, return any errors
-		// TODO return nil if the upstream type is not OIDC
-		// TODO lookup the idp by name in c.idpCache to get the cached provider interface, return error if not found
-		// TODO use the cached interface to always revoke the refresh token, return any error
-		plog.Trace("garbage collector successfully revoked upstream refresh token", logKV(secret))
-		return nil
+		// For refresh token storage, always revoke its upstream refresh token. This refresh token storage could
+		// be the result of the initial downstream authcode exchange, or it could be the result of a downstream
+		// refresh. Either way, it always contains the latest upstream refresh token when it exists.
+		refreshTokenSession, err := refreshtoken.ReadFromSecret(secret)
+		if err != nil {
+			return err
+		}
+		return c.revokeUpstreamOIDCRefreshToken(ctx, refreshTokenSession.Request.Session.(*psession.PinnipedSession).Custom, secret)
+
 	case pkce.TypeLabelValue:
 		// For PKCE storage, its very existence means that the authcode was never exchanged, because these
 		// are deleted during authcode exchange. No need to do anything, since the upstream refresh token
 		// revocation is handled by authcode storage case above.
 		return nil
+
 	case openidconnect.TypeLabelValue:
 		// For OIDC storage, there is no need to do anything for reasons similar to the PKCE storage.
 		// These are not deleted during authcode exchange, probably due to a bug in fosite, even though it
 		// will never be read or updated again. However, the refresh token contained inside will be revoked
 		// by one of the other cases above.
 		return nil
+
 	default:
 		// There are no other storage types, so this should never happen in practice.
 		return errors.New("garbage collector saw invalid label on Secret when trying to determine if upstream revocation was needed")
 	}
+}
+
+func (c *garbageCollectorController) revokeUpstreamOIDCRefreshToken(ctx context.Context, customSessionData *psession.CustomSessionData, secret *v1.Secret) error {
+	// When session was for another upstream IDP type, e.g. LDAP, there is no upstream OIDC refresh token involved.
+	if customSessionData.ProviderType != psession.ProviderTypeOIDC {
+		return nil
+	}
+
+	// Try to find the provider that was originally used to create the stored session.
+	var foundOIDCIdentityProviderI provider.UpstreamOIDCIdentityProviderI
+	for _, p := range c.idpCache.GetOIDCIdentityProviders() {
+		if p.GetName() == customSessionData.ProviderName && p.GetResourceUID() == customSessionData.ProviderUID {
+			foundOIDCIdentityProviderI = p
+		}
+	}
+	if foundOIDCIdentityProviderI == nil {
+		return fmt.Errorf("could not find upstream OIDC provider named %q with resource UID %q", customSessionData.ProviderName, customSessionData.ProviderUID)
+	}
+
+	// Revoke the upstream refresh token. This is a noop if the upstream provider does not offer a revocation endpoint.
+	err := foundOIDCIdentityProviderI.RevokeRefreshToken(ctx, customSessionData.OIDC.UpstreamRefreshToken)
+	if err != nil {
+		return err
+	}
+
+	plog.Trace("garbage collector successfully revoked upstream OIDC refresh token (or provider has no revocation endpoint)", logKV(secret))
+	return nil
 }
 
 func logKV(secret *v1.Secret) []interface{} {

--- a/internal/controller/supervisorstorage/garbage_collector_test.go
+++ b/internal/controller/supervisorstorage/garbage_collector_test.go
@@ -39,6 +39,7 @@ func TestGarbageCollectorControllerInformerFilters(t *testing.T) {
 			observableWithInformerOption = testutil.NewObservableWithInformerOption()
 			secretsInformer := kubeinformers.NewSharedInformerFactory(nil, 0).Core().V1().Secrets()
 			_ = GarbageCollectorController(
+				nil,
 				clock.RealClock{},
 				nil,
 				secretsInformer,
@@ -132,6 +133,7 @@ func TestGarbageCollectorControllerSync(t *testing.T) {
 		var startInformersAndController = func() {
 			// Set this at the last second to allow for injection of server override.
 			subject = GarbageCollectorController(
+				nil, // TODO put an IDP cache here for these tests (use the builder like other controller tests)
 				fakeClock,
 				deleteOptionsRecorder,
 				kubeInformers.Core().V1().Secrets(),

--- a/internal/fositestorage/authorizationcode/authorizationcode.go
+++ b/internal/fositestorage/authorizationcode/authorizationcode.go
@@ -39,7 +39,7 @@ type authorizeCodeStorage struct {
 	storage crud.Storage
 }
 
-type AuthorizeCodeSession struct {
+type Session struct {
 	Active  bool            `json:"active"`
 	Request *fosite.Request `json:"request"`
 	Version string          `json:"version"`
@@ -49,8 +49,8 @@ func New(secrets corev1client.SecretInterface, clock func() time.Time, sessionSt
 	return &authorizeCodeStorage{storage: crud.New(TypeLabelValue, secrets, clock, sessionStorageLifetime)}
 }
 
-// ReadFromSecret reads the contents of a Secret as an AuthorizeCodeSession.
-func ReadFromSecret(secret *v1.Secret) (*AuthorizeCodeSession, error) {
+// ReadFromSecret reads the contents of a Secret as a Session.
+func ReadFromSecret(secret *v1.Secret) (*Session, error) {
 	session := NewValidEmptyAuthorizeCodeSession()
 	err := crud.FromSecret(TypeLabelValue, secret, session)
 	if err != nil {
@@ -88,7 +88,7 @@ func (a *authorizeCodeStorage) CreateAuthorizeCodeSession(ctx context.Context, s
 	//      of the consent authorization request. It is used to identify the session.
 	//  signature for lookup in the DB
 
-	_, err = a.storage.Create(ctx, signature, &AuthorizeCodeSession{Active: true, Request: request, Version: authorizeCodeStorageVersion}, nil)
+	_, err = a.storage.Create(ctx, signature, &Session{Active: true, Request: request, Version: authorizeCodeStorageVersion}, nil)
 	return err
 }
 
@@ -126,7 +126,7 @@ func (a *authorizeCodeStorage) InvalidateAuthorizeCodeSession(ctx context.Contex
 	return nil
 }
 
-func (a *authorizeCodeStorage) getSession(ctx context.Context, signature string) (*AuthorizeCodeSession, string, error) {
+func (a *authorizeCodeStorage) getSession(ctx context.Context, signature string) (*Session, string, error) {
 	session := NewValidEmptyAuthorizeCodeSession()
 	rv, err := a.storage.Get(ctx, signature, session)
 
@@ -155,8 +155,8 @@ func (a *authorizeCodeStorage) getSession(ctx context.Context, signature string)
 	return session, rv, nil
 }
 
-func NewValidEmptyAuthorizeCodeSession() *AuthorizeCodeSession {
-	return &AuthorizeCodeSession{
+func NewValidEmptyAuthorizeCodeSession() *Session {
+	return &Session{
 		Request: &fosite.Request{
 			Client:  &clientregistry.Client{},
 			Session: &psession.PinnipedSession{},

--- a/internal/fositestorage/authorizationcode/authorizationcode_test.go
+++ b/internal/fositestorage/authorizationcode/authorizationcode_test.go
@@ -403,7 +403,7 @@ func TestReadFromSecret(t *testing.T) {
 	tests := []struct {
 		name        string
 		secret      *corev1.Secret
-		wantSession *AuthorizeCodeSession
+		wantSession *Session
 		wantErr     string
 	}{
 		{
@@ -422,7 +422,7 @@ func TestReadFromSecret(t *testing.T) {
 				},
 				Type: "storage.pinniped.dev/authcode",
 			},
-			wantSession: &AuthorizeCodeSession{
+			wantSession: &Session{
 				Version: "2",
 				Active:  true,
 				Request: &fosite.Request{

--- a/internal/fositestorage/refreshtoken/refreshtoken_test.go
+++ b/internal/fositestorage/refreshtoken/refreshtoken_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ory/fosite"
+	"github.com/ory/fosite/handler/openid"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -276,4 +277,120 @@ func makeTestSubject() (context.Context, *fake.Clientset, corev1client.SecretInt
 	client := fake.NewSimpleClientset()
 	secrets := client.CoreV1().Secrets(namespace)
 	return context.Background(), client, secrets, New(secrets, clock.NewFakeClock(fakeNow).Now, lifetime)
+}
+
+func TestReadFromSecret(t *testing.T) {
+	tests := []struct {
+		name        string
+		secret      *corev1.Secret
+		wantSession *Session
+		wantErr     string
+	}{
+		{
+			name: "happy path",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "pinniped-storage-refresh-token-pwu5zs7lekbhnln2w4",
+					ResourceVersion: "",
+					Labels: map[string]string{
+						"storage.pinniped.dev/type": "refresh-token",
+					},
+				},
+				Data: map[string][]byte{
+					"pinniped-storage-data":    []byte(`{"request":{"id":"abcd-1","session":{"fosite":{"Claims":null,"Headers":null,"ExpiresAt":null,"Username":"snorlax","Subject":"panda"},"custom":{"providerUID":"fake-provider-uid","providerName":"fake-provider-name","providerType":"fake-provider-type","oidc":{"upstreamRefreshToken":"fake-upstream-refresh-token"}}}},"version":"2","active": true}`),
+					"pinniped-storage-version": []byte("1"),
+				},
+				Type: "storage.pinniped.dev/refresh-token",
+			},
+			wantSession: &Session{
+				Version: "2",
+				Request: &fosite.Request{
+					ID:     "abcd-1",
+					Client: &clientregistry.Client{},
+					Session: &psession.PinnipedSession{
+						Fosite: &openid.DefaultSession{
+							Username: "snorlax",
+							Subject:  "panda",
+						},
+						Custom: &psession.CustomSessionData{
+							ProviderUID:  "fake-provider-uid",
+							ProviderName: "fake-provider-name",
+							ProviderType: "fake-provider-type",
+							OIDC: &psession.OIDCSessionData{
+								UpstreamRefreshToken: "fake-upstream-refresh-token",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "wrong secret type",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "pinniped-storage-refresh-token-pwu5zs7lekbhnln2w4",
+					ResourceVersion: "",
+					Labels: map[string]string{
+						"storage.pinniped.dev/type": "refresh-token",
+					},
+				},
+				Data: map[string][]byte{
+					"pinniped-storage-data":    []byte(`{"request":{"id":"abcd-1"},"version":"2","active": true}`),
+					"pinniped-storage-version": []byte("1"),
+				},
+				Type: "storage.pinniped.dev/not-refresh-token",
+			},
+			wantErr: "secret storage data has incorrect type: storage.pinniped.dev/not-refresh-token must equal storage.pinniped.dev/refresh-token",
+		},
+		{
+			name: "wrong session version",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "pinniped-storage-refresh-token-pwu5zs7lekbhnln2w4",
+					ResourceVersion: "",
+					Labels: map[string]string{
+						"storage.pinniped.dev/type": "refresh-token",
+					},
+				},
+				Data: map[string][]byte{
+					"pinniped-storage-data":    []byte(`{"request":{"id":"abcd-1"},"version":"wrong-version-here","active": true}`),
+					"pinniped-storage-version": []byte("1"),
+				},
+				Type: "storage.pinniped.dev/refresh-token",
+			},
+			wantErr: "refresh token request data has wrong version: refresh token session has version wrong-version-here instead of 2",
+		},
+		{
+			name: "missing request",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "pinniped-storage-refresh-token-pwu5zs7lekbhnln2w4",
+					ResourceVersion: "",
+					Labels: map[string]string{
+						"storage.pinniped.dev/type": "refresh-token",
+					},
+				},
+				Data: map[string][]byte{
+					"pinniped-storage-data":    []byte(`{"version":"2","active": true}`),
+					"pinniped-storage-version": []byte("1"),
+				},
+				Type: "storage.pinniped.dev/refresh-token",
+			},
+			wantErr: "malformed refresh token session: refresh token request data must be present",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			session, err := ReadFromSecret(tt.secret)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				require.Equal(t, tt.wantSession, session)
+			} else {
+				require.EqualError(t, err, tt.wantErr)
+				require.Nil(t, session)
+			}
+		})
+	}
 }

--- a/internal/mocks/mockupstreamoidcidentityprovider/mockupstreamoidcidentityprovider.go
+++ b/internal/mocks/mockupstreamoidcidentityprovider/mockupstreamoidcidentityprovider.go
@@ -215,6 +215,20 @@ func (mr *MockUpstreamOIDCIdentityProviderIMockRecorder) PerformRefresh(arg0, ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PerformRefresh", reflect.TypeOf((*MockUpstreamOIDCIdentityProviderI)(nil).PerformRefresh), arg0, arg1)
 }
 
+// RevokeRefreshToken mocks base method.
+func (m *MockUpstreamOIDCIdentityProviderI) RevokeRefreshToken(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RevokeRefreshToken", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RevokeRefreshToken indicates an expected call of RevokeRefreshToken.
+func (mr *MockUpstreamOIDCIdentityProviderIMockRecorder) RevokeRefreshToken(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeRefreshToken", reflect.TypeOf((*MockUpstreamOIDCIdentityProviderI)(nil).RevokeRefreshToken), arg0, arg1)
+}
+
 // ValidateToken mocks base method.
 func (m *MockUpstreamOIDCIdentityProviderI) ValidateToken(arg0 context.Context, arg1 *oauth2.Token, arg2 nonce.Nonce) (*oidctypes.Token, error) {
 	m.ctrl.T.Helper()

--- a/internal/oidc/provider/dynamic_upstream_idp_provider.go
+++ b/internal/oidc/provider/dynamic_upstream_idp_provider.go
@@ -68,6 +68,9 @@ type UpstreamOIDCIdentityProviderI interface {
 	// validate the ID token.
 	PerformRefresh(ctx context.Context, refreshToken string) (*oauth2.Token, error)
 
+	// RevokeRefreshToken will attempt to revoke the given token, if the provider has a revocation endpoint.
+	RevokeRefreshToken(ctx context.Context, refreshToken string) error
+
 	// ValidateToken will validate the ID token. It will also merge the claims from the userinfo endpoint response
 	// into the ID token's claims, if the provider offers the userinfo endpoint. It returns the validated/updated
 	// tokens, or an error.

--- a/internal/supervisor/server/server.go
+++ b/internal/supervisor/server/server.go
@@ -124,6 +124,7 @@ func prepareControllers(
 		NewManager().
 		WithController(
 			supervisorstorage.GarbageCollectorController(
+				dynamicUpstreamIDPProvider,
 				clock.RealClock{},
 				kubeClient,
 				secretInformer,

--- a/internal/upstreamoidc/upstreamoidc.go
+++ b/internal/upstreamoidc/upstreamoidc.go
@@ -8,8 +8,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	coreosoidc "github.com/coreos/go-oidc/v3/oidc"
 	"golang.org/x/oauth2"
@@ -40,6 +42,7 @@ type ProviderConfig struct {
 	Client                   *http.Client
 	AllowPasswordGrant       bool
 	AdditionalAuthcodeParams map[string]string
+	RevocationURL            *url.URL // will commonly be nil: many providers do not offer this
 	Provider                 interface {
 		Verifier(*coreosoidc.Config) *coreosoidc.IDTokenVerifier
 		Claims(v interface{}) error
@@ -51,6 +54,10 @@ var _ provider.UpstreamOIDCIdentityProviderI = (*ProviderConfig)(nil)
 
 func (p *ProviderConfig) GetResourceUID() types.UID {
 	return p.ResourceUID
+}
+
+func (p *ProviderConfig) GetRevocationURL() *url.URL {
+	return p.RevocationURL
 }
 
 func (p *ProviderConfig) GetAdditionalAuthcodeParams() map[string]string {
@@ -128,6 +135,100 @@ func (p *ProviderConfig) PerformRefresh(ctx context.Context, refreshToken string
 	// Create a TokenSource without an access token, so it thinks that a refresh is immediately required.
 	// Then ask it for the tokens to cause it to perform the refresh and return the results.
 	return p.Config.TokenSource(httpClientContext, &oauth2.Token{RefreshToken: refreshToken}).Token()
+}
+
+// RevokeRefreshToken will attempt to revoke the given token, if the provider has a revocation endpoint.
+func (p *ProviderConfig) RevokeRefreshToken(ctx context.Context, refreshToken string) error {
+	if p.RevocationURL == nil {
+		return nil
+	}
+	// First try using client auth in the request params.
+	tryAnotherClientAuthMethod, err := p.tryRevokeRefreshToken(ctx, refreshToken, false)
+	if tryAnotherClientAuthMethod {
+		// Try again using basic auth this time. Overwrite the first client auth error,
+		// which isn't useful anymore when retrying.
+		_, err = p.tryRevokeRefreshToken(ctx, refreshToken, true)
+	}
+	return err
+}
+
+// tryRevokeRefreshToken will call the revocation endpoint using either basic auth or by including
+// client auth in the request params. It will return an error when the request failed. If the
+// request failed for a reason that might be due to bad client auth, then it will return true
+// for the tryAnotherClientAuthMethod return value, indicating that it might be worth trying
+// again using the other client auth method.
+// RFC 7009 defines how to make a revocation request and how to interpret the response.
+// See https://datatracker.ietf.org/doc/html/rfc7009#section-2.1 for details.
+func (p *ProviderConfig) tryRevokeRefreshToken(
+	ctx context.Context,
+	refreshToken string,
+	useBasicAuth bool,
+) (tryAnotherClientAuthMethod bool, err error) {
+	clientID := p.Config.ClientID
+	clientSecret := p.Config.ClientSecret
+	// Use the provided HTTP client to benefit from its CA, proxy, and other settings.
+	httpClient := p.Client
+
+	params := url.Values{
+		"token":           []string{refreshToken},
+		"token_type_hint": []string{"refresh_token"},
+	}
+	if !useBasicAuth {
+		params["client_id"] = []string{clientID}
+		params["client_secret"] = []string{clientSecret}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.RevocationURL.String(), strings.NewReader(params.Encode()))
+	if err != nil {
+		// This shouldn't really happen since we already know that the method and URL are legal.
+		return false, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	if useBasicAuth {
+		req.SetBasicAuth(clientID, clientSecret)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		// Couldn't connect to the server or some similar error.
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// Success!
+		return false, nil
+	case http.StatusBadRequest:
+		// Bad request might be due to bad client auth method. Try to detect that.
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return false,
+				fmt.Errorf("error reading response body on response with status code %d: %w", resp.StatusCode, err)
+		}
+		var parsedResp struct {
+			ErrorType        string `json:"error"`
+			ErrorDescription string `json:"error_description"`
+		}
+		bodyStr := strings.TrimSpace(string(body)) // trimmed for logging purposes
+		err = json.Unmarshal(body, &parsedResp)
+		if err != nil {
+			return false,
+				fmt.Errorf("error parsing response body %q on response with status code %d: %w", bodyStr, resp.StatusCode, err)
+		}
+		err = fmt.Errorf("server responded with status %d with body: %s", resp.StatusCode, bodyStr)
+		if parsedResp.ErrorType != "invalid_client" {
+			// Got an error unrelated to client auth, so not worth trying again.
+			return false, err
+		}
+		// Got an "invalid_client" response, which might mean client auth failed, so it may be worth trying again
+		// using another client auth method. See https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
+		return true, err
+	default:
+		// Any other error is probably not due to failed client auth.
+		return false, fmt.Errorf("server responded with status %d", resp.StatusCode)
+	}
 }
 
 // ValidateToken will validate the ID token. It will also merge the claims from the userinfo endpoint response,


### PR DESCRIPTION
Revoke upstream refresh tokens during downstream session garbage collection

- Discover the revocation endpoint of the upstream provider in OIDC upstream watcher controller, and save it into the cache for future use by the garbage collector controller
- Adds RevokeRefreshToken() to UpstreamOIDCIdentityProviderI
- Implements the production version of RevokeRefreshToken()
- Implements test doubles for RevokeRefreshToken() for future use in garbage collector's unit tests
- Refactors the crud and session storage types for use in the garbage collector controller
- Updates the garbage collector controller to perform new upstream OIDC refresh token revocation business logic based on type of fosite storage Secret
- When upstream revocation fails, keep the Secret for a while so the garbage collector can keep retrying

**Release note**:

```release-note
Revokes upstream refresh tokens during downstream session garbage collection for sessions started using upstream OIDC providers.
```
