### PR TITLE
Attempt to fix a unit test that always failed on my laptop

### DIFF
--- a/internal/kubeclient/kubeclient_test.go
+++ b/internal/kubeclient/kubeclient_test.go
@@ -979,6 +979,9 @@ func TestUnwrap(t *testing.T) {
 		gcpClient := makeClient(t, restConfig, func(config *rest.Config) {
 			config.AuthProvider = &clientcmdapi.AuthProviderConfig{
 				Name: "gcp",
+				Config: map[string]string{
+					"cmd-path": `echo {"access_token":"fake","token_expiry":"2200-01-02T15:04:05.999999999Z07:00"}`,
+				},
 			}
 		})
 


### PR DESCRIPTION
Try to make the GCP plugin config less sensitive to the setup of the computer on which it runs.

**Release note**:

```release-note
NONE
```
