### PR TITLE
Add Supervisor HTTP/HTTPS port listener configuration options

### DIFF
--- a/deploy/supervisor/deployment.yaml
+++ b/deploy/supervisor/deployment.yaml
@@ -32,6 +32,8 @@ data:
   #@yaml/text-templated-strings
   pinniped.yaml: |
     apiGroupSuffix: (@= data.values.api_group_suffix @)
+    supervisorHTTPListener: (@= data.values.container_http_listener @)
+    supervisorHTTPSListener: (@= data.values.container_https_listener @)
     names:
       defaultTLSCertificateSecret: (@= defaultResourceNameWithSuffix("default-tls-certificate") @)
     labels: (@= json.encode(labels()).rstrip() @)

--- a/deploy/supervisor/values.yaml
+++ b/deploy/supervisor/values.yaml
@@ -73,3 +73,29 @@ api_group_suffix: pinniped.dev
 #! Optional.
 https_proxy: #! e.g. http://proxy.example.com
 no_proxy: "$(KUBERNETES_SERVICE_HOST),169.254.169.254,127.0.0.1,localhost,.svc,.cluster.local" #! do not proxy Kubernetes endpoints
+
+#! Configure the Supervisor server's HTTP listener. The required format is "network,address", where network and
+#! address are each defined the same as the parameters of https://pkg.go.dev/net#Listen, joined by the separator ","
+#! (with no spaces around the ","). Specifying an empty string will cause the Supervisor to not open an HTTP port at all.
+#! Note that changing this value is not necessarily sufficient by itself, and will require also manually
+#! changing port numbers of Services and Deployment health checks in other parts of the YAML manifests.
+#! The default value of "tcp,:8080" will bind to all IPv4 and IPv6 addresses on port 8080. Note that this makes it
+#! possible to expose the Supervisor's APIs to the public via insecure HTTP, but this should never be done in a
+#! production system. It is never safe for the APIs to be public without TLS, since many of them deal with
+#! credentials and secret tokens. The only exception is the HTTP port's /healthz endpoint can be used safely for
+#! in-cluster health checking without TLS. It might be safe to use the HTTP port for traffic from a service mesh
+#! sidecar in the same pod, assuming that the service mesh is using other mechanisms to secure the network traffic.
+#! Refer to the documentation of your service mesh for more information. If using a service mesh to secure all traffic,
+#! consider changing this setting to bind only to localhost addresses to make it impossible to accidentally accept
+#! insecure traffic from outside the pod. The default value of this option may change in the future to a more restrictive
+#! default to help users avoid accidentally exposing the APIs to the public via HTTP.
+#! If the default value is changed in the future, it will be announced via release notes on the GitHub releases.
+container_http_listener: "tcp,:8080"
+
+#! Configure the Supervisor server's HTTPS listener. The required format is "network,address", where network and
+#! address are each defined the same as the parameters of https://pkg.go.dev/net#Listen, joined by the separator ","
+#! (with no spaces around the ","). Empty values are not allowed.
+#! Note that changing this value is not necessarily sufficient by itself, and will require also manually
+#! changing port numbers of Services and Deployment health checks in other parts of the YAML manifests.
+#! The default value of "tcp,:8443" will bind to all IPv4 and IPv6 addresses on port 8443.
+container_https_listener: "tcp,:8443"

--- a/internal/config/supervisor/types.go
+++ b/internal/config/supervisor/types.go
@@ -3,7 +3,11 @@
 
 package supervisor
 
-import "go.pinniped.dev/internal/plog"
+import (
+	"strings"
+
+	"go.pinniped.dev/internal/plog"
+)
 
 // Config contains knobs to setup an instance of the Pinniped Supervisor.
 type Config struct {
@@ -11,9 +15,34 @@ type Config struct {
 	Labels         map[string]string `json:"labels"`
 	NamesConfig    NamesConfigSpec   `json:"names"`
 	LogLevel       plog.LogLevel     `json:"logLevel"`
+
+	SupervisorHTTPListener  string `json:"supervisorHTTPListener"`
+	SupervisorHTTPSListener string `json:"supervisorHTTPSListener"`
 }
 
 // NamesConfigSpec configures the names of some Kubernetes resources for the Supervisor.
 type NamesConfigSpec struct {
 	DefaultTLSCertificateSecret string `json:"defaultTLSCertificateSecret"`
+}
+
+func (c *Config) SupervisorHTTPListenerNetwork() string {
+	if len(c.SupervisorHTTPListener) > 0 {
+		return strings.SplitN(c.SupervisorHTTPListener, ",", 2)[0]
+	}
+	return ""
+}
+
+func (c *Config) SupervisorHTTPListenerAddress() string {
+	if len(c.SupervisorHTTPListener) > 0 {
+		return strings.SplitN(c.SupervisorHTTPListener, ",", 2)[1]
+	}
+	return ""
+}
+
+func (c *Config) SupervisorHTTPSListenerNetwork() string {
+	return strings.SplitN(c.SupervisorHTTPSListener, ",", 2)[0]
+}
+
+func (c *Config) SupervisorHTTPSListenerAddress() string {
+	return strings.SplitN(c.SupervisorHTTPSListener, ",", 2)[1]
 }

--- a/internal/supervisor/server/server.go
+++ b/internal/supervisor/server/server.go
@@ -304,7 +304,7 @@ func startControllers(ctx context.Context, shutdown *sync.WaitGroup, buildContro
 	return nil
 }
 
-func runSupervisor(podInfo *downward.PodInfo, cfg *supervisor.Config) error {
+func runSupervisor(podInfo *downward.PodInfo, cfg *supervisor.Config) error { //nolint:funlen // kinda long but wires the world
 	serverInstallationNamespace := podInfo.Namespace
 
 	dref, supervisorDeployment, err := deploymentref.New(podInfo)

--- a/site/content/docs/howto/configure-supervisor.md
+++ b/site/content/docs/howto/configure-supervisor.md
@@ -9,23 +9,55 @@ menu:
     weight: 70
     parent: howtos
 ---
+
 The Supervisor is an [OpenID Connect (OIDC)](https://openid.net/connect/) issuer that supports connecting a single
-"upstream" identity provider to many "downstream" cluster clients.
+"upstream" identity provider to many "downstream" cluster clients. When a user authenticates, the Supervisor can issue
+[JSON Web Tokens (JWTs)](https://tools.ietf.org/html/rfc7519) that can be [validated by the Pinniped Concierge]({{< ref "configure-concierge-jwt" >}}).
 
-This guide show you how to use this capability to issue [JSON Web Tokens (JWTs)](https://tools.ietf.org/html/rfc7519) that can be validated by the [Pinniped Concierge]({{< ref "configure-concierge-jwt" >}}).
+This guide explains how to expose the Supervisor's REST endpoints to clients.
 
-Before starting, you should have the [command-line tool installed]({{< ref "install-cli" >}}) locally and the Concierge [installed]({{< ref "install-concierge" >}}) in your cluster.
+## Prerequisites
 
-## Expose the Supervisor app as a service
+This how-to guide assumes that you have already [installed the Pinniped Supervisor]({{< ref "install-supervisor" >}}).
 
-The Supervisor app's endpoints should be exposed as HTTPS endpoints with proper TLS certificates signed by a certificate authority (CA) which is trusted by your user's web browsers.
+## Exposing the Supervisor app's endpoints outside the cluster
+
+The Supervisor app's endpoints should be exposed as HTTPS endpoints with proper TLS certificates signed by a
+certificate authority (CA) which is trusted by your end user's web browsers.
+
+It is recommended that the traffic to these endpoints should be encrypted via TLS all the way into the
+Supervisor pods, even when crossing boundaries that are entirely inside the Kubernetes cluster.
+The credentials and tokens that are handled by these endpoints are too sensitive to transmit without encryption.
+
+In all versions of the Supervisor app so far, there are both HTTP and HTTPS ports available for use by default.
+These ports each host all the Supervisor's endpoints. Unfortunately, this has caused some confusion in the community
+and some blog posts have been written which demonstrate using the HTTP port in such a way that a portion of the traffic's
+path is unencrypted. **Anything which exposes the non-TLS HTTP port outside the Pod should be considered deprecated**.
+A future version of the Supervisor app may include a breaking change to adjust the default behavior of the HTTP port
+to only listen on localhost (or perhaps even to be disabled) to make it more clear that the Supervisor app is not intended to receive
+non-TLS HTTP traffic from outside the Pod (expect the `/healthz` endpoint).
 
 Because there are many ways to expose TLS services from a Kubernetes cluster, the Supervisor app leaves this up to the user.
 The most common ways are:
 
-1. Define an [`Ingress` resource](https://kubernetes.io/docs/concepts/services-networking/ingress/) with TLS certificates.
-   In this case, the ingress terminates TLS. Typically, the ingress then talks plain HTTP to its backend,
+- Define a [TCP LoadBalancer Service](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer).
+
+  In this case, the Service is a layer 4 load balancer which does not terminate TLS, so the Supervisor app needs to be
+  configured with TLS certificates and will terminate the TLS connection itself (see the section about FederationDomain
+  below). The LoadBalancer Service should be configured to use the HTTPS port 443 of the Supervisor pods as its `targetPort`.
+
+  *Warning:* Never expose the Supervisor's HTTP port 8080 to the public. It would not be secure for the OIDC protocol
+  to use HTTP, because the user's secret OIDC tokens would be transmitted across the network without encryption.
+
+- Or, define an [Ingress resource](https://kubernetes.io/docs/concepts/services-networking/ingress/).
+
+   In this case, the [Ingress typically terminates TLS](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls)
+   and then talks plain HTTP to its backend,
    which would be a NodePort or LoadBalancer Service in front of the HTTP port 8080 of the Supervisor pods.
+   However, because the Supervisor's endpoints deal with sensitive credentials, it is much better if the
+   traffic is encrypted using TLS all the way into the Supervisor's Pods. Some Ingress implementations
+   may support re-encrypting the traffic before sending it to the backend. If your Ingress controller does not
+   support this, then consider using one of the other configurations described here instead of using an Ingress.
 
    The required configuration of the Ingress is specific to your cluster's Ingress Controller, so please refer to the
    documentation from your Kubernetes provider. If you are using a cluster from a cloud provider, then you'll probably
@@ -35,26 +67,40 @@ The most common ways are:
    [Ingress Controllers](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/), including
    [Contour](https://projectcontour.io/) and many others.
 
-1. Or, define a [TCP LoadBalancer Service](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer)
-   which is a layer 4 load balancer and does not terminate TLS. In this case, the Supervisor app needs to be
-   configured with TLS certificates and terminates the TLS connection itself (see the section about FederationDomain
-   below). The LoadBalancer Service should be configured to use the HTTPS port 443 of the Supervisor pods as its `targetPort`.
+- Or, expose the Supervisor app using a Kubernetes service mesh technology (e.g. [Istio](https://istio.io/)).
 
-   *Warning:* do not expose the Supervisor's port 8080 to the public. It would not be secure for the OIDC protocol
-   to use HTTP, because the user's secret OIDC tokens would be transmitted across the network without encryption.
+   In this case, the setup would be similar to the previous description
+   for defining an Ingress, except the service mesh would probably provide both the ingress with TLS termination
+   and the service. Please see the documentation for your service mesh.
 
-1. Or, expose the Supervisor app using a Kubernetes service mesh technology, for example [Istio](https://istio.io/).
-   Please see the documentation for your service mesh. Generally, the setup would be similar to the previous description
-   for defining an ingress, except the service mesh would probably provide both the ingress with TLS termination
-   and the service.
+   If your service mesh is capable of transparently encrypting traffic all the way into the
+   Supervisor Pods, then you should use that capability. In this case, it may make sense to configure the Supervisor's
+   HTTP port to only listen on localhost, such as when the service mesh injects a sidecar container that can securely
+   access the HTTP port via localhost networking from within the same Pod.
+   See the `container_http_listener` option in [deploy/supervisor/values.yml](https://github.com/vmware-tanzu/pinniped/blob/main/deploy/supervisor/values.yaml)
+   for more information.
+   This would prevent any unencrypted traffic from accidentally being transmitted from outside the Pod into the
+   Supervisor app's HTTP port.
 
-For either of the first two options, if you installed using `ytt` then you can use
-the related `service_*` options from [deploy/supervisor/values.yml](https://github.com/vmware-tanzu/pinniped/blob/main/deploy/supervisor/values.yaml) to create a Service.
-If you installed using `install-supervisor.yaml` then you can create
-the Service separately after installing the Supervisor app. There is no `Ingress` included in the `ytt` templates,
-so if you choose to use an Ingress then you'll need to create that separately after installing the Supervisor app.
+## Creating a Service to expose the Supervisor app's endpoints within the cluster
 
-#### Example: Using a LoadBalancer Service
+Now that you've selected a strategy to expose the endpoints outside the cluster, you can choose how to expose
+the endpoints inside the cluster in support of that strategy.
+
+If you've decided to use a LoadBalancer Service then you'll need to create it. On the other hand, if you've decided to
+use an Ingress then you'll need to create a Service which the Ingress can use as its backend. Either way, how you
+create the Service will depend on how you choose to install the Supervisor:
+
+- If you installed using `ytt` then you can use
+the related `service_*` options from [deploy/supervisor/values.yml](https://github.com/vmware-tanzu/pinniped/blob/main/deploy/supervisor/values.yaml)
+to create a Service. 
+- If you installed using the pre-rendered manifests attached to the Pinniped GitHub releases, then you can create
+the Service separately after installing the Supervisor app.
+
+There is no Ingress included in either the `ytt` templates or the pre-rendered manifests,
+so if you choose to use an Ingress then you'll need to create the Ingress separately after installing the Supervisor app.
+
+### Example: Creating a LoadBalancer Service
 
 This is an example of creating a LoadBalancer Service to expose port 8443 of the Supervisor app outside the cluster.
 
@@ -63,70 +109,79 @@ apiVersion: v1
 kind: Service
 metadata:
   name: pinniped-supervisor-loadbalancer
-  # Assuming that this is the namespace where the supervisor was installed. This is the default in install-supervisor.yaml.
+  # Assuming that this is the namespace where the Supervisor was installed.
+  # This is the default.
   namespace: pinniped-supervisor
 spec:
   type: LoadBalancer
   selector:
-    # Assuming that this is how the supervisor pods are labeled. This is the default in install-supervisor.yaml.
+    # Assuming that this is how the Supervisor Pods are labeled.
+    # This is the default.
     app: pinniped-supervisor
   ports:
   - protocol: TCP
     port: 443
-    targetPort: 8443
+    targetPort: 8443 # 8443 is the TLS port. Do not expose port 8080.
 ```
 
-#### Example: Using a NodePort Service
+### Example: Creating a NodePort Service
 
-A NodePort Service exposes the app as a port on the nodes of the cluster.
+A NodePort Service exposes the app as a port on the nodes of the cluster. For example, a NodePort Service could also be
+used as the backend of an Ingress.
 
-This is convenient for use with kind clusters, because kind can
+This is also convenient for use with Kind clusters, because kind can
 [expose node ports as localhost ports on the host machine](https://kind.sigs.k8s.io/docs/user/configuration/#extra-port-mappings)
 without requiring an Ingress, although
-[kind also supports several Ingress Controllers](https://kind.sigs.k8s.io/docs/user/ingress).
-
-A NodePort Service could also be used behind an Ingress which is terminating TLS.
-
-For example:
+[Kind also supports several Ingress Controllers](https://kind.sigs.k8s.io/docs/user/ingress).
 
 ```yaml
 apiVersion: v1
 kind: Service
 metadata:
   name: pinniped-supervisor-nodeport
-  # Assuming that this is the namespace where the supervisor was installed. This is the default in install-supervisor.yaml.
+  # Assuming that this is the namespace where the Supervisor was installed.
+  # This is the default.
   namespace: pinniped-supervisor
 spec:
   type: NodePort
   selector:
-    # Assuming that this is how the supervisor pods are labeled. This is the default in install-supervisor.yaml.
+    # Assuming that this is how the Supervisor Pods are labeled.
+    # This is the default.
     app: pinniped-supervisor
   ports:
   - protocol: TCP
-    port: 80
-    targetPort: 8080
-    nodePort: 31234 # This is the port that you would forward to the kind host. Or omit this key for a random port.
+    port: 443
+    targetPort: 8443
+    # This is the port that you would forward to the kind host.
+    # Or omit this key for a random port on the node.
+    nodePort: 31234
 ```
 
-### Configuring the Supervisor to act as an OIDC provider
+## Configuring the Supervisor to act as an OIDC provider
 
 The Supervisor can be configured as an OIDC provider by creating FederationDomain resources
-in the same namespace where the Supervisor app was installed. For example:
+in the same namespace where the Supervisor app was installed. At least one FederationDomain must be configured
+for the Supervisor to provide its functionality.
+
+Here is an example of a FederationDomain.
 
 ```yaml
 apiVersion: config.supervisor.pinniped.dev/v1alpha1
 kind: FederationDomain
 metadata:
   name: my-provider
-  # Assuming that this is the namespace where the supervisor was installed. This is the default in install-supervisor.yaml.
+  # Assuming that this is the namespace where the supervisor was installed.
+  # This is the default.
   namespace: pinniped-supervisor
 spec:
-  # The hostname would typically match the DNS name of the public ingress or load balancer for the cluster.
-  # Any path can be specified, which allows a single hostname to have multiple different issuers. The path is optional.
+  # The hostname would typically match the DNS name of the public ingress
+  # or load balancer for the cluster.
+  # Any path can be specified, which allows a single hostname to have
+  # multiple different issuers. The path is optional.
   issuer: https://my-issuer.example.com/any/path
-
-  # Optionally configure the name of a Secret in the same namespace, of type `kubernetes.io/tls`,
-  # which contains the TLS serving certificate for the HTTPS endpoints served by this OIDC Provider.
+  # Optionally configure the name of a Secret in the same namespace,
+  # of type `kubernetes.io/tls`, which contains the TLS serving certificate
+  # for the HTTPS endpoints served by this OIDC Provider.
   tls:
     secretName: my-tls-cert-secret
 ```
@@ -134,38 +189,41 @@ spec:
 You can create multiple FederationDomains as long as each has a unique issuer string.
 Each FederationDomain can be used to provide access to a set of Kubernetes clusters for a set of user identities.
 
-#### Configuring TLS for the Supervisor OIDC endpoints
+### Configuring TLS for the Supervisor OIDC endpoints
 
-If you have terminated TLS outside the app, for example using an Ingress with TLS certificates, then you do not need to
-configure TLS certificates on the FederationDomain.
+If you have terminated TLS outside the app, for example using service mesh which handles encrypting the traffic for you,
+then you do not need to configure TLS certificates on the FederationDomain.  Otherwise, you need to configure the
+Supervisor app to terminate TLS.
 
-If you are using a LoadBalancer Service to expose the Supervisor app outside your cluster, then you
-also need to configure the Supervisor app to terminate TLS. There are two places to configure TLS certificates:
+There are two places to optionally configure TLS certificates:
 
-1. Each `FederationDomain` can be configured with TLS certificates, using the `spec.tls.secretName` field.
+1. Each FederationDomain can be configured with TLS certificates, using the `spec.tls.secretName` field.
 
-1. The default TLS certificate for all OIDC providers can be configured by creating a Secret called
+1. The default TLS certificate for all FederationDomains can be configured by creating a Secret called
 `pinniped-supervisor-default-tls-certificate` in the same namespace in which the Supervisor was installed.
 
-The default TLS certificate are used for all OIDC providers which did not declare a `spec.tls.secretName`.
-Also, the `spec.tls.secretName` is ignored for incoming requests to the OIDC endpoints
-that use an IP address as the host, so those requests always present the default TLS certificates
-to the client. When the request includes the hostname, and that hostname matches the hostname of an `Issuer`,
-then the TLS certificate defined by the `spec.tls.secretName` is used. If that issuer did not
-define `spec.tls.secretName` then the default TLS certificate is used. If neither exists,
-then the client gets a TLS error because the server does not present any TLS certificate.
+Each incoming request to the endpoints of the Supervisor may use TLS certificates that were configured in either
+of the above ways. The TLS certificate to present to the client is selected dynamically for each request
+using Server Name Indication (SNI):
+- When incoming requests use SNI to specify a hostname, and that hostname matches the hostname
+  of a FederationDomain, and that FederationDomain specifies `spec.tls.secretName`, then the TLS certificate from the
+  `spec.tls.secretName` Secret will be used.
+- Any other request will use the default TLS certificate, if it is specified. This includes any request to a host
+  which is an IP address, because SNI does not work for IP addresses. If the default TLS certificate is not specified,
+  then these requests will fail.
 
 It is recommended that you have a DNS entry for your load balancer or Ingress, and that you configure the
-OIDC provider's `Issuer` using that DNS hostname, and that the TLS certificate for that provider also
+OIDC provider's `issuer` using that DNS hostname, and that the TLS certificate for that provider also
 covers that same hostname.
 
 You can create the certificate Secrets however you like, for example you could use [cert-manager](https://cert-manager.io/)
-or `kubectl create secret tls`.
-Keep in mind that your users must load some of these endpoints in their web browsers, so the TLS certificates
+or `kubectl create secret tls`. They must be Secrets of type `kubernetes.io/tls`.
+Keep in mind that your end users must load some of these endpoints in their web browsers, so the TLS certificates
 should be signed by a certificate authority that is trusted by their browsers.
 
 ## Next steps
 
-Next, configure an `OIDCIdentityProvider` or an `LDAPIdentityProvider` for the Supervisor (several examples are available in these guides),
+Next, configure an OIDCIdentityProvider, ActiveDirectoryIdentityProvider, or an LDAPIdentityProvider for the Supervisor
+(several examples are available in these guides),
 and [configure the Concierge to use the Supervisor for authentication]({{< ref "configure-concierge-supervisor-jwt" >}})
 on each cluster!

--- a/site/content/docs/howto/install-supervisor.md
+++ b/site/content/docs/howto/install-supervisor.md
@@ -9,12 +9,21 @@ menu:
     weight: 60
     parent: howtos
 ---
+
 This guide shows you how to install the Pinniped Supervisor, which allows seamless login across one or many Kubernetes clusters.
-You should have a supported Kubernetes cluster with working HTTPS ingress capabilities.
-<!-- TODO: link to support matrix -->
 
 In the examples below, you can replace *{{< latestversion >}}* with your preferred version number.
 You can find a list of Pinniped releases [on GitHub](https://github.com/vmware-tanzu/pinniped/releases).
+
+## Prerequisites
+
+You should have a Kubernetes cluster with working HTTPS ingress or load balancer capabilities. Unlike the Concierge app, which can
+only run on [supported Kubernetes cluster types]({{< ref "supported-clusters" >}}), the Supervisor app can run on almost any Kubernetes cluster.
+
+The Supervisor app controls authentication to Kubernetes clusters, so access to its settings and internals should be protected carefully.
+Typically, the Supervisor is installed on a secure Kubernetes cluster which is only accessible by administrators,
+separate from the clusters for which it is providing authentication services which are accessible by application
+developers or devops teams.
 
 ## With default options
 


### PR DESCRIPTION
- Support IPv4, IPv6, both IPv4 and IPv6 at the same time, UNIX domain sockets, binding to all addresses, binding to localhost only, and anything else that Go supports by basically allowing the user to configure Go directly.
- Also allow not binding the HTTP port at all.
- Require binding the HTTPS port since it never hurts to listen on it even if it were to be unused in some complex configuration.
- Changing the setting does not automatically update the Deployment health/readiness checks to keep them working, nor does it automatically update the Service port numbers.
- The old default behavior is unchanged, for now. HTTP binds to all addresses, both IPv4 and IPv6, on port 8080. HTTPS binds to all address, both IPv4 and IPv6, on port 8443.

**Release note**:

```release-note
Added Supervisor HTTP/HTTPS port listener configuration options as ytt values.
See new options `container_http_listener` and `container_https_listener` in deploy/supervisor/values.yml for details.
Also updated docs on pinniped.dev site to better explain how to use the Supervisor's HTTP and HTTPS ports.
```
