### PR TITLE
Make Concierge server port numbers configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,8 @@ FROM gcr.io/distroless/static:nonroot@sha256:bca3c203cdb36f5914ab8568e4c25165643
 # Copy the server binary from the build-env stage.
 COPY --from=build-env /usr/local/bin /usr/local/bin
 
-# Document the ports
-EXPOSE 8080 8443
+# Document the default server ports for the various server apps
+EXPOSE 8080 8443 8444 10250
 
 # Run as non-root for security posture
 # Use the same non-root user as https://github.com/GoogleContainerTools/distroless/blob/fc3c4eaceb0518900f886aae90407c43be0a42d9/base/base.bzl#L9

--- a/deploy/concierge/deployment.yaml
+++ b/deploy/concierge/deployment.yaml
@@ -58,6 +58,7 @@ data:
         durationSeconds: (@= str(data.values.api_serving_certificate_duration_seconds) @)
         renewBeforeSeconds: (@= str(data.values.api_serving_certificate_renew_before_seconds) @)
     apiGroupSuffix: (@= data.values.api_group_suffix @)
+    # aggregatedAPIServerPort may be set here, although other YAML references to the default port (10250) may also need to be updated
     names:
       servingCertificateSecret: (@= defaultResourceNameWithSuffix("api-tls-serving-certificate") @)
       credentialIssuer: (@= defaultResourceNameWithSuffix("config") @)
@@ -175,7 +176,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 8443
+              port: 10250
               scheme: HTTPS
             initialDelaySeconds: 2
             timeoutSeconds: 15
@@ -184,7 +185,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /healthz
-              port: 8443
+              port: 10250
               scheme: HTTPS
             initialDelaySeconds: 2
             timeoutSeconds: 3
@@ -251,7 +252,7 @@ spec:
   ports:
     - protocol: TCP
       port: 443
-      targetPort: 8443
+      targetPort: 10250
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/concierge/deployment.yaml
+++ b/deploy/concierge/deployment.yaml
@@ -59,6 +59,7 @@ data:
         renewBeforeSeconds: (@= str(data.values.api_serving_certificate_renew_before_seconds) @)
     apiGroupSuffix: (@= data.values.api_group_suffix @)
     # aggregatedAPIServerPort may be set here, although other YAML references to the default port (10250) may also need to be updated
+    # impersonationProxyServerPort may be set here, although other YAML references to the default port (8444) may also need to be updated
     names:
       servingCertificateSecret: (@= defaultResourceNameWithSuffix("api-tls-serving-certificate") @)
       credentialIssuer: (@= defaultResourceNameWithSuffix("config") @)

--- a/deploy/concierge/values.yaml
+++ b/deploy/concierge/values.yaml
@@ -41,7 +41,7 @@ kube_cert_agent_image:
 image_pull_dockerconfigjson: #! e.g. {"auths":{"https://registry.example.com":{"username":"USERNAME","password":"PASSWORD","auth":"BASE64_ENCODED_USERNAME_COLON_PASSWORD"}}}
 
 #! Pinniped will try to guess the right K8s API URL for sharing that information with potential clients.
-#! This settings allows the guess to be overridden.
+#! This setting allows the guess to be overridden.
 #! Optional.
 discovery_url: #! e.g., https://example.com
 

--- a/internal/concierge/server/server.go
+++ b/internal/concierge/server/server.go
@@ -150,6 +150,8 @@ func (a *App) runServer(ctx context.Context) error {
 			ServingCertDuration:              time.Duration(*cfg.APIConfig.ServingCertificateConfig.DurationSeconds) * time.Second,
 			ServingCertRenewBefore:           time.Duration(*cfg.APIConfig.ServingCertificateConfig.RenewBeforeSeconds) * time.Second,
 			AuthenticatorCache:               authenticators,
+			// This port should be safe to cast because the config reader already validated it.
+			ImpersonationProxyServerPort: int(*cfg.ImpersonationProxyServerPort),
 		},
 	)
 	if err != nil {

--- a/internal/concierge/server/server.go
+++ b/internal/concierge/server/server.go
@@ -168,6 +168,7 @@ func (a *App) runServer(ctx context.Context) error {
 		certIssuer,
 		buildControllers,
 		*cfg.APIGroupSuffix,
+		*cfg.AggregatedAPIServerPort,
 		scheme,
 		loginGV,
 		identityGV,
@@ -193,6 +194,7 @@ func getAggregatedAPIServerConfig(
 	issuer issuer.ClientCertIssuer,
 	buildControllers controllerinit.RunnerBuilder,
 	apiGroupSuffix string,
+	aggregatedAPIServerPort int64,
 	scheme *runtime.Scheme,
 	loginConciergeGroupVersion, identityConciergeGroupVersion schema.GroupVersion,
 ) (*apiserver.Config, error) {
@@ -207,7 +209,9 @@ func getAggregatedAPIServerConfig(
 	)
 	recommendedOptions.Etcd = nil // turn off etcd storage because we don't need it yet
 	recommendedOptions.SecureServing.ServerCert.GeneratedCert = dynamicCertProvider
-	recommendedOptions.SecureServing.BindPort = 8443 // Don't run on default 443 because that requires root
+
+	// This port is configurable. It should be safe to cast because the config reader already validated it.
+	recommendedOptions.SecureServing.BindPort = int(aggregatedAPIServerPort)
 
 	serverConfig := genericapiserver.NewRecommendedConfig(codecs)
 	// Note that among other things, this ApplyTo() function copies

--- a/internal/config/concierge/config.go
+++ b/internal/config/concierge/config.go
@@ -21,6 +21,12 @@ import (
 const (
 	aboutAYear   = 60 * 60 * 24 * 365
 	about9Months = 60 * 60 * 24 * 30 * 9
+
+	// Use 10250 because it happens to be the same port on which the Kubelet listens, so some cluster types
+	// are more permissive with servers that run on this port. For example, GKE private clusters do not
+	// allow traffic from the control plane to most ports, but do allow traffic to port 10250. This allows
+	// the Concierge to work without additional configuration on these types of clusters.
+	aggregatedAPIServerPortDefault = 10250
 )
 
 // FromPath loads an Config from a provided local file path, inserts any
@@ -42,6 +48,7 @@ func FromPath(path string) (*Config, error) {
 	}
 
 	maybeSetAPIDefaults(&config.APIConfig)
+	maybeSetAggregatedAPIServerPortDefaults(&config.AggregatedAPIServerPort)
 	maybeSetAPIGroupSuffixDefault(&config.APIGroupSuffix)
 	maybeSetKubeCertAgentDefaults(&config.KubeCertAgentConfig)
 
@@ -51,6 +58,10 @@ func FromPath(path string) (*Config, error) {
 
 	if err := validateAPIGroupSuffix(*config.APIGroupSuffix); err != nil {
 		return nil, fmt.Errorf("validate apiGroupSuffix: %w", err)
+	}
+
+	if err := validateAggregatedAPIServerPort(config.AggregatedAPIServerPort); err != nil {
+		return nil, fmt.Errorf("validate aggregatedAPIServerPort: %w", err)
 	}
 
 	if err := validateNames(&config.NamesConfig); err != nil {
@@ -81,6 +92,12 @@ func maybeSetAPIDefaults(apiConfig *APIConfigSpec) {
 func maybeSetAPIGroupSuffixDefault(apiGroupSuffix **string) {
 	if *apiGroupSuffix == nil {
 		*apiGroupSuffix = pointer.StringPtr(groupsuffix.PinnipedDefaultSuffix)
+	}
+}
+
+func maybeSetAggregatedAPIServerPortDefaults(aggregatedAPIServerPort **int64) {
+	if *aggregatedAPIServerPort == nil {
+		*aggregatedAPIServerPort = pointer.Int64Ptr(aggregatedAPIServerPortDefault)
 	}
 }
 
@@ -146,4 +163,12 @@ func validateAPI(apiConfig *APIConfigSpec) error {
 
 func validateAPIGroupSuffix(apiGroupSuffix string) error {
 	return groupsuffix.Validate(apiGroupSuffix)
+}
+
+func validateAggregatedAPIServerPort(aggregatedAPIServerPort *int64) error {
+	// It cannot be below 1024 because the container is not running as root.
+	if *aggregatedAPIServerPort < 1024 || *aggregatedAPIServerPort > 65535 {
+		return constable.Error("must be within range 1024 to 65535")
+	}
+	return nil
 }

--- a/internal/config/concierge/config_test.go
+++ b/internal/config/concierge/config_test.go
@@ -33,6 +33,7 @@ func TestFromPath(t *testing.T) {
 					durationSeconds: 3600
 					renewBeforeSeconds: 2400
 				apiGroupSuffix: some.suffix.com
+				aggregatedAPIServerPort: 12345
 				names:
 				  servingCertificateSecret: pinniped-concierge-api-tls-serving-certificate
 				  credentialIssuer: pinniped-config
@@ -65,7 +66,8 @@ func TestFromPath(t *testing.T) {
 						RenewBeforeSeconds: pointer.Int64Ptr(2400),
 					},
 				},
-				APIGroupSuffix: pointer.StringPtr("some.suffix.com"),
+				APIGroupSuffix:          pointer.StringPtr("some.suffix.com"),
+				AggregatedAPIServerPort: pointer.Int64Ptr(12345),
 				NamesConfig: NamesConfigSpec{
 					ServingCertificateSecret:          "pinniped-concierge-api-tls-serving-certificate",
 					CredentialIssuer:                  "pinniped-config",
@@ -108,7 +110,8 @@ func TestFromPath(t *testing.T) {
 				DiscoveryInfo: DiscoveryInfoSpec{
 					URL: nil,
 				},
-				APIGroupSuffix: pointer.StringPtr("pinniped.dev"),
+				APIGroupSuffix:          pointer.StringPtr("pinniped.dev"),
+				AggregatedAPIServerPort: pointer.Int64Ptr(10250),
 				APIConfig: APIConfigSpec{
 					ServingCertificateConfig: ServingCertificateConfigSpec{
 						DurationSeconds:    pointer.Int64Ptr(60 * 60 * 24 * 365),    // about a year
@@ -322,6 +325,22 @@ func TestFromPath(t *testing.T) {
 				  impersonationSignerSecret: impersonationSignerSecret-value
 			`),
 			wantError: "validate api: renewBefore must be positive",
+		},
+		{
+			name: "AggregatedAPIServerPortDefault too small",
+			yaml: here.Doc(`
+				---
+				aggregatedAPIServerPort: 1023
+			`),
+			wantError: "validate aggregatedAPIServerPort: must be within range 1024 to 65535",
+		},
+		{
+			name: "AggregatedAPIServerPortDefault too large",
+			yaml: here.Doc(`
+				---
+				aggregatedAPIServerPort: 65536
+			`),
+			wantError: "validate aggregatedAPIServerPort: must be within range 1024 to 65535",
 		},
 		{
 			name: "ZeroRenewBefore",

--- a/internal/config/concierge/config_test.go
+++ b/internal/config/concierge/config_test.go
@@ -34,6 +34,7 @@ func TestFromPath(t *testing.T) {
 					renewBeforeSeconds: 2400
 				apiGroupSuffix: some.suffix.com
 				aggregatedAPIServerPort: 12345
+				impersonationProxyServerPort: 4242
 				names:
 				  servingCertificateSecret: pinniped-concierge-api-tls-serving-certificate
 				  credentialIssuer: pinniped-config
@@ -66,8 +67,9 @@ func TestFromPath(t *testing.T) {
 						RenewBeforeSeconds: pointer.Int64Ptr(2400),
 					},
 				},
-				APIGroupSuffix:          pointer.StringPtr("some.suffix.com"),
-				AggregatedAPIServerPort: pointer.Int64Ptr(12345),
+				APIGroupSuffix:               pointer.StringPtr("some.suffix.com"),
+				AggregatedAPIServerPort:      pointer.Int64Ptr(12345),
+				ImpersonationProxyServerPort: pointer.Int64Ptr(4242),
 				NamesConfig: NamesConfigSpec{
 					ServingCertificateSecret:          "pinniped-concierge-api-tls-serving-certificate",
 					CredentialIssuer:                  "pinniped-config",
@@ -110,8 +112,9 @@ func TestFromPath(t *testing.T) {
 				DiscoveryInfo: DiscoveryInfoSpec{
 					URL: nil,
 				},
-				APIGroupSuffix:          pointer.StringPtr("pinniped.dev"),
-				AggregatedAPIServerPort: pointer.Int64Ptr(10250),
+				APIGroupSuffix:               pointer.StringPtr("pinniped.dev"),
+				AggregatedAPIServerPort:      pointer.Int64Ptr(10250),
+				ImpersonationProxyServerPort: pointer.Int64Ptr(8444),
 				APIConfig: APIConfigSpec{
 					ServingCertificateConfig: ServingCertificateConfigSpec{
 						DurationSeconds:    pointer.Int64Ptr(60 * 60 * 24 * 365),    // about a year
@@ -341,6 +344,22 @@ func TestFromPath(t *testing.T) {
 				aggregatedAPIServerPort: 65536
 			`),
 			wantError: "validate aggregatedAPIServerPort: must be within range 1024 to 65535",
+		},
+		{
+			name: "ImpersonationProxyServerPort too small",
+			yaml: here.Doc(`
+				---
+				impersonationProxyServerPort: 1023
+			`),
+			wantError: "validate impersonationProxyServerPort: must be within range 1024 to 65535",
+		},
+		{
+			name: "ImpersonationProxyServerPort too large",
+			yaml: here.Doc(`
+				---
+				impersonationProxyServerPort: 65536
+			`),
+			wantError: "validate impersonationProxyServerPort: must be within range 1024 to 65535",
 		},
 		{
 			name: "ZeroRenewBefore",

--- a/internal/config/concierge/types.go
+++ b/internal/config/concierge/types.go
@@ -7,13 +7,14 @@ import "go.pinniped.dev/internal/plog"
 
 // Config contains knobs to setup an instance of the Pinniped Concierge.
 type Config struct {
-	DiscoveryInfo       DiscoveryInfoSpec `json:"discovery"`
-	APIConfig           APIConfigSpec     `json:"api"`
-	APIGroupSuffix      *string           `json:"apiGroupSuffix,omitempty"`
-	NamesConfig         NamesConfigSpec   `json:"names"`
-	KubeCertAgentConfig KubeCertAgentSpec `json:"kubeCertAgent"`
-	Labels              map[string]string `json:"labels"`
-	LogLevel            plog.LogLevel     `json:"logLevel"`
+	DiscoveryInfo           DiscoveryInfoSpec `json:"discovery"`
+	APIConfig               APIConfigSpec     `json:"api"`
+	APIGroupSuffix          *string           `json:"apiGroupSuffix,omitempty"`
+	AggregatedAPIServerPort *int64            `json:"aggregatedAPIServerPort"`
+	NamesConfig             NamesConfigSpec   `json:"names"`
+	KubeCertAgentConfig     KubeCertAgentSpec `json:"kubeCertAgent"`
+	Labels                  map[string]string `json:"labels"`
+	LogLevel                plog.LogLevel     `json:"logLevel"`
 }
 
 // DiscoveryInfoSpec contains configuration knobs specific to

--- a/internal/config/concierge/types.go
+++ b/internal/config/concierge/types.go
@@ -7,14 +7,15 @@ import "go.pinniped.dev/internal/plog"
 
 // Config contains knobs to setup an instance of the Pinniped Concierge.
 type Config struct {
-	DiscoveryInfo           DiscoveryInfoSpec `json:"discovery"`
-	APIConfig               APIConfigSpec     `json:"api"`
-	APIGroupSuffix          *string           `json:"apiGroupSuffix,omitempty"`
-	AggregatedAPIServerPort *int64            `json:"aggregatedAPIServerPort"`
-	NamesConfig             NamesConfigSpec   `json:"names"`
-	KubeCertAgentConfig     KubeCertAgentSpec `json:"kubeCertAgent"`
-	Labels                  map[string]string `json:"labels"`
-	LogLevel                plog.LogLevel     `json:"logLevel"`
+	DiscoveryInfo                DiscoveryInfoSpec `json:"discovery"`
+	APIConfig                    APIConfigSpec     `json:"api"`
+	APIGroupSuffix               *string           `json:"apiGroupSuffix,omitempty"`
+	AggregatedAPIServerPort      *int64            `json:"aggregatedAPIServerPort"`
+	ImpersonationProxyServerPort *int64            `json:"impersonationProxyServerPort"`
+	NamesConfig                  NamesConfigSpec   `json:"names"`
+	KubeCertAgentConfig          KubeCertAgentSpec `json:"kubeCertAgent"`
+	Labels                       map[string]string `json:"labels"`
+	LogLevel                     plog.LogLevel     `json:"logLevel"`
 }
 
 // DiscoveryInfoSpec contains configuration knobs specific to

--- a/internal/controller/impersonatorconfig/impersonator_config_test.go
+++ b/internal/controller/impersonatorconfig/impersonator_config_test.go
@@ -51,6 +51,7 @@ import (
 func TestImpersonatorConfigControllerOptions(t *testing.T) {
 	spec.Run(t, "options", func(t *testing.T, when spec.G, it spec.S) {
 		const installedInNamespace = "some-namespace"
+		const impersonationProxyPort = 8444
 		const credentialIssuerResourceName = "some-credential-issuer-resource-name"
 		const generatedLoadBalancerServiceName = "some-service-resource-name"
 		const generatedClusterIPServiceName = "some-cluster-ip-resource-name"
@@ -84,6 +85,7 @@ func TestImpersonatorConfigControllerOptions(t *testing.T) {
 				servicesInformer,
 				secretsInformer,
 				observableWithInformerOption.WithInformer,
+				impersonationProxyPort,
 				generatedLoadBalancerServiceName,
 				generatedClusterIPServiceName,
 				tlsSecretName,
@@ -252,6 +254,7 @@ func TestImpersonatorConfigControllerSync(t *testing.T) {
 	name := t.Name()
 	spec.Run(t, "Sync", func(t *testing.T, when spec.G, it spec.S) {
 		const installedInNamespace = "some-namespace"
+		const impersonationProxyPort = 8444
 		const credentialIssuerResourceName = "some-credential-issuer-resource-name"
 		const loadBalancerServiceName = "some-service-resource-name"
 		const clusterIPServiceName = "some-cluster-ip-resource-name"
@@ -553,6 +556,7 @@ func TestImpersonatorConfigControllerSync(t *testing.T) {
 				kubeInformers.Core().V1().Services(),
 				kubeInformers.Core().V1().Secrets(),
 				controllerlib.WithInformer,
+				impersonationProxyPort,
 				loadBalancerServiceName,
 				clusterIPServiceName,
 				tlsSecretName,

--- a/internal/controllermanager/prepare_controllers.go
+++ b/internal/controllermanager/prepare_controllers.go
@@ -59,6 +59,9 @@ type Config struct {
 	// the kubecertagent package's controllers should manage the agent pods.
 	KubeCertAgentConfig *concierge.KubeCertAgentSpec
 
+	// ImpersonationProxyServerPort decides which port the impersonation proxy should bind.
+	ImpersonationProxyServerPort int
+
 	// DiscoveryURLOverride allows a caller to inject a hardcoded discovery URL into Pinniped
 	// discovery document.
 	DiscoveryURLOverride *string
@@ -93,7 +96,7 @@ type Config struct {
 	Labels map[string]string
 }
 
-// Prepare the controllers and their informers and return a function that will start them when called.
+// PrepareControllers prepares the controllers and their informers and returns a function that will start them when called.
 //nolint:funlen // Eh, fair, it is a really long function...but it is wiring the world...so...
 func PrepareControllers(c *Config) (controllerinit.RunnerBuilder, error) {
 	loginConciergeGroupData, identityConciergeGroupData := groupsuffix.ConciergeAggregatedGroups(c.APIGroupSuffix)
@@ -262,6 +265,7 @@ func PrepareControllers(c *Config) (controllerinit.RunnerBuilder, error) {
 				informers.installationNamespaceK8s.Core().V1().Services(),
 				informers.installationNamespaceK8s.Core().V1().Secrets(),
 				controllerlib.WithInformer,
+				c.ImpersonationProxyServerPort,
 				c.NamesConfig.ImpersonationLoadBalancerService,
 				c.NamesConfig.ImpersonationClusterIPService,
 				c.NamesConfig.ImpersonationTLSCertificateSecret,


### PR DESCRIPTION
Make several ports configurable to partially address #864.

- Add aggregatedAPIServerPort to the Concierge's static ConfigMap
  - The aggregated API server now defaults to port 10250 to allow it to work without needing further configuration on private GKE clusters.
- Add impersonationProxyServerPort to the Concierge's static ConfigMap (still defaults to 8444 as before)
- Allow both port numbers to be configured to any value within the range 1024 to 65535. It cannot be below 1024 because the container is not running as root.
- This does not include adding new config knobs to the ytt values file, so while it is possible to change this port without needing to recompile, it is not convenient. This is because it is unlikely that users would need to configure this, and we are waiting for more feedback before promoting it to a first-class configuration option.

**Release note**:

```release-note
Makes it possible to change the listening port numbers of the aggregated API server and impersonation proxy, which is typically not necessary but could be used for example on a cluster using host networking where these ports are already consumed by other services. The aggregated API server now defaults to port 10250 to allow it to work without needing further configuration on private GKE clusters.
```
