### PR TITLE
Upstream ldap refresh

### DIFF
--- a/internal/authenticators/authenticators.go
+++ b/internal/authenticators/authenticators.go
@@ -7,7 +7,7 @@ package authenticators
 import (
 	"context"
 
-	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/user"
 )
 
 // This interface is similar to the k8s token authenticator, but works with username/passwords instead
@@ -31,5 +31,10 @@ import (
 // See k8s.io/apiserver/pkg/authentication/authenticator/interfaces.go for the token authenticator
 // interface, as well as the Response type.
 type UserAuthenticator interface {
-	AuthenticateUser(ctx context.Context, username, password string) (*authenticator.Response, bool, error)
+	AuthenticateUser(ctx context.Context, username, password string) (*Response, bool, error)
+}
+
+type Response struct {
+	User user.Info
+	DN   string
 }

--- a/internal/fositestorage/authorizationcode/authorizationcode.go
+++ b/internal/fositestorage/authorizationcode/authorizationcode.go
@@ -328,14 +328,22 @@ const ExpectedAuthorizeCodeSessionJSONFromFuzzing = `{
 				"providerType": "闣ʬ橳(ý綃ʃʚƟ覣k眐4Ĉt",
 				"oidc": {
 					"upstreamRefreshToken": "嵽痊w©Ź榨Q|ôɵt毇妬"
+				},
+				"ldap": {
+					"userDN": "6鉢緋uƴŤȱʀļÂ?墖\u003cƬb獭潜Ʃ饾"
+				},
+				"activedirectory": {
+					"userDN": "|鬌R蜚蠣麹概÷驣7Ʀ澉1æɽ誮rʨ鷞"
 				}
 			}
 		},
 		"requestedAudience": [
-			"6鉢緋uƴŤȱʀļÂ?墖\u003cƬb獭潜Ʃ饾"
+			"ŚB碠k9"
 		],
 		"grantedAudience": [
-			"|鬌R蜚蠣麹概÷驣7Ʀ澉1æɽ誮rʨ鷞"
+			"ʘ赱",
+			"ď逳鞪?3)藵睋邔\u0026Ű惫蜀Ģ¡圔",
+			"墀jMʥ"
 		]
 	},
 	"version": "2"

--- a/internal/oidc/auth/auth_handler.go
+++ b/internal/oidc/auth/auth_handler.go
@@ -113,9 +113,6 @@ func handleAuthRequestForLDAPUpstream(
 	username = authenticateResponse.User.GetName()
 	groups := authenticateResponse.User.GetGroups()
 	dn := userDNFromAuthenticatedResponse(authenticateResponse)
-	if dn == "" {
-		return httperr.New(http.StatusInternalServerError, "unexpected error during upstream authentication")
-	}
 
 	customSessionData := &psession.CustomSessionData{
 		ProviderUID:  ldapUpstream.GetResourceUID(),
@@ -491,7 +488,7 @@ func downstreamSubjectFromUpstreamLDAP(ldapUpstream provider.UpstreamLDAPIdentit
 }
 
 func userDNFromAuthenticatedResponse(authenticatedResponse *authenticator.Response) string {
-	// This error shouldn't happen, but do some error checking anyway so it doesn't panic
+	// We should always have something here, but do some error checking anyway so it doesn't panic
 	dnSlice := authenticatedResponse.User.GetExtra()["userDN"]
 	if len(dnSlice) != 1 {
 		return ""

--- a/internal/oidc/auth/auth_handler.go
+++ b/internal/oidc/auth/auth_handler.go
@@ -491,12 +491,8 @@ func downstreamSubjectFromUpstreamLDAP(ldapUpstream provider.UpstreamLDAPIdentit
 }
 
 func userDNFromAuthenticatedResponse(authenticatedResponse *authenticator.Response) string {
-	// These errors shouldn't happen, but do some error checking anyway so it doesn't panic
-	extra := authenticatedResponse.User.GetExtra()
-	if len(extra) == 0 {
-		return ""
-	}
-	dnSlice := extra["userDN"]
+	// This error shouldn't happen, but do some error checking anyway so it doesn't panic
+	dnSlice := authenticatedResponse.User.GetExtra()["userDN"]
 	if len(dnSlice) != 1 {
 		return ""
 	}

--- a/internal/oidc/auth/auth_handler.go
+++ b/internal/oidc/auth/auth_handler.go
@@ -487,10 +487,7 @@ func addCSRFSetCookieHeader(w http.ResponseWriter, csrfValue csrftoken.CSRFToken
 
 func downstreamSubjectFromUpstreamLDAP(ldapUpstream provider.UpstreamLDAPIdentityProviderI, authenticateResponse *authenticator.Response) string {
 	ldapURL := *ldapUpstream.GetURL()
-	q := ldapURL.Query()
-	q.Set(oidc.IDTokenSubjectClaim, authenticateResponse.User.GetUID())
-	ldapURL.RawQuery = q.Encode()
-	return ldapURL.String()
+	return downstreamsession.DownstreamLDAPSubject(authenticateResponse.User.GetUID(), ldapURL)
 }
 
 func userDNFromAuthenticatedResponse(authenticatedResponse *authenticator.Response) string {

--- a/internal/oidc/auth/auth_handler_test.go
+++ b/internal/oidc/auth/auth_handler_test.go
@@ -267,6 +267,7 @@ func TestAuthorizationEndpoint(t *testing.T) {
 	happyLDAPUsernameFromAuthenticator := "some-mapped-ldap-username"
 	happyLDAPPassword := "some-ldap-password" //nolint:gosec
 	happyLDAPUID := "some-ldap-uid"
+	happyLDAPUserDN := "cn=foo,dn=bar"
 	happyLDAPGroups := []string{"group1", "group2", "group3"}
 
 	parsedUpstreamLDAPURL, err := url.Parse(upstreamLDAPURL)
@@ -282,6 +283,7 @@ func TestAuthorizationEndpoint(t *testing.T) {
 					Name:   happyLDAPUsernameFromAuthenticator,
 					UID:    happyLDAPUID,
 					Groups: happyLDAPGroups,
+					Extra:  map[string][]string{"userDN": {happyLDAPUserDN}},
 				},
 			}, true, nil
 		}
@@ -438,6 +440,10 @@ func TestAuthorizationEndpoint(t *testing.T) {
 		ProviderName: activeDirectoryUpstreamName,
 		ProviderType: psession.ProviderTypeActiveDirectory,
 		OIDC:         nil,
+		LDAP:         nil,
+		ActiveDirectory: &psession.ActiveDirectorySessionData{
+			UserDN: happyLDAPUserDN,
+		},
 	}
 
 	expectedHappyLDAPUpstreamCustomSession := &psession.CustomSessionData{
@@ -445,6 +451,10 @@ func TestAuthorizationEndpoint(t *testing.T) {
 		ProviderName: ldapUpstreamName,
 		ProviderType: psession.ProviderTypeLDAP,
 		OIDC:         nil,
+		LDAP: &psession.LDAPSessionData{
+			UserDN: happyLDAPUserDN,
+		},
+		ActiveDirectory: nil,
 	}
 
 	expectedHappyOIDCPasswordGrantCustomSession := &psession.CustomSessionData{

--- a/internal/oidc/downstreamsession/downstream_session.go
+++ b/internal/oidc/downstreamsession/downstream_session.go
@@ -169,6 +169,13 @@ func extractStringClaimValue(claimName string, upstreamIDPName string, idTokenCl
 	return valueAsString, nil
 }
 
+func DownstreamLDAPSubject(uid string, ldapURL url.URL) string {
+	q := ldapURL.Query()
+	q.Set(oidc.IDTokenSubjectClaim, uid)
+	ldapURL.RawQuery = q.Encode()
+	return ldapURL.String()
+}
+
 func downstreamSubjectFromUpstreamOIDC(upstreamIssuerAsString string, upstreamSubject string) string {
 	return fmt.Sprintf("%s?%s=%s", upstreamIssuerAsString, oidc.IDTokenSubjectClaim, url.QueryEscape(upstreamSubject))
 }

--- a/internal/oidc/provider/dynamic_upstream_idp_provider.go
+++ b/internal/oidc/provider/dynamic_upstream_idp_provider.go
@@ -90,7 +90,7 @@ type UpstreamLDAPIdentityProviderI interface {
 	authenticators.UserAuthenticator
 
 	// PerformRefresh performs a refresh against the upstream LDAP identity provider
-	PerformRefresh(ctx context.Context, userDN string) error
+	PerformRefresh(ctx context.Context, userDN string, expectedUsername string, expectedSubject string) error
 }
 
 type DynamicUpstreamIDPProvider interface {

--- a/internal/oidc/provider/dynamic_upstream_idp_provider.go
+++ b/internal/oidc/provider/dynamic_upstream_idp_provider.go
@@ -88,6 +88,9 @@ type UpstreamLDAPIdentityProviderI interface {
 
 	// UserAuthenticator adds an interface method for performing user authentication against the upstream LDAP provider.
 	authenticators.UserAuthenticator
+
+	// PerformRefresh performs a refresh against the upstream LDAP identity provider
+	PerformRefresh(ctx context.Context, userDN string) error
 }
 
 type DynamicUpstreamIDPProvider interface {

--- a/internal/oidc/provider/dynamic_upstream_idp_provider.go
+++ b/internal/oidc/provider/dynamic_upstream_idp_provider.go
@@ -90,7 +90,7 @@ type UpstreamLDAPIdentityProviderI interface {
 	authenticators.UserAuthenticator
 
 	// PerformRefresh performs a refresh against the upstream LDAP identity provider
-	PerformRefresh(ctx context.Context, userDN string, expectedUsername string, expectedSubject string) error
+	PerformRefresh(ctx context.Context, userDN, expectedUsername, expectedSubject string) error
 }
 
 type DynamicUpstreamIDPProvider interface {

--- a/internal/oidc/token/token_handler.go
+++ b/internal/oidc/token/token_handler.go
@@ -118,9 +118,9 @@ func upstreamOIDCRefresh(ctx context.Context, s *psession.CustomSessionData, pro
 
 	refreshedTokens, err := p.PerformRefresh(ctx, s.OIDC.UpstreamRefreshToken)
 	if err != nil {
-		return errorsx.WithStack(errUpstreamRefreshError.WithHintf(
-			"Upstream refresh failed using provider %q of type %q.",
-			s.ProviderName, s.ProviderType).WithWrap(err))
+		return errorsx.WithStack(errUpstreamRefreshError.WithHint(
+			"Upstream refresh failed.",
+		).WithWrap(err).WithDebugf("provider name: %q, provider type: %q", s.ProviderName, s.ProviderType))
 	}
 
 	// Upstream refresh may or may not return a new ID token. From the spec:
@@ -133,8 +133,7 @@ func upstreamOIDCRefresh(ctx context.Context, s *psession.CustomSessionData, pro
 		_, err = p.ValidateToken(ctx, refreshedTokens, "")
 		if err != nil {
 			return errorsx.WithStack(errUpstreamRefreshError.WithHintf(
-				"Upstream refresh returned an invalid ID token using provider %q of type %q.",
-				s.ProviderName, s.ProviderType).WithWrap(err))
+				"Upstream refresh returned an invalid ID token.").WithWrap(err).WithDebugf("provider name: %q, provider type: %q", s.ProviderName, s.ProviderType))
 		}
 	} else {
 		plog.Debug("upstream refresh request did not return a new ID token",
@@ -167,7 +166,7 @@ func findOIDCProviderByNameAndValidateUID(
 		}
 	}
 	return nil, errorsx.WithStack(errUpstreamRefreshError.
-		WithHintf("Provider %q of type %q from upstream session data was not found.", s.ProviderName, s.ProviderType))
+		WithHint("Provider from upstream session data was not found.").WithDebugf("provider name: %q, provider type: %q", s.ProviderName, s.ProviderType))
 }
 
 func upstreamLDAPRefresh(ctx context.Context, s *psession.CustomSessionData, providerCache oidc.UpstreamIdentityProvidersLister, username string, subject string) error {
@@ -186,9 +185,8 @@ func upstreamLDAPRefresh(ctx context.Context, s *psession.CustomSessionData, pro
 	// run PerformRefresh
 	err = p.PerformRefresh(ctx, dn, username, subject)
 	if err != nil {
-		return errorsx.WithStack(errUpstreamRefreshError.WithHintf(
-			"Upstream refresh failed using provider %q of type %q.",
-			s.ProviderName, s.ProviderType).WithWrap(err))
+		return errorsx.WithStack(errUpstreamRefreshError.WithHint(
+			"Upstream refresh failed.").WithWrap(err).WithDebugf("provider name: %q, provider type: %q", s.ProviderName, s.ProviderType))
 	}
 
 	return nil
@@ -211,16 +209,15 @@ func findLDAPProviderByNameAndValidateUID(
 	for _, p := range providers {
 		if p.GetName() == s.ProviderName {
 			if p.GetResourceUID() != s.ProviderUID {
-				return nil, "", errorsx.WithStack(errUpstreamRefreshError.WithHintf(
-					"Provider %q of type %q from upstream session data has changed its resource UID since authentication.",
-					s.ProviderName, s.ProviderType))
+				return nil, "", errorsx.WithStack(errUpstreamRefreshError.WithHint(
+					"Provider from upstream session data has changed its resource UID since authentication.").WithDebugf("provider name: %q, provider type: %q", s.ProviderName, s.ProviderType))
 			}
 			return p, dn, nil
 		}
 	}
 
 	return nil, "", errorsx.WithStack(errUpstreamRefreshError.
-		WithHintf("Provider %q of type %q from upstream session data was not found.", s.ProviderName, s.ProviderType))
+		WithHint("Provider from upstream session data was not found.").WithDebugf("provider name: %q, provider type: %q", s.ProviderName, s.ProviderType))
 }
 
 func getDownstreamUsernameFromPinnipedSession(session *psession.PinnipedSession) (string, error) {

--- a/internal/oidc/token/token_handler_test.go
+++ b/internal/oidc/token/token_handler_test.go
@@ -1020,12 +1020,28 @@ func TestRefreshGrant(t *testing.T) {
 		return tokens
 	}
 
+	happyActiveDirectoryCustomSessionData := &psession.CustomSessionData{
+		ProviderUID:  activeDirectoryUpstreamResourceUID,
+		ProviderName: activeDirectoryUpstreamName,
+		ProviderType: activeDirectoryUpstreamType,
+		ActiveDirectory: &psession.ActiveDirectorySessionData{
+			UserDN: activeDirectoryUpstreamDN,
+		},
+	}
+	happyLDAPCustomSessionData := &psession.CustomSessionData{
+		ProviderUID:  ldapUpstreamResourceUID,
+		ProviderName: ldapUpstreamName,
+		ProviderType: ldapUpstreamType,
+		LDAP: &psession.LDAPSessionData{
+			UserDN: ldapUpstreamDN,
+		},
+	}
 	tests := []struct {
-		name                           string
-		idps                           *oidctestutil.UpstreamIDPListerBuilder
-		authcodeExchange               authcodeExchangeInputs
-		authEndpointInitialSessionData *psession.CustomSessionData
-		refreshRequest                 refreshRequestInputs
+		name                      string
+		idps                      *oidctestutil.UpstreamIDPListerBuilder
+		authcodeExchange          authcodeExchangeInputs
+		refreshRequest            refreshRequestInputs
+		modifyRefreshTokenStorage func(t *testing.T, oauthStore *oidc.KubeStorage, refreshToken string)
 	}{
 		{
 			name: "happy path refresh grant with openid scope granted (id token returned)",
@@ -1544,35 +1560,14 @@ func TestRefreshGrant(t *testing.T) {
 			}),
 			authcodeExchange: authcodeExchangeInputs{
 				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access") },
-				customSessionData: &psession.CustomSessionData{
-					ProviderUID:  ldapUpstreamResourceUID,
-					ProviderName: ldapUpstreamName,
-					ProviderType: ldapUpstreamType,
-					LDAP: &psession.LDAPSessionData{
-						UserDN: ldapUpstreamDN,
-					},
-				},
+				customSessionData: happyLDAPCustomSessionData,
 				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
-					&psession.CustomSessionData{
-						ProviderUID:  ldapUpstreamResourceUID,
-						ProviderName: ldapUpstreamName,
-						ProviderType: ldapUpstreamType,
-						LDAP: &psession.LDAPSessionData{
-							UserDN: ldapUpstreamDN,
-						},
-					},
+					happyLDAPCustomSessionData,
 				),
 			},
 			refreshRequest: refreshRequestInputs{
 				want: happyRefreshTokenResponseForLDAP(
-					&psession.CustomSessionData{
-						ProviderUID:  ldapUpstreamResourceUID,
-						ProviderName: ldapUpstreamName,
-						ProviderType: ldapUpstreamType,
-						LDAP: &psession.LDAPSessionData{
-							UserDN: ldapUpstreamDN,
-						},
-					},
+					happyLDAPCustomSessionData,
 				),
 			},
 		},
@@ -1585,35 +1580,14 @@ func TestRefreshGrant(t *testing.T) {
 			}),
 			authcodeExchange: authcodeExchangeInputs{
 				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access") },
-				customSessionData: &psession.CustomSessionData{
-					ProviderUID:  activeDirectoryUpstreamResourceUID,
-					ProviderName: activeDirectoryUpstreamName,
-					ProviderType: activeDirectoryUpstreamType,
-					ActiveDirectory: &psession.ActiveDirectorySessionData{
-						UserDN: activeDirectoryUpstreamDN,
-					},
-				},
+				customSessionData: happyActiveDirectoryCustomSessionData,
 				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
-					&psession.CustomSessionData{
-						ProviderUID:  activeDirectoryUpstreamResourceUID,
-						ProviderName: activeDirectoryUpstreamName,
-						ProviderType: activeDirectoryUpstreamType,
-						ActiveDirectory: &psession.ActiveDirectorySessionData{
-							UserDN: activeDirectoryUpstreamDN,
-						},
-					},
+					happyActiveDirectoryCustomSessionData,
 				),
 			},
 			refreshRequest: refreshRequestInputs{
 				want: happyRefreshTokenResponseForActiveDirectory(
-					&psession.CustomSessionData{
-						ProviderUID:  activeDirectoryUpstreamResourceUID,
-						ProviderName: activeDirectoryUpstreamName,
-						ProviderType: activeDirectoryUpstreamType,
-						ActiveDirectory: &psession.ActiveDirectorySessionData{
-							UserDN: activeDirectoryUpstreamDN,
-						},
-					},
+					happyActiveDirectoryCustomSessionData,
 				),
 			},
 		},
@@ -1779,23 +1753,9 @@ func TestRefreshGrant(t *testing.T) {
 			}),
 			authcodeExchange: authcodeExchangeInputs{
 				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access") },
-				customSessionData: &psession.CustomSessionData{
-					ProviderUID:  ldapUpstreamResourceUID,
-					ProviderName: ldapUpstreamName,
-					ProviderType: ldapUpstreamType,
-					LDAP: &psession.LDAPSessionData{
-						UserDN: ldapUpstreamDN,
-					},
-				},
+				customSessionData: happyLDAPCustomSessionData,
 				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
-					&psession.CustomSessionData{
-						ProviderUID:  ldapUpstreamResourceUID,
-						ProviderName: ldapUpstreamName,
-						ProviderType: ldapUpstreamType,
-						LDAP: &psession.LDAPSessionData{
-							UserDN: ldapUpstreamDN,
-						},
-					},
+					happyLDAPCustomSessionData,
 				),
 			},
 			refreshRequest: refreshRequestInputs{
@@ -1821,23 +1781,9 @@ func TestRefreshGrant(t *testing.T) {
 			}),
 			authcodeExchange: authcodeExchangeInputs{
 				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access") },
-				customSessionData: &psession.CustomSessionData{
-					ProviderUID:  activeDirectoryUpstreamResourceUID,
-					ProviderName: activeDirectoryUpstreamName,
-					ProviderType: activeDirectoryUpstreamType,
-					ActiveDirectory: &psession.ActiveDirectorySessionData{
-						UserDN: activeDirectoryUpstreamDN,
-					},
-				},
+				customSessionData: happyActiveDirectoryCustomSessionData,
 				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
-					&psession.CustomSessionData{
-						ProviderUID:  activeDirectoryUpstreamResourceUID,
-						ProviderName: activeDirectoryUpstreamName,
-						ProviderType: activeDirectoryUpstreamType,
-						ActiveDirectory: &psession.ActiveDirectorySessionData{
-							UserDN: activeDirectoryUpstreamDN,
-						},
-					},
+					happyActiveDirectoryCustomSessionData,
 				),
 			},
 			refreshRequest: refreshRequestInputs{
@@ -1858,23 +1804,9 @@ func TestRefreshGrant(t *testing.T) {
 			idps: oidctestutil.NewUpstreamIDPListerBuilder(),
 			authcodeExchange: authcodeExchangeInputs{
 				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access") },
-				customSessionData: &psession.CustomSessionData{
-					ProviderUID:  ldapUpstreamResourceUID,
-					ProviderName: ldapUpstreamName,
-					ProviderType: ldapUpstreamType,
-					LDAP: &psession.LDAPSessionData{
-						UserDN: ldapUpstreamDN,
-					},
-				},
+				customSessionData: happyLDAPCustomSessionData,
 				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
-					&psession.CustomSessionData{
-						ProviderUID:  ldapUpstreamResourceUID,
-						ProviderName: ldapUpstreamName,
-						ProviderType: ldapUpstreamType,
-						LDAP: &psession.LDAPSessionData{
-							UserDN: ldapUpstreamDN,
-						},
-					},
+					happyLDAPCustomSessionData,
 				),
 			},
 			refreshRequest: refreshRequestInputs{
@@ -1894,23 +1826,9 @@ func TestRefreshGrant(t *testing.T) {
 			idps: oidctestutil.NewUpstreamIDPListerBuilder(),
 			authcodeExchange: authcodeExchangeInputs{
 				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access") },
-				customSessionData: &psession.CustomSessionData{
-					ProviderUID:  activeDirectoryUpstreamResourceUID,
-					ProviderName: activeDirectoryUpstreamName,
-					ProviderType: activeDirectoryUpstreamType,
-					ActiveDirectory: &psession.ActiveDirectorySessionData{
-						UserDN: activeDirectoryUpstreamDN,
-					},
-				},
+				customSessionData: happyActiveDirectoryCustomSessionData,
 				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
-					&psession.CustomSessionData{
-						ProviderUID:  activeDirectoryUpstreamResourceUID,
-						ProviderName: activeDirectoryUpstreamName,
-						ProviderType: activeDirectoryUpstreamType,
-						ActiveDirectory: &psession.ActiveDirectorySessionData{
-							UserDN: activeDirectoryUpstreamDN,
-						},
-					},
+					happyActiveDirectoryCustomSessionData,
 				),
 			},
 			refreshRequest: refreshRequestInputs{
@@ -1920,6 +1838,85 @@ func TestRefreshGrant(t *testing.T) {
 						{
 							"error":             "error",
 							"error_description": "Error during upstream refresh. Provider 'some-ad-idp' of type 'activedirectory' from upstream session data was not found."
+						}
+					`),
+				},
+			},
+		},
+		{
+			name: "fosite session is empty",
+			idps: oidctestutil.NewUpstreamIDPListerBuilder().WithLDAP(&oidctestutil.TestUpstreamLDAPIdentityProvider{
+				Name:        ldapUpstreamName,
+				ResourceUID: ldapUpstreamResourceUID,
+				URL:         ldapUpstreamURL,
+			}),
+			authcodeExchange: authcodeExchangeInputs{
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access") },
+				customSessionData: happyLDAPCustomSessionData,
+				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
+					happyLDAPCustomSessionData,
+				),
+			},
+			modifyRefreshTokenStorage: func(t *testing.T, oauthStore *oidc.KubeStorage, refreshToken string) {
+				refreshTokenSignature := getFositeDataSignature(t, refreshToken)
+				firstRequester, err := oauthStore.GetRefreshTokenSession(context.Background(), refreshTokenSignature, nil)
+				require.NoError(t, err)
+				session := firstRequester.GetSession().(*psession.PinnipedSession)
+				session.Fosite = &openid.DefaultSession{}
+				err = oauthStore.DeleteRefreshTokenSession(context.Background(), refreshTokenSignature)
+				require.NoError(t, err)
+				err = oauthStore.CreateRefreshTokenSession(context.Background(), refreshTokenSignature, firstRequester)
+				require.NoError(t, err)
+			},
+			refreshRequest: refreshRequestInputs{
+				want: tokenEndpointResponseExpectedValues{
+					wantStatus: http.StatusInternalServerError,
+					wantErrorResponseBody: here.Doc(`
+						{
+							"error":             "error",
+							"error_description": "There was an internal server error. Required upstream data not found in session."
+						}
+					`),
+				},
+			},
+		},
+		{
+			name: "username not found in extra field",
+			idps: oidctestutil.NewUpstreamIDPListerBuilder().WithLDAP(&oidctestutil.TestUpstreamLDAPIdentityProvider{
+				Name:        ldapUpstreamName,
+				ResourceUID: ldapUpstreamResourceUID,
+				URL:         ldapUpstreamURL,
+			}),
+			authcodeExchange: authcodeExchangeInputs{
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access") },
+				customSessionData: happyLDAPCustomSessionData,
+				//fositeSessionData: &openid.DefaultSession{},
+				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
+					happyLDAPCustomSessionData,
+				),
+			},
+			modifyRefreshTokenStorage: func(t *testing.T, oauthStore *oidc.KubeStorage, refreshToken string) {
+				refreshTokenSignature := getFositeDataSignature(t, refreshToken)
+				firstRequester, err := oauthStore.GetRefreshTokenSession(context.Background(), refreshTokenSignature, nil)
+				require.NoError(t, err)
+				session := firstRequester.GetSession().(*psession.PinnipedSession)
+				session.Fosite = &openid.DefaultSession{
+					Claims: &jwt.IDTokenClaims{
+						Extra: map[string]interface{}{},
+					},
+				}
+				err = oauthStore.DeleteRefreshTokenSession(context.Background(), refreshTokenSignature)
+				require.NoError(t, err)
+				err = oauthStore.CreateRefreshTokenSession(context.Background(), refreshTokenSignature, firstRequester)
+				require.NoError(t, err)
+			},
+			refreshRequest: refreshRequestInputs{
+				want: tokenEndpointResponseExpectedValues{
+					wantStatus: http.StatusInternalServerError,
+					wantErrorResponseBody: here.Doc(`
+						{
+							"error":             "error",
+							"error_description": "There was an internal server error. Required upstream data not found in session."
 						}
 					`),
 				},
@@ -1952,6 +1949,10 @@ func TestRefreshGrant(t *testing.T) {
 			// Send the refresh token back and preform a refresh.
 			firstRefreshToken := parsedAuthcodeExchangeResponseBody["refresh_token"].(string)
 			require.NotEmpty(t, firstRefreshToken)
+
+			if test.modifyRefreshTokenStorage != nil {
+				test.modifyRefreshTokenStorage(t, oauthStore, firstRefreshToken)
+			}
 			reqContext := context.WithValue(context.Background(), struct{ name string }{name: "test"}, "request-context")
 			req := httptest.NewRequest("POST", "/path/shouldn't/matter",
 				happyRefreshRequestBody(firstRefreshToken).ReadCloser()).WithContext(reqContext)

--- a/internal/oidc/token/token_handler_test.go
+++ b/internal/oidc/token/token_handler_test.go
@@ -1465,7 +1465,7 @@ func TestRefreshGrant(t *testing.T) {
 					wantErrorResponseBody: here.Doc(`
 						{
 							"error":             "error",
-							"error_description": "Error during upstream refresh. Provider 'this-name-will-not-be-found' of type 'oidc' from upstream session data was not found."
+							"error_description": "Error during upstream refresh. Provider from upstream session data was not found."
 						}
 					`),
 				},
@@ -1519,7 +1519,7 @@ func TestRefreshGrant(t *testing.T) {
 					wantErrorResponseBody: here.Doc(`
 						{
 							"error":             "error",
-							"error_description": "Error during upstream refresh. Upstream refresh failed using provider 'some-oidc-idp' of type 'oidc'."
+							"error_description": "Error during upstream refresh. Upstream refresh failed."
 						}
 					`),
 				},
@@ -1545,7 +1545,7 @@ func TestRefreshGrant(t *testing.T) {
 					wantErrorResponseBody: here.Doc(`
 						{
 							"error":             "error",
-							"error_description": "Error during upstream refresh. Upstream refresh returned an invalid ID token using provider 'some-oidc-idp' of type 'oidc'."
+							"error_description": "Error during upstream refresh. Upstream refresh returned an invalid ID token."
 						}
 					`),
 				},
@@ -1765,7 +1765,7 @@ func TestRefreshGrant(t *testing.T) {
 					wantErrorResponseBody: here.Doc(`
 						{
 							"error":             "error",
-							"error_description": "Error during upstream refresh. Upstream refresh failed using provider 'some-ldap-idp' of type 'ldap'."
+							"error_description": "Error during upstream refresh. Upstream refresh failed."
 						}
 					`),
 				},
@@ -1793,7 +1793,7 @@ func TestRefreshGrant(t *testing.T) {
 					wantErrorResponseBody: here.Doc(`
 						{
 							"error":             "error",
-							"error_description": "Error during upstream refresh. Upstream refresh failed using provider 'some-ad-idp' of type 'activedirectory'."
+							"error_description": "Error during upstream refresh. Upstream refresh failed."
 						}
 					`),
 				},
@@ -1815,7 +1815,7 @@ func TestRefreshGrant(t *testing.T) {
 					wantErrorResponseBody: here.Doc(`
 						{
 							"error":             "error",
-							"error_description": "Error during upstream refresh. Provider 'some-ldap-idp' of type 'ldap' from upstream session data was not found."
+							"error_description": "Error during upstream refresh. Provider from upstream session data was not found."
 						}
 					`),
 				},
@@ -1837,7 +1837,7 @@ func TestRefreshGrant(t *testing.T) {
 					wantErrorResponseBody: here.Doc(`
 						{
 							"error":             "error",
-							"error_description": "Error during upstream refresh. Provider 'some-ad-idp' of type 'activedirectory' from upstream session data was not found."
+							"error_description": "Error during upstream refresh. Provider from upstream session data was not found."
 						}
 					`),
 				},
@@ -2026,7 +2026,7 @@ func TestRefreshGrant(t *testing.T) {
 					wantErrorResponseBody: here.Doc(`
 						{
 							"error":             "error",
-							"error_description": "Error during upstream refresh. Provider 'some-ldap-idp' of type 'ldap' from upstream session data has changed its resource UID since authentication."
+							"error_description": "Error during upstream refresh. Provider from upstream session data has changed its resource UID since authentication."
 						}
 					`),
 				},
@@ -2052,7 +2052,7 @@ func TestRefreshGrant(t *testing.T) {
 					wantErrorResponseBody: here.Doc(`
 						{
 							"error":             "error",
-							"error_description": "Error during upstream refresh. Provider 'some-ad-idp' of type 'activedirectory' from upstream session data has changed its resource UID since authentication."
+							"error_description": "Error during upstream refresh. Provider from upstream session data has changed its resource UID since authentication."
 						}
 					`),
 				},

--- a/internal/oidc/token/token_handler_test.go
+++ b/internal/oidc/token/token_handler_test.go
@@ -1923,6 +1923,90 @@ func TestRefreshGrant(t *testing.T) {
 			},
 		},
 		{
+			name: "username in extra is not a string",
+			idps: oidctestutil.NewUpstreamIDPListerBuilder().WithLDAP(&oidctestutil.TestUpstreamLDAPIdentityProvider{
+				Name:        ldapUpstreamName,
+				ResourceUID: ldapUpstreamResourceUID,
+				URL:         ldapUpstreamURL,
+			}),
+			authcodeExchange: authcodeExchangeInputs{
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access") },
+				customSessionData: happyLDAPCustomSessionData,
+				//fositeSessionData: &openid.DefaultSession{},
+				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
+					happyLDAPCustomSessionData,
+				),
+			},
+			modifyRefreshTokenStorage: func(t *testing.T, oauthStore *oidc.KubeStorage, refreshToken string) {
+				refreshTokenSignature := getFositeDataSignature(t, refreshToken)
+				firstRequester, err := oauthStore.GetRefreshTokenSession(context.Background(), refreshTokenSignature, nil)
+				require.NoError(t, err)
+				session := firstRequester.GetSession().(*psession.PinnipedSession)
+				session.Fosite = &openid.DefaultSession{
+					Claims: &jwt.IDTokenClaims{
+						Extra: map[string]interface{}{"username": 123},
+					},
+				}
+				err = oauthStore.DeleteRefreshTokenSession(context.Background(), refreshTokenSignature)
+				require.NoError(t, err)
+				err = oauthStore.CreateRefreshTokenSession(context.Background(), refreshTokenSignature, firstRequester)
+				require.NoError(t, err)
+			},
+			refreshRequest: refreshRequestInputs{
+				want: tokenEndpointResponseExpectedValues{
+					wantStatus: http.StatusInternalServerError,
+					wantErrorResponseBody: here.Doc(`
+						{
+							"error":             "error",
+							"error_description": "There was an internal server error. Required upstream data not found in session."
+						}
+					`),
+				},
+			},
+		},
+		{
+			name: "username in extra is an empty string",
+			idps: oidctestutil.NewUpstreamIDPListerBuilder().WithLDAP(&oidctestutil.TestUpstreamLDAPIdentityProvider{
+				Name:        ldapUpstreamName,
+				ResourceUID: ldapUpstreamResourceUID,
+				URL:         ldapUpstreamURL,
+			}),
+			authcodeExchange: authcodeExchangeInputs{
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access") },
+				customSessionData: happyLDAPCustomSessionData,
+				//fositeSessionData: &openid.DefaultSession{},
+				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
+					happyLDAPCustomSessionData,
+				),
+			},
+			modifyRefreshTokenStorage: func(t *testing.T, oauthStore *oidc.KubeStorage, refreshToken string) {
+				refreshTokenSignature := getFositeDataSignature(t, refreshToken)
+				firstRequester, err := oauthStore.GetRefreshTokenSession(context.Background(), refreshTokenSignature, nil)
+				require.NoError(t, err)
+				session := firstRequester.GetSession().(*psession.PinnipedSession)
+				session.Fosite = &openid.DefaultSession{
+					Claims: &jwt.IDTokenClaims{
+						Extra: map[string]interface{}{"username": ""},
+					},
+				}
+				err = oauthStore.DeleteRefreshTokenSession(context.Background(), refreshTokenSignature)
+				require.NoError(t, err)
+				err = oauthStore.CreateRefreshTokenSession(context.Background(), refreshTokenSignature, firstRequester)
+				require.NoError(t, err)
+			},
+			refreshRequest: refreshRequestInputs{
+				want: tokenEndpointResponseExpectedValues{
+					wantStatus: http.StatusInternalServerError,
+					wantErrorResponseBody: here.Doc(`
+						{
+							"error":             "error",
+							"error_description": "There was an internal server error. Required upstream data not found in session."
+						}
+					`),
+				},
+			},
+		},
+		{
 			name: "when the ldap provider in the session storage is found but has the wrong resource UID during the refresh request",
 			idps: oidctestutil.NewUpstreamIDPListerBuilder().WithLDAP(&oidctestutil.TestUpstreamLDAPIdentityProvider{
 				Name:        ldapUpstreamName,

--- a/internal/psession/pinniped_session.go
+++ b/internal/psession/pinniped_session.go
@@ -45,6 +45,10 @@ type CustomSessionData struct {
 
 	// Only used when ProviderType == "oidc".
 	OIDC *OIDCSessionData `json:"oidc,omitempty"`
+
+	LDAP *LDAPSessionData `json:"ldap,omitempty"`
+
+	ActiveDirectory *ActiveDirectorySessionData `json:"activedirectory,omitempty"`
 }
 
 type ProviderType string
@@ -58,6 +62,16 @@ const (
 // OIDCSessionData is the additional data needed by Pinniped when the upstream IDP is an OIDC provider.
 type OIDCSessionData struct {
 	UpstreamRefreshToken string `json:"upstreamRefreshToken"`
+}
+
+// LDAPSessionData is the additional data needed by Pinniped when the upstream IDP is an LDAP provider.
+type LDAPSessionData struct {
+	UserDN string `json:"userDN"`
+}
+
+// ActiveDirectorySessionData is the additional data needed by Pinniped when the upstream IDP is an Active Directory provider.
+type ActiveDirectorySessionData struct {
+	UserDN string `json:"userDN"`
 }
 
 // NewPinnipedSession returns a new empty session.

--- a/internal/testutil/oidctestutil/oidctestutil.go
+++ b/internal/testutil/oidctestutil/oidctestutil.go
@@ -61,9 +61,11 @@ type PasswordCredentialsGrantAndValidateTokensArgs struct {
 // PerformRefreshArgs is used to spy on calls to
 // TestUpstreamOIDCIdentityProvider.PerformRefreshFunc().
 type PerformRefreshArgs struct {
-	Ctx          context.Context
-	RefreshToken string
-	DN           string
+	Ctx              context.Context
+	RefreshToken     string
+	DN               string
+	ExpectedUsername string
+	ExpectedSubject  string
 }
 
 // ValidateTokenArgs is used to spy on calls to
@@ -102,14 +104,16 @@ func (u *TestUpstreamLDAPIdentityProvider) GetURL() *url.URL {
 	return u.URL
 }
 
-func (u *TestUpstreamLDAPIdentityProvider) PerformRefresh(ctx context.Context, userDN string) error {
+func (u *TestUpstreamLDAPIdentityProvider) PerformRefresh(ctx context.Context, userDN string, expectedUsername string, expectedSubject string) error {
 	if u.performRefreshArgs == nil {
 		u.performRefreshArgs = make([]*PerformRefreshArgs, 0)
 	}
 	u.performRefreshCallCount++
 	u.performRefreshArgs = append(u.performRefreshArgs, &PerformRefreshArgs{
-		Ctx: ctx,
-		DN:  userDN,
+		Ctx:              ctx,
+		DN:               userDN,
+		ExpectedUsername: expectedUsername,
+		ExpectedSubject:  expectedSubject,
 	})
 	if u.PerformRefreshErr != nil {
 		return u.PerformRefreshErr

--- a/internal/testutil/oidctestutil/oidctestutil.go
+++ b/internal/testutil/oidctestutil/oidctestutil.go
@@ -21,10 +21,10 @@ import (
 	"gopkg.in/square/go-jose.v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/client-go/kubernetes/fake"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
+	"go.pinniped.dev/internal/authenticators"
 	"go.pinniped.dev/internal/crud"
 	"go.pinniped.dev/internal/fositestorage/authorizationcode"
 	"go.pinniped.dev/internal/fositestorage/openidconnect"
@@ -80,7 +80,7 @@ type TestUpstreamLDAPIdentityProvider struct {
 	Name                    string
 	ResourceUID             types.UID
 	URL                     *url.URL
-	AuthenticateFunc        func(ctx context.Context, username, password string) (*authenticator.Response, bool, error)
+	AuthenticateFunc        func(ctx context.Context, username, password string) (*authenticators.Response, bool, error)
 	performRefreshCallCount int
 	performRefreshArgs      []*PerformRefreshArgs
 	PerformRefreshErr       error
@@ -96,7 +96,7 @@ func (u *TestUpstreamLDAPIdentityProvider) GetName() string {
 	return u.Name
 }
 
-func (u *TestUpstreamLDAPIdentityProvider) AuthenticateUser(ctx context.Context, username, password string) (*authenticator.Response, bool, error) {
+func (u *TestUpstreamLDAPIdentityProvider) AuthenticateUser(ctx context.Context, username, password string) (*authenticators.Response, bool, error) {
 	return u.AuthenticateFunc(ctx, username, password)
 }
 
@@ -104,7 +104,7 @@ func (u *TestUpstreamLDAPIdentityProvider) GetURL() *url.URL {
 	return u.URL
 }
 
-func (u *TestUpstreamLDAPIdentityProvider) PerformRefresh(ctx context.Context, userDN string, expectedUsername string, expectedSubject string) error {
+func (u *TestUpstreamLDAPIdentityProvider) PerformRefresh(ctx context.Context, userDN, expectedUsername, expectedSubject string) error {
 	if u.performRefreshArgs == nil {
 		u.performRefreshArgs = make([]*PerformRefreshArgs, 0)
 	}

--- a/internal/upstreamldap/upstreamldap.go
+++ b/internal/upstreamldap/upstreamldap.go
@@ -641,9 +641,9 @@ func (p *Provider) refreshUserSearchRequest(dn string) *ldap.SearchRequest {
 		SizeLimit:    2,
 		TimeLimit:    90,
 		TypesOnly:    false,
-		Filter:       "(objectClass=*)",                 // we already have the dn, so the filter doesn't matter
-		Attributes:   p.userSearchRequestedAttributes(), // TODO this will need to include some other AD attributes
-		Controls:     nil,                               // this could be used to enable paging, but we're already limiting the result max size
+		Filter:       "(objectClass=*)", // we already have the dn, so the filter doesn't matter
+		Attributes:   p.userSearchRequestedAttributes(),
+		Controls:     nil, // this could be used to enable paging, but we're already limiting the result max size
 	}
 }
 

--- a/internal/upstreamldap/upstreamldap.go
+++ b/internal/upstreamldap/upstreamldap.go
@@ -169,6 +169,43 @@ func (p *Provider) GetConfig() ProviderConfig {
 	return p.c
 }
 
+func (p *Provider) PerformRefresh(ctx context.Context, userDN string) error {
+	t := trace.FromContext(ctx).Nest("slow ldap refresh attempt", trace.Field{Key: "providerName", Value: p.GetName()})
+	defer t.LogIfLong(500 * time.Millisecond) // to help users debug slow LDAP searches
+	search := p.refreshUserSearchRequest(userDN)
+
+	conn, err := p.dial(ctx)
+	if err != nil {
+		p.traceAuthFailure(t, err)
+		return fmt.Errorf(`error dialing host "%s": %w`, p.c.Host, err)
+	}
+	defer conn.Close()
+
+	err = conn.Bind(p.c.BindUsername, p.c.BindPassword)
+	if err != nil {
+		p.traceAuthFailure(t, err)
+		return fmt.Errorf(`error binding as "%s" before user search: %w`, p.c.BindUsername, err)
+	}
+
+	searchResult, err := conn.Search(search)
+
+	if err != nil {
+		return fmt.Errorf(`error searching for user "%s": %w`, userDN, err)
+	}
+
+	// if any more or less than one entry, error.
+	// we don't need to worry about logging this because we know it's a dn.
+	if len(searchResult.Entries) != 1 {
+		return fmt.Errorf(`searching for user "%s" resulted in %d search results, but expected 1 result`,
+			userDN, len(searchResult.Entries),
+		)
+	}
+
+	// do nothing. if we got exactly one search result back then that means the user
+	// still exists.
+	return nil
+}
+
 func (p *Provider) dial(ctx context.Context) (Conn, error) {
 	tlsAddr, err := endpointaddr.Parse(p.c.Host, defaultLDAPSPort)
 	if err != nil {
@@ -355,7 +392,7 @@ func (p *Provider) authenticateUserImpl(ctx context.Context, username string, bi
 		return nil, false, fmt.Errorf(`error binding as "%s" before user search: %w`, p.c.BindUsername, err)
 	}
 
-	mappedUsername, mappedUID, mappedGroupNames, err := p.searchAndBindUser(conn, username, bindFunc)
+	mappedUsername, mappedUID, mappedGroupNames, userDN, err := p.searchAndBindUser(conn, username, bindFunc)
 	if err != nil {
 		p.traceAuthFailure(t, err)
 		return nil, false, err
@@ -371,6 +408,7 @@ func (p *Provider) authenticateUserImpl(ctx context.Context, username string, bi
 			Name:   mappedUsername,
 			UID:    mappedUID,
 			Groups: mappedGroupNames,
+			Extra:  map[string][]string{"userDN": {userDN}},
 		},
 	}
 	p.traceAuthSuccess(t)
@@ -454,7 +492,7 @@ func (p *Provider) SearchForDefaultNamingContext(ctx context.Context) (string, e
 	return searchBase, nil
 }
 
-func (p *Provider) searchAndBindUser(conn Conn, username string, bindFunc func(conn Conn, foundUserDN string) error) (string, string, []string, error) {
+func (p *Provider) searchAndBindUser(conn Conn, username string, bindFunc func(conn Conn, foundUserDN string) error) (string, string, []string, string, error) {
 	searchResult, err := conn.Search(p.userSearchRequest(username))
 	if err != nil {
 		plog.All(`error searching for user`,
@@ -462,7 +500,7 @@ func (p *Provider) searchAndBindUser(conn Conn, username string, bindFunc func(c
 			"username", username,
 			"err", err,
 		)
-		return "", "", nil, fmt.Errorf(`error searching for user: %w`, err)
+		return "", "", nil, "", fmt.Errorf(`error searching for user: %w`, err)
 	}
 	if len(searchResult.Entries) == 0 {
 		if plog.Enabled(plog.LevelAll) {
@@ -473,38 +511,38 @@ func (p *Provider) searchAndBindUser(conn Conn, username string, bindFunc func(c
 		} else {
 			plog.Debug("error finding user: user not found (cowardly avoiding printing username because log level is not 'all')", "upstreamName", p.GetName())
 		}
-		return "", "", nil, nil
+		return "", "", nil, "", nil
 	}
 
 	// At this point, we have matched at least one entry, so we can be confident that the username is not actually
 	// someone's password mistakenly entered into the username field, so we can log it without concern.
 	if len(searchResult.Entries) > 1 {
-		return "", "", nil, fmt.Errorf(`searching for user "%s" resulted in %d search results, but expected 1 result`,
+		return "", "", nil, "", fmt.Errorf(`searching for user "%s" resulted in %d search results, but expected 1 result`,
 			username, len(searchResult.Entries),
 		)
 	}
 	userEntry := searchResult.Entries[0]
 	if len(userEntry.DN) == 0 {
-		return "", "", nil, fmt.Errorf(`searching for user "%s" resulted in search result without DN`, username)
+		return "", "", nil, "", fmt.Errorf(`searching for user "%s" resulted in search result without DN`, username)
 	}
 
 	mappedUsername, err := p.getSearchResultAttributeValue(p.c.UserSearch.UsernameAttribute, userEntry, username)
 	if err != nil {
-		return "", "", nil, err
+		return "", "", nil, "", err
 	}
 
 	// We would like to support binary typed attributes for UIDs, so always read them as binary and encode them,
 	// even when the attribute may not be binary.
 	mappedUID, err := p.getSearchResultAttributeRawValueEncoded(p.c.UserSearch.UIDAttribute, userEntry, username)
 	if err != nil {
-		return "", "", nil, err
+		return "", "", nil, "", err
 	}
 
 	mappedGroupNames := []string{}
 	if len(p.c.GroupSearch.Base) > 0 {
 		mappedGroupNames, err = p.searchGroupsForUserDN(conn, userEntry.DN)
 		if err != nil {
-			return "", "", nil, err
+			return "", "", nil, "", err
 		}
 	}
 	sort.Strings(mappedGroupNames)
@@ -516,12 +554,12 @@ func (p *Provider) searchAndBindUser(conn Conn, username string, bindFunc func(c
 			err, "upstreamName", p.GetName(), "username", username, "dn", userEntry.DN)
 		ldapErr := &ldap.Error{}
 		if errors.As(err, &ldapErr) && ldapErr.ResultCode == ldap.LDAPResultInvalidCredentials {
-			return "", "", nil, nil
+			return "", "", nil, "", nil
 		}
-		return "", "", nil, fmt.Errorf(`error binding for user "%s" using provided password against DN "%s": %w`, username, userEntry.DN, err)
+		return "", "", nil, "", fmt.Errorf(`error binding for user "%s" using provided password against DN "%s": %w`, username, userEntry.DN, err)
 	}
 
-	return mappedUsername, mappedUID, mappedGroupNames, nil
+	return mappedUsername, mappedUID, mappedGroupNames, userEntry.DN, nil
 }
 
 func (p *Provider) defaultNamingContextRequest() *ldap.SearchRequest {
@@ -565,6 +603,21 @@ func (p *Provider) groupSearchRequest(userDN string) *ldap.SearchRequest {
 		Filter:       p.groupSearchFilter(userDN),
 		Attributes:   p.groupSearchRequestedAttributes(),
 		Controls:     nil, // nil because ldap.SearchWithPaging() will set the appropriate controls for us
+	}
+}
+
+func (p *Provider) refreshUserSearchRequest(dn string) *ldap.SearchRequest {
+	// See https://ldap.com/the-ldap-search-operation for general documentation of LDAP search options.
+	return &ldap.SearchRequest{
+		BaseDN:       dn,
+		Scope:        ldap.ScopeBaseObject,
+		DerefAliases: ldap.NeverDerefAliases,
+		SizeLimit:    2,
+		TimeLimit:    90,
+		TypesOnly:    false,
+		Filter:       "(objectClass=*)", // we already have the dn, so the filter doesn't matter
+		Attributes:   []string{},        // TODO this will need to include some other AD attributes
+		Controls:     nil,               // this could be used to enable paging, but we're already limiting the result max size
 	}
 }
 

--- a/internal/upstreamldap/upstreamldap.go
+++ b/internal/upstreamldap/upstreamldap.go
@@ -210,7 +210,7 @@ func (p *Provider) PerformRefresh(ctx context.Context, userDN string, expectedUs
 
 	newUsername, err := p.getSearchResultAttributeValue(p.c.UserSearch.UsernameAttribute, userEntry, userDN)
 	if err != nil {
-		return err // TODO test having no values or more than one maybe
+		return err
 	}
 	if newUsername != expectedUsername {
 		return fmt.Errorf(`searching for user "%s" returned a different username than the previous value. expected: "%s", actual: "%s"`,
@@ -220,15 +220,14 @@ func (p *Provider) PerformRefresh(ctx context.Context, userDN string, expectedUs
 
 	newUID, err := p.getSearchResultAttributeRawValueEncoded(p.c.UserSearch.UIDAttribute, userEntry, userDN)
 	if err != nil {
-		return err // TODO test
+		return err
 	}
 	newSubject := downstreamsession.DownstreamLDAPSubject(newUID, *p.GetURL())
 	if newSubject != expectedSubject {
 		return fmt.Errorf(`searching for user "%s" produced a different subject than the previous value. expected: "%s", actual: "%s"`, userDN, expectedSubject, newSubject)
 	}
 
-	// do nothing. if we got exactly one search result back then that means the user
-	// still exists.
+	// we checked that the user still exists and their information is the same, so just return.
 	return nil
 }
 

--- a/internal/upstreamldap/upstreamldap_test.go
+++ b/internal/upstreamldap/upstreamldap_test.go
@@ -1511,8 +1511,8 @@ func TestUpstreamRefresh(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		tt := test
+	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			t.Cleanup(ctrl.Finish)

--- a/test/integration/ldap_client_test.go
+++ b/test/integration/ldap_client_test.go
@@ -83,7 +83,7 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 			password: pinnyPassword,
 			provider: upstreamldap.New(*providerConfig(nil)),
 			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}},
+				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
 			},
 		},
 		{
@@ -95,7 +95,7 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 				p.ConnectionProtocol = upstreamldap.StartTLS
 			})),
 			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}},
+				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
 			},
 		},
 		{
@@ -104,7 +104,7 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 			password: pinnyPassword,
 			provider: upstreamldap.New(*providerConfig(func(p *upstreamldap.ProviderConfig) { p.UserSearch.Base = "dc=pinniped,dc=dev" })),
 			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}},
+				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
 			},
 		},
 		{
@@ -113,7 +113,7 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 			password: pinnyPassword,
 			provider: upstreamldap.New(*providerConfig(func(p *upstreamldap.ProviderConfig) { p.UserSearch.Filter = "(cn={})" })),
 			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}},
+				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
 			},
 		},
 		{
@@ -125,7 +125,7 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 				p.UserSearch.Filter = "cn={}"
 			})),
 			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "cn=pinny,ou=users,dc=pinniped,dc=dev", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}},
+				User: &user.DefaultInfo{Name: "cn=pinny,ou=users,dc=pinniped,dc=dev", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
 			},
 		},
 		{
@@ -136,7 +136,7 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 				p.UserSearch.Filter = "(|(cn={})(mail={}))"
 			})),
 			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}},
+				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
 			},
 		},
 		{
@@ -147,7 +147,7 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 				p.UserSearch.Filter = "(|(cn={})(mail={}))"
 			})),
 			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}},
+				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
 			},
 		},
 		{
@@ -156,7 +156,7 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 			password: pinnyPassword,
 			provider: upstreamldap.New(*providerConfig(func(p *upstreamldap.ProviderConfig) { p.UserSearch.UIDAttribute = "dn" })),
 			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "pinny", UID: b64("cn=pinny,ou=users,dc=pinniped,dc=dev"), Groups: []string{"ball-game-players", "seals"}},
+				User: &user.DefaultInfo{Name: "pinny", UID: b64("cn=pinny,ou=users,dc=pinniped,dc=dev"), Groups: []string{"ball-game-players", "seals"}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
 			},
 		},
 		{
@@ -165,7 +165,7 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 			password: pinnyPassword,
 			provider: upstreamldap.New(*providerConfig(func(p *upstreamldap.ProviderConfig) { p.UserSearch.UIDAttribute = "sn" })),
 			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "pinny", UID: b64("Seal"), Groups: []string{"ball-game-players", "seals"}},
+				User: &user.DefaultInfo{Name: "pinny", UID: b64("Seal"), Groups: []string{"ball-game-players", "seals"}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
 			},
 		},
 		{
@@ -174,7 +174,7 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 			password: pinnyPassword,
 			provider: upstreamldap.New(*providerConfig(func(p *upstreamldap.ProviderConfig) { p.UserSearch.UsernameAttribute = "sn" })),
 			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "Seal", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}}, // note that the final answer has case preserved from the entry
+				User: &user.DefaultInfo{Name: "Seal", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}}, // note that the final answer has case preserved from the entry
 			},
 		},
 		{
@@ -187,7 +187,7 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 				p.UserSearch.UIDAttribute = "givenName"
 			})),
 			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "Pinny the 🦭", UID: b64("Pinny the 🦭"), Groups: []string{"ball-game-players", "seals"}},
+				User: &user.DefaultInfo{Name: "Pinny the 🦭", UID: b64("Pinny the 🦭"), Groups: []string{"ball-game-players", "seals"}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
 			},
 		},
 		{
@@ -199,7 +199,7 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 				p.UserSearch.UsernameAttribute = "cn"
 			})),
 			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}},
+				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
 			},
 		},
 		{
@@ -220,7 +220,7 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 				p.GroupSearch.Base = ""
 			})),
 			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{}},
+				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
 			},
 		},
 		{
@@ -231,7 +231,7 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 				p.GroupSearch.Base = "ou=users,dc=pinniped,dc=dev" // there are no groups under this part of the tree
 			})),
 			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{}},
+				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
 			},
 		},
 		{
@@ -245,7 +245,7 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{
 					"cn=ball-game-players,ou=beach-groups,ou=groups,dc=pinniped,dc=dev",
 					"cn=seals,ou=groups,dc=pinniped,dc=dev",
-				}},
+				}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
 			},
 		},
 		{
@@ -259,7 +259,7 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{
 					"cn=ball-game-players,ou=beach-groups,ou=groups,dc=pinniped,dc=dev",
 					"cn=seals,ou=groups,dc=pinniped,dc=dev",
-				}},
+				}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
 			},
 		},
 		{
@@ -270,7 +270,7 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 				p.GroupSearch.GroupNameAttribute = "objectClass" // silly example, but still a meaningful test
 			})),
 			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"groupOfNames", "groupOfNames"}},
+				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"groupOfNames", "groupOfNames"}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
 			},
 		},
 		{
@@ -281,7 +281,7 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 				p.GroupSearch.Filter = "(&(&(objectClass=groupOfNames)(member={}))(cn=seals))"
 			})),
 			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"seals"}},
+				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"seals"}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
 			},
 		},
 		{
@@ -292,7 +292,7 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 				p.GroupSearch.Filter = "foobar={}" // foobar is not a valid attribute name for this LDAP server's schema
 			})),
 			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{}},
+				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
 			},
 		},
 		{
@@ -671,7 +671,7 @@ func TestSimultaneousLDAPRequestsOnSingleProvider(t *testing.T) {
 		assert.NoError(t, result.err)
 		assert.True(t, result.authenticated, "expected the user to be authenticated, but they were not")
 		assert.Equal(t, &authenticator.Response{
-			User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}},
+			User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
 		}, result.response)
 	}
 }

--- a/test/integration/ldap_client_test.go
+++ b/test/integration/ldap_client_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
 
 	"go.pinniped.dev/internal/authenticators"
@@ -75,7 +74,7 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 		password            string
 		provider            *upstreamldap.Provider
 		wantError           string
-		wantAuthResponse    *authenticator.Response
+		wantAuthResponse    *authenticators.Response
 		wantUnauthenticated bool
 	}{
 		{
@@ -83,8 +82,8 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 			username: "pinny",
 			password: pinnyPassword,
 			provider: upstreamldap.New(*providerConfig(nil)),
-			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
+			wantAuthResponse: &authenticators.Response{
+				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}}, DN: "cn=pinny,ou=users,dc=pinniped,dc=dev",
 			},
 		},
 		{
@@ -95,8 +94,8 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 				p.Host = "127.0.0.1:" + ldapLocalhostPort
 				p.ConnectionProtocol = upstreamldap.StartTLS
 			})),
-			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
+			wantAuthResponse: &authenticators.Response{
+				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}}, DN: "cn=pinny,ou=users,dc=pinniped,dc=dev",
 			},
 		},
 		{
@@ -104,8 +103,8 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 			username: "pinny",
 			password: pinnyPassword,
 			provider: upstreamldap.New(*providerConfig(func(p *upstreamldap.ProviderConfig) { p.UserSearch.Base = "dc=pinniped,dc=dev" })),
-			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
+			wantAuthResponse: &authenticators.Response{
+				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}}, DN: "cn=pinny,ou=users,dc=pinniped,dc=dev",
 			},
 		},
 		{
@@ -113,8 +112,8 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 			username: "pinny",
 			password: pinnyPassword,
 			provider: upstreamldap.New(*providerConfig(func(p *upstreamldap.ProviderConfig) { p.UserSearch.Filter = "(cn={})" })),
-			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
+			wantAuthResponse: &authenticators.Response{
+				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}}, DN: "cn=pinny,ou=users,dc=pinniped,dc=dev",
 			},
 		},
 		{
@@ -125,8 +124,8 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 				p.UserSearch.UsernameAttribute = "dn"
 				p.UserSearch.Filter = "cn={}"
 			})),
-			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "cn=pinny,ou=users,dc=pinniped,dc=dev", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
+			wantAuthResponse: &authenticators.Response{
+				User: &user.DefaultInfo{Name: "cn=pinny,ou=users,dc=pinniped,dc=dev", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}}, DN: "cn=pinny,ou=users,dc=pinniped,dc=dev",
 			},
 		},
 		{
@@ -136,8 +135,8 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 			provider: upstreamldap.New(*providerConfig(func(p *upstreamldap.ProviderConfig) {
 				p.UserSearch.Filter = "(|(cn={})(mail={}))"
 			})),
-			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
+			wantAuthResponse: &authenticators.Response{
+				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}}, DN: "cn=pinny,ou=users,dc=pinniped,dc=dev",
 			},
 		},
 		{
@@ -147,8 +146,8 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 			provider: upstreamldap.New(*providerConfig(func(p *upstreamldap.ProviderConfig) {
 				p.UserSearch.Filter = "(|(cn={})(mail={}))"
 			})),
-			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
+			wantAuthResponse: &authenticators.Response{
+				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}}, DN: "cn=pinny,ou=users,dc=pinniped,dc=dev",
 			},
 		},
 		{
@@ -156,8 +155,8 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 			username: "pinny",
 			password: pinnyPassword,
 			provider: upstreamldap.New(*providerConfig(func(p *upstreamldap.ProviderConfig) { p.UserSearch.UIDAttribute = "dn" })),
-			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "pinny", UID: b64("cn=pinny,ou=users,dc=pinniped,dc=dev"), Groups: []string{"ball-game-players", "seals"}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
+			wantAuthResponse: &authenticators.Response{
+				User: &user.DefaultInfo{Name: "pinny", UID: b64("cn=pinny,ou=users,dc=pinniped,dc=dev"), Groups: []string{"ball-game-players", "seals"}}, DN: "cn=pinny,ou=users,dc=pinniped,dc=dev",
 			},
 		},
 		{
@@ -165,8 +164,8 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 			username: "pinny",
 			password: pinnyPassword,
 			provider: upstreamldap.New(*providerConfig(func(p *upstreamldap.ProviderConfig) { p.UserSearch.UIDAttribute = "sn" })),
-			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "pinny", UID: b64("Seal"), Groups: []string{"ball-game-players", "seals"}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
+			wantAuthResponse: &authenticators.Response{
+				User: &user.DefaultInfo{Name: "pinny", UID: b64("Seal"), Groups: []string{"ball-game-players", "seals"}}, DN: "cn=pinny,ou=users,dc=pinniped,dc=dev",
 			},
 		},
 		{
@@ -174,8 +173,8 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 			username: "seAl", // note that this is not case-sensitive! sn=Seal. The server decides which fields are compared case-sensitive.
 			password: pinnyPassword,
 			provider: upstreamldap.New(*providerConfig(func(p *upstreamldap.ProviderConfig) { p.UserSearch.UsernameAttribute = "sn" })),
-			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "Seal", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}}, // note that the final answer has case preserved from the entry
+			wantAuthResponse: &authenticators.Response{
+				User: &user.DefaultInfo{Name: "Seal", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}}, DN: "cn=pinny,ou=users,dc=pinniped,dc=dev", // note that the final answer has case preserved from the entry
 			},
 		},
 		{
@@ -187,8 +186,8 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 				p.UserSearch.UsernameAttribute = "givenName"
 				p.UserSearch.UIDAttribute = "givenName"
 			})),
-			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "Pinny the 🦭", UID: b64("Pinny the 🦭"), Groups: []string{"ball-game-players", "seals"}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
+			wantAuthResponse: &authenticators.Response{
+				User: &user.DefaultInfo{Name: "Pinny the 🦭", UID: b64("Pinny the 🦭"), Groups: []string{"ball-game-players", "seals"}}, DN: "cn=pinny,ou=users,dc=pinniped,dc=dev",
 			},
 		},
 		{
@@ -199,8 +198,8 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 				p.UserSearch.Filter = "givenName={}"
 				p.UserSearch.UsernameAttribute = "cn"
 			})),
-			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
+			wantAuthResponse: &authenticators.Response{
+				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}}, DN: "cn=pinny,ou=users,dc=pinniped,dc=dev",
 			},
 		},
 		{
@@ -220,8 +219,8 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 			provider: upstreamldap.New(*providerConfig(func(p *upstreamldap.ProviderConfig) {
 				p.GroupSearch.Base = ""
 			})),
-			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
+			wantAuthResponse: &authenticators.Response{
+				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{}}, DN: "cn=pinny,ou=users,dc=pinniped,dc=dev",
 			},
 		},
 		{
@@ -231,8 +230,8 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 			provider: upstreamldap.New(*providerConfig(func(p *upstreamldap.ProviderConfig) {
 				p.GroupSearch.Base = "ou=users,dc=pinniped,dc=dev" // there are no groups under this part of the tree
 			})),
-			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
+			wantAuthResponse: &authenticators.Response{
+				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{}}, DN: "cn=pinny,ou=users,dc=pinniped,dc=dev",
 			},
 		},
 		{
@@ -242,11 +241,11 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 			provider: upstreamldap.New(*providerConfig(func(p *upstreamldap.ProviderConfig) {
 				p.GroupSearch.GroupNameAttribute = "dn"
 			})),
-			wantAuthResponse: &authenticator.Response{
+			wantAuthResponse: &authenticators.Response{
 				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{
 					"cn=ball-game-players,ou=beach-groups,ou=groups,dc=pinniped,dc=dev",
 					"cn=seals,ou=groups,dc=pinniped,dc=dev",
-				}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
+				}}, DN: "cn=pinny,ou=users,dc=pinniped,dc=dev",
 			},
 		},
 		{
@@ -256,11 +255,11 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 			provider: upstreamldap.New(*providerConfig(func(p *upstreamldap.ProviderConfig) {
 				p.GroupSearch.GroupNameAttribute = ""
 			})),
-			wantAuthResponse: &authenticator.Response{
+			wantAuthResponse: &authenticators.Response{
 				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{
 					"cn=ball-game-players,ou=beach-groups,ou=groups,dc=pinniped,dc=dev",
 					"cn=seals,ou=groups,dc=pinniped,dc=dev",
-				}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
+				}}, DN: "cn=pinny,ou=users,dc=pinniped,dc=dev",
 			},
 		},
 		{
@@ -270,8 +269,8 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 			provider: upstreamldap.New(*providerConfig(func(p *upstreamldap.ProviderConfig) {
 				p.GroupSearch.GroupNameAttribute = "objectClass" // silly example, but still a meaningful test
 			})),
-			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"groupOfNames", "groupOfNames"}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
+			wantAuthResponse: &authenticators.Response{
+				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"groupOfNames", "groupOfNames"}}, DN: "cn=pinny,ou=users,dc=pinniped,dc=dev",
 			},
 		},
 		{
@@ -281,8 +280,8 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 			provider: upstreamldap.New(*providerConfig(func(p *upstreamldap.ProviderConfig) {
 				p.GroupSearch.Filter = "(&(&(objectClass=groupOfNames)(member={}))(cn=seals))"
 			})),
-			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"seals"}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
+			wantAuthResponse: &authenticators.Response{
+				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"seals"}}, DN: "cn=pinny,ou=users,dc=pinniped,dc=dev",
 			},
 		},
 		{
@@ -292,8 +291,8 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 			provider: upstreamldap.New(*providerConfig(func(p *upstreamldap.ProviderConfig) {
 				p.GroupSearch.Filter = "foobar={}" // foobar is not a valid attribute name for this LDAP server's schema
 			})),
-			wantAuthResponse: &authenticator.Response{
-				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
+			wantAuthResponse: &authenticators.Response{
+				User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{}}, DN: "cn=pinny,ou=users,dc=pinniped,dc=dev",
 			},
 		},
 		{
@@ -671,8 +670,9 @@ func TestSimultaneousLDAPRequestsOnSingleProvider(t *testing.T) {
 		// Record failures but allow the test to keep running so that all the background goroutines have a chance to try.
 		assert.NoError(t, result.err)
 		assert.True(t, result.authenticated, "expected the user to be authenticated, but they were not")
-		assert.Equal(t, &authenticator.Response{
-			User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}, Extra: map[string][]string{"userDN": {"cn=pinny,ou=users,dc=pinniped,dc=dev"}}},
+		assert.Equal(t, &authenticators.Response{
+			User: &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}},
+			DN:   "cn=pinny,ou=users,dc=pinniped,dc=dev",
 		}, result.response)
 	}
 }

--- a/test/integration/ldap_client_test.go
+++ b/test/integration/ldap_client_test.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
 
+	"go.pinniped.dev/internal/authenticators"
 	"go.pinniped.dev/internal/upstreamldap"
 	"go.pinniped.dev/test/testlib"
 )
@@ -677,7 +678,7 @@ func TestSimultaneousLDAPRequestsOnSingleProvider(t *testing.T) {
 }
 
 type authUserResult struct {
-	response      *authenticator.Response
+	response      *authenticators.Response
 	authenticated bool
 	err           error
 }

--- a/test/integration/supervisor_login_test.go
+++ b/test/integration/supervisor_login_test.go
@@ -214,7 +214,11 @@ func TestSupervisorLogin(t *testing.T) {
 					false,
 				)
 			},
-			breakRefreshSessionData: nil, // upstream refresh not yet implemented for this IDP type
+			breakRefreshSessionData: func(t *testing.T, customSessionData *psession.CustomSessionData) {
+				require.Equal(t, psession.ProviderTypeLDAP, customSessionData.ProviderType)
+				require.NotEmpty(t, customSessionData.LDAP.UserDN)
+				customSessionData.LDAP.UserDN = "cn=not-a-user,dc=pinniped,dc=dev"
+			},
 			// the ID token Subject should be the Host URL plus the value pulled from the requested UserSearch.Attributes.UID attribute
 			wantDownstreamIDTokenSubjectToMatch: "^" + regexp.QuoteMeta(
 				"ldaps://"+env.SupervisorUpstreamLDAP.Host+
@@ -281,7 +285,11 @@ func TestSupervisorLogin(t *testing.T) {
 					false,
 				)
 			},
-			breakRefreshSessionData: nil, // upstream refresh not yet implemented for this IDP type
+			breakRefreshSessionData: func(t *testing.T, customSessionData *psession.CustomSessionData) {
+				require.Equal(t, psession.ProviderTypeLDAP, customSessionData.ProviderType)
+				require.NotEmpty(t, customSessionData.LDAP.UserDN)
+				customSessionData.LDAP.UserDN = "cn=not-a-user,dc=pinniped,dc=dev"
+			},
 			// the ID token Subject should be the Host URL plus the value pulled from the requested UserSearch.Attributes.UID attribute
 			wantDownstreamIDTokenSubjectToMatch: "^" + regexp.QuoteMeta(
 				"ldaps://"+env.SupervisorUpstreamLDAP.StartTLSOnlyHost+
@@ -348,9 +356,13 @@ func TestSupervisorLogin(t *testing.T) {
 					true,
 				)
 			},
-			breakRefreshSessionData: nil, // upstream refresh not yet implemented for this IDP type
-			wantErrorDescription:    "The resource owner or authorization server denied the request. Username/password not accepted by LDAP provider.",
-			wantErrorType:           "access_denied",
+			breakRefreshSessionData: func(t *testing.T, customSessionData *psession.CustomSessionData) {
+				require.Equal(t, psession.ProviderTypeLDAP, customSessionData.ProviderType)
+				require.NotEmpty(t, customSessionData.LDAP.UserDN)
+				customSessionData.LDAP.UserDN = "cn=not-a-user,dc=pinniped,dc=dev"
+			},
+			wantErrorDescription: "The resource owner or authorization server denied the request. Username/password not accepted by LDAP provider.",
+			wantErrorType:        "access_denied",
 		},
 		{
 			name: "ldap login still works after updating bind secret",
@@ -426,7 +438,11 @@ func TestSupervisorLogin(t *testing.T) {
 					false,
 				)
 			},
-			breakRefreshSessionData: nil, // upstream refresh not yet implemented for this IDP type
+			breakRefreshSessionData: func(t *testing.T, customSessionData *psession.CustomSessionData) {
+				require.Equal(t, psession.ProviderTypeLDAP, customSessionData.ProviderType)
+				require.NotEmpty(t, customSessionData.LDAP.UserDN)
+				customSessionData.LDAP.UserDN = "cn=not-a-user,dc=pinniped,dc=dev"
+			},
 			// the ID token Subject should be the Host URL plus the value pulled from the requested UserSearch.Attributes.UID attribute
 			wantDownstreamIDTokenSubjectToMatch: "^" + regexp.QuoteMeta(
 				"ldaps://"+env.SupervisorUpstreamLDAP.Host+
@@ -525,7 +541,11 @@ func TestSupervisorLogin(t *testing.T) {
 					false,
 				)
 			},
-			breakRefreshSessionData: nil, // upstream refresh not yet implemented for this IDP type
+			breakRefreshSessionData: func(t *testing.T, customSessionData *psession.CustomSessionData) {
+				require.Equal(t, psession.ProviderTypeLDAP, customSessionData.ProviderType)
+				require.NotEmpty(t, customSessionData.LDAP.UserDN)
+				customSessionData.LDAP.UserDN = "cn=not-a-user,dc=pinniped,dc=dev"
+			},
 			// the ID token Subject should be the Host URL plus the value pulled from the requested UserSearch.Attributes.UID attribute
 			wantDownstreamIDTokenSubjectToMatch: "^" + regexp.QuoteMeta(
 				"ldaps://"+env.SupervisorUpstreamLDAP.Host+
@@ -580,7 +600,11 @@ func TestSupervisorLogin(t *testing.T) {
 					false,
 				)
 			},
-			breakRefreshSessionData: nil, // upstream refresh not yet implemented for this IDP type
+			breakRefreshSessionData: func(t *testing.T, customSessionData *psession.CustomSessionData) {
+				require.Equal(t, psession.ProviderTypeActiveDirectory, customSessionData.ProviderType)
+				require.NotEmpty(t, customSessionData.ActiveDirectory.UserDN)
+				customSessionData.ActiveDirectory.UserDN = "cn=not-a-user,dc=pinniped,dc=dev"
+			},
 			// the ID token Subject should be the Host URL plus the value pulled from the requested UserSearch.Attributes.UID attribute
 			wantDownstreamIDTokenSubjectToMatch: "^" + regexp.QuoteMeta(
 				"ldaps://"+env.SupervisorUpstreamActiveDirectory.Host+
@@ -648,7 +672,11 @@ func TestSupervisorLogin(t *testing.T) {
 					false,
 				)
 			},
-			breakRefreshSessionData: nil, // upstream refresh not yet implemented for this IDP type
+			breakRefreshSessionData: func(t *testing.T, customSessionData *psession.CustomSessionData) {
+				require.Equal(t, psession.ProviderTypeActiveDirectory, customSessionData.ProviderType)
+				require.NotEmpty(t, customSessionData.ActiveDirectory.UserDN)
+				customSessionData.ActiveDirectory.UserDN = "cn=not-a-user,dc=pinniped,dc=dev"
+			},
 			// the ID token Subject should be the Host URL plus the value pulled from the requested UserSearch.Attributes.UID attribute
 			wantDownstreamIDTokenSubjectToMatch: "^" + regexp.QuoteMeta(
 				"ldaps://"+env.SupervisorUpstreamActiveDirectory.Host+
@@ -721,7 +749,11 @@ func TestSupervisorLogin(t *testing.T) {
 					false,
 				)
 			},
-			breakRefreshSessionData: nil, // upstream refresh not yet implemented for this IDP type
+			breakRefreshSessionData: func(t *testing.T, customSessionData *psession.CustomSessionData) {
+				require.Equal(t, psession.ProviderTypeActiveDirectory, customSessionData.ProviderType)
+				require.NotEmpty(t, customSessionData.ActiveDirectory.UserDN)
+				customSessionData.ActiveDirectory.UserDN = "cn=not-a-user,dc=pinniped,dc=dev"
+			},
 			// the ID token Subject should be the Host URL plus the value pulled from the requested UserSearch.Attributes.UID attribute
 			wantDownstreamIDTokenSubjectToMatch: "^" + regexp.QuoteMeta(
 				"ldaps://"+env.SupervisorUpstreamActiveDirectory.Host+
@@ -809,7 +841,11 @@ func TestSupervisorLogin(t *testing.T) {
 					false,
 				)
 			},
-			breakRefreshSessionData: nil, // upstream refresh not yet implemented for this IDP type
+			breakRefreshSessionData: func(t *testing.T, customSessionData *psession.CustomSessionData) {
+				require.Equal(t, psession.ProviderTypeActiveDirectory, customSessionData.ProviderType)
+				require.NotEmpty(t, customSessionData.ActiveDirectory.UserDN)
+				customSessionData.ActiveDirectory.UserDN = "cn=not-a-user,dc=pinniped,dc=dev"
+			},
 			// the ID token Subject should be the Host URL plus the value pulled from the requested UserSearch.Attributes.UID attribute
 			wantDownstreamIDTokenSubjectToMatch: "^" + regexp.QuoteMeta(
 				"ldaps://"+env.SupervisorUpstreamActiveDirectory.Host+
@@ -864,7 +900,7 @@ func TestSupervisorLogin(t *testing.T) {
 					true,
 				)
 			},
-			breakRefreshSessionData: nil, // upstream refresh not yet implemented for this IDP type
+			breakRefreshSessionData: nil,
 			wantErrorDescription:    "The resource owner or authorization server denied the request. Username/password not accepted by LDAP provider.",
 			wantErrorType:           "access_denied",
 		},

--- a/test/integration/supervisor_login_test.go
+++ b/test/integration/supervisor_login_test.go
@@ -1250,9 +1250,8 @@ func testSupervisorLogin(
 			require.Error(t, err)
 			require.Regexp(t,
 				regexp.QuoteMeta("oauth2: cannot fetch token: 401 Unauthorized\n")+
-					regexp.QuoteMeta(`Response: {"error":"error","error_description":"Error during upstream refresh. Upstream refresh failed using provider '`)+
-					"[^']+"+ // this would be the name of the identity provider CR
-					regexp.QuoteMeta(fmt.Sprintf(`' of type '%s'."`, pinnipedSession.Custom.ProviderType)),
+					regexp.QuoteMeta(`Response: {"error":"error","error_description":"Error during upstream refresh. Upstream refresh failed`)+
+					"[^']+",
 				err.Error(),
 			)
 		}


### PR DESCRIPTION
This resolves #340.
It includes:
- Storing the user's DN upon login
- ensuring the LDAP/AD entry still exists upon refresh
- ensuring the LDAP/AD entry still has the same username and subject
It doesn't include:
- Anything to do with groups
- Anything AD specific