### PR TITLE
tls: fix integration tests for long lived environments

### DIFF
--- a/test/integration/concierge_impersonation_proxy_test.go
+++ b/test/integration/concierge_impersonation_proxy_test.go
@@ -317,7 +317,7 @@ func TestImpersonationProxy(t *testing.T) { //nolint:gocyclo // yeah, it's compl
 		supervisorPod := supervisorPods.Items[0]
 
 		// make sure the supervisor has a default TLS cert during this test so that it can handle a TLS connection
-		_ = createTLSCertificateSecret(ctx, t, env.SupervisorNamespace, "cert-hostname-doesnt-matter", nil, defaultTLSCertSecretName(env), adminClient)
+		createSupervisorDefaultTLSCertificateSecretIfNeeded(ctx, t)
 
 		// Test that the user can perform basic actions through the client with their username and group membership
 		// influencing RBAC checks correctly.

--- a/test/integration/securetls_test.go
+++ b/test/integration/securetls_test.go
@@ -102,17 +102,16 @@ func TestSecureTLSConciergeAggregatedAPI_Parallel(t *testing.T) {
 	require.Contains(t, stdout, getExpectedCiphers(ptls.Secure), "stdout:\n%s", stdout)
 }
 
-func TestSecureTLSSupervisor(t *testing.T) { // does not run in parallel because of the createTLSCertificateSecret call
+func TestSecureTLSSupervisor(t *testing.T) { // does not run in parallel because of the createSupervisorDefaultTLSCertificateSecretIfNeeded call
 	env := testlib.IntegrationEnv(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	adminClient := testlib.NewKubernetesClientset(t)
 	// make sure the supervisor has a default TLS cert during this test so that it can handle a TLS connection
-	_ = createTLSCertificateSecret(ctx, t, env.SupervisorNamespace, "cert-hostname-doesnt-matter", nil, defaultTLSCertSecretName(env), adminClient)
+	createSupervisorDefaultTLSCertificateSecretIfNeeded(ctx, t)
 
-	startKubectlPortForward(ctx, t, "10447", "443", env.SupervisorAppName+"-clusterip", env.SupervisorNamespace)
+	startKubectlPortForward(ctx, t, "10447", "443", env.SupervisorAppName+"-nodeport", env.SupervisorNamespace)
 
 	stdout, stderr := runNmapSSLEnum(t, "127.0.0.1", 10447)
 

--- a/test/integration/supervisor_discovery_test.go
+++ b/test/integration/supervisor_discovery_test.go
@@ -320,6 +320,22 @@ func createTLSCertificateSecret(ctx context.Context, t *testing.T, ns string, ho
 	return ca
 }
 
+func createSupervisorDefaultTLSCertificateSecretIfNeeded(ctx context.Context, t *testing.T) {
+	env := testlib.IntegrationEnv(t)
+	adminClient := testlib.NewKubernetesClientset(t)
+
+	ns := env.SupervisorNamespace
+	name := defaultTLSCertSecretName(env)
+
+	_, err := adminClient.CoreV1().Secrets(ns).Get(ctx, name, metav1.GetOptions{})
+
+	if k8serrors.IsNotFound(err) {
+		_ = createTLSCertificateSecret(ctx, t, ns, "cert-hostname-doesnt-matter", nil, name, adminClient)
+	} else {
+		require.NoError(t, err)
+	}
+}
+
 func temporarilyRemoveAllFederationDomainsAndDefaultTLSCertSecret(
 	ctx context.Context,
 	t *testing.T,


### PR DESCRIPTION
This change updates the new TLS integration tests to:

1. Only create the supervisor default TLS serving cert if needed
2. Port forward the node port supervisor service since that is available in all environments

Signed-off-by: Monis Khan <mok@vmware.com>

**Release note**:

```release-note
NONE
```