### PR TITLE
pinniped CLI: allow all forms of http redirects

### DIFF
--- a/internal/controller/supervisorconfig/activedirectoryupstreamwatcher/active_directory_upstream_watcher_test.go
+++ b/internal/controller/supervisorconfig/activedirectoryupstreamwatcher/active_directory_upstream_watcher_test.go
@@ -220,11 +220,11 @@ func TestActiveDirectoryUpstreamWatcherControllerSync(t *testing.T) {
 			Filter:             testGroupSearchFilter,
 			GroupNameAttribute: testGroupNameAttrName,
 		},
-		UIDAttributeParsingOverrides: map[string]func(*ldap.Entry) (string, error){"objectGUID": MicrosoftUUIDFromBinary("objectGUID")},
+		UIDAttributeParsingOverrides: map[string]func(*ldap.Entry) (string, error){"objectGUID": microsoftUUIDFromBinaryAttr("objectGUID")},
 		RefreshAttributeChecks: map[string]func(*ldap.Entry, provider.StoredRefreshAttributes) error{
 			"pwdLastSet":                         upstreamldap.AttributeUnchangedSinceLogin("pwdLastSet"),
-			"userAccountControl":                 ValidUserAccountControl,
-			"msDS-User-Account-Control-Computed": ValidComputedUserAccountControl,
+			"userAccountControl":                 validUserAccountControl,
+			"msDS-User-Account-Control-Computed": validComputedUserAccountControl,
 		},
 	}
 
@@ -541,11 +541,11 @@ func TestActiveDirectoryUpstreamWatcherControllerSync(t *testing.T) {
 						Filter:             testGroupSearchFilter,
 						GroupNameAttribute: testGroupNameAttrName,
 					},
-					UIDAttributeParsingOverrides: map[string]func(*ldap.Entry) (string, error){"objectGUID": MicrosoftUUIDFromBinary("objectGUID")},
+					UIDAttributeParsingOverrides: map[string]func(*ldap.Entry) (string, error){"objectGUID": microsoftUUIDFromBinaryAttr("objectGUID")},
 					RefreshAttributeChecks: map[string]func(*ldap.Entry, provider.StoredRefreshAttributes) error{
 						"pwdLastSet":                         upstreamldap.AttributeUnchangedSinceLogin("pwdLastSet"),
-						"userAccountControl":                 ValidUserAccountControl,
-						"msDS-User-Account-Control-Computed": ValidComputedUserAccountControl,
+						"userAccountControl":                 validUserAccountControl,
+						"msDS-User-Account-Control-Computed": validComputedUserAccountControl,
 					},
 				},
 			},
@@ -602,11 +602,11 @@ func TestActiveDirectoryUpstreamWatcherControllerSync(t *testing.T) {
 						Filter:             testGroupSearchFilter,
 						GroupNameAttribute: "sAMAccountName",
 					},
-					UIDAttributeParsingOverrides: map[string]func(*ldap.Entry) (string, error){"objectGUID": MicrosoftUUIDFromBinary("objectGUID")},
+					UIDAttributeParsingOverrides: map[string]func(*ldap.Entry) (string, error){"objectGUID": microsoftUUIDFromBinaryAttr("objectGUID")},
 					RefreshAttributeChecks: map[string]func(*ldap.Entry, provider.StoredRefreshAttributes) error{
 						"pwdLastSet":                         upstreamldap.AttributeUnchangedSinceLogin("pwdLastSet"),
-						"userAccountControl":                 ValidUserAccountControl,
-						"msDS-User-Account-Control-Computed": ValidComputedUserAccountControl,
+						"userAccountControl":                 validUserAccountControl,
+						"msDS-User-Account-Control-Computed": validComputedUserAccountControl,
 					},
 				},
 			},
@@ -666,11 +666,11 @@ func TestActiveDirectoryUpstreamWatcherControllerSync(t *testing.T) {
 						Filter:             testGroupSearchFilter,
 						GroupNameAttribute: testGroupNameAttrName,
 					},
-					UIDAttributeParsingOverrides: map[string]func(*ldap.Entry) (string, error){"objectGUID": MicrosoftUUIDFromBinary("objectGUID")},
+					UIDAttributeParsingOverrides: map[string]func(*ldap.Entry) (string, error){"objectGUID": microsoftUUIDFromBinaryAttr("objectGUID")},
 					RefreshAttributeChecks: map[string]func(*ldap.Entry, provider.StoredRefreshAttributes) error{
 						"pwdLastSet":                         upstreamldap.AttributeUnchangedSinceLogin("pwdLastSet"),
-						"userAccountControl":                 ValidUserAccountControl,
-						"msDS-User-Account-Control-Computed": ValidComputedUserAccountControl,
+						"userAccountControl":                 validUserAccountControl,
+						"msDS-User-Account-Control-Computed": validComputedUserAccountControl,
 					},
 				},
 			},
@@ -730,11 +730,11 @@ func TestActiveDirectoryUpstreamWatcherControllerSync(t *testing.T) {
 						Filter:             testGroupSearchFilter,
 						GroupNameAttribute: testGroupNameAttrName,
 					},
-					UIDAttributeParsingOverrides: map[string]func(*ldap.Entry) (string, error){"objectGUID": MicrosoftUUIDFromBinary("objectGUID")},
+					UIDAttributeParsingOverrides: map[string]func(*ldap.Entry) (string, error){"objectGUID": microsoftUUIDFromBinaryAttr("objectGUID")},
 					RefreshAttributeChecks: map[string]func(*ldap.Entry, provider.StoredRefreshAttributes) error{
 						"pwdLastSet":                         upstreamldap.AttributeUnchangedSinceLogin("pwdLastSet"),
-						"userAccountControl":                 ValidUserAccountControl,
-						"msDS-User-Account-Control-Computed": ValidComputedUserAccountControl,
+						"userAccountControl":                 validUserAccountControl,
+						"msDS-User-Account-Control-Computed": validComputedUserAccountControl,
 					},
 				},
 			},
@@ -793,11 +793,11 @@ func TestActiveDirectoryUpstreamWatcherControllerSync(t *testing.T) {
 						Filter:             testGroupSearchFilter,
 						GroupNameAttribute: testGroupNameAttrName,
 					},
-					UIDAttributeParsingOverrides: map[string]func(*ldap.Entry) (string, error){"objectGUID": MicrosoftUUIDFromBinary("objectGUID")},
+					UIDAttributeParsingOverrides: map[string]func(*ldap.Entry) (string, error){"objectGUID": microsoftUUIDFromBinaryAttr("objectGUID")},
 					RefreshAttributeChecks: map[string]func(*ldap.Entry, provider.StoredRefreshAttributes) error{
 						"pwdLastSet":                         upstreamldap.AttributeUnchangedSinceLogin("pwdLastSet"),
-						"userAccountControl":                 ValidUserAccountControl,
-						"msDS-User-Account-Control-Computed": ValidComputedUserAccountControl,
+						"userAccountControl":                 validUserAccountControl,
+						"msDS-User-Account-Control-Computed": validComputedUserAccountControl,
 					},
 				},
 			},
@@ -927,11 +927,11 @@ func TestActiveDirectoryUpstreamWatcherControllerSync(t *testing.T) {
 						Filter:             testGroupSearchFilter,
 						GroupNameAttribute: testGroupNameAttrName,
 					},
-					UIDAttributeParsingOverrides: map[string]func(*ldap.Entry) (string, error){"objectGUID": MicrosoftUUIDFromBinary("objectGUID")},
+					UIDAttributeParsingOverrides: map[string]func(*ldap.Entry) (string, error){"objectGUID": microsoftUUIDFromBinaryAttr("objectGUID")},
 					RefreshAttributeChecks: map[string]func(*ldap.Entry, provider.StoredRefreshAttributes) error{
 						"pwdLastSet":                         upstreamldap.AttributeUnchangedSinceLogin("pwdLastSet"),
-						"userAccountControl":                 ValidUserAccountControl,
-						"msDS-User-Account-Control-Computed": ValidComputedUserAccountControl,
+						"userAccountControl":                 validUserAccountControl,
+						"msDS-User-Account-Control-Computed": validComputedUserAccountControl,
 					},
 				},
 			},
@@ -1056,11 +1056,11 @@ func TestActiveDirectoryUpstreamWatcherControllerSync(t *testing.T) {
 						Filter:             testGroupSearchFilter,
 						GroupNameAttribute: testGroupNameAttrName,
 					},
-					UIDAttributeParsingOverrides: map[string]func(*ldap.Entry) (string, error){"objectGUID": MicrosoftUUIDFromBinary("objectGUID")},
+					UIDAttributeParsingOverrides: map[string]func(*ldap.Entry) (string, error){"objectGUID": microsoftUUIDFromBinaryAttr("objectGUID")},
 					RefreshAttributeChecks: map[string]func(*ldap.Entry, provider.StoredRefreshAttributes) error{
 						"pwdLastSet":                         upstreamldap.AttributeUnchangedSinceLogin("pwdLastSet"),
-						"userAccountControl":                 ValidUserAccountControl,
-						"msDS-User-Account-Control-Computed": ValidComputedUserAccountControl,
+						"userAccountControl":                 validUserAccountControl,
+						"msDS-User-Account-Control-Computed": validComputedUserAccountControl,
 					}},
 			},
 			wantResultingUpstreams: []v1alpha1.ActiveDirectoryIdentityProvider{{
@@ -1111,11 +1111,11 @@ func TestActiveDirectoryUpstreamWatcherControllerSync(t *testing.T) {
 						Filter:             testGroupSearchFilter,
 						GroupNameAttribute: testGroupNameAttrName,
 					},
-					UIDAttributeParsingOverrides: map[string]func(*ldap.Entry) (string, error){"objectGUID": MicrosoftUUIDFromBinary("objectGUID")},
+					UIDAttributeParsingOverrides: map[string]func(*ldap.Entry) (string, error){"objectGUID": microsoftUUIDFromBinaryAttr("objectGUID")},
 					RefreshAttributeChecks: map[string]func(*ldap.Entry, provider.StoredRefreshAttributes) error{
 						"pwdLastSet":                         upstreamldap.AttributeUnchangedSinceLogin("pwdLastSet"),
-						"userAccountControl":                 ValidUserAccountControl,
-						"msDS-User-Account-Control-Computed": ValidComputedUserAccountControl,
+						"userAccountControl":                 validUserAccountControl,
+						"msDS-User-Account-Control-Computed": validComputedUserAccountControl,
 					},
 				},
 			},
@@ -1315,12 +1315,12 @@ func TestActiveDirectoryUpstreamWatcherControllerSync(t *testing.T) {
 						Filter:             "(&(objectClass=group)(member:1.2.840.113556.1.4.1941:={}))",
 						GroupNameAttribute: "sAMAccountName",
 					},
-					UIDAttributeParsingOverrides:   map[string]func(*ldap.Entry) (string, error){"objectGUID": MicrosoftUUIDFromBinary("objectGUID")},
-					GroupAttributeParsingOverrides: map[string]func(*ldap.Entry) (string, error){"sAMAccountName": GroupSAMAccountNameWithDomainSuffix},
+					UIDAttributeParsingOverrides:   map[string]func(*ldap.Entry) (string, error){"objectGUID": microsoftUUIDFromBinaryAttr("objectGUID")},
+					GroupAttributeParsingOverrides: map[string]func(*ldap.Entry) (string, error){"sAMAccountName": groupSAMAccountNameWithDomainSuffix},
 					RefreshAttributeChecks: map[string]func(*ldap.Entry, provider.StoredRefreshAttributes) error{
 						"pwdLastSet":                         upstreamldap.AttributeUnchangedSinceLogin("pwdLastSet"),
-						"userAccountControl":                 ValidUserAccountControl,
-						"msDS-User-Account-Control-Computed": ValidComputedUserAccountControl,
+						"userAccountControl":                 validUserAccountControl,
+						"msDS-User-Account-Control-Computed": validComputedUserAccountControl,
 					},
 				},
 			},
@@ -1373,11 +1373,11 @@ func TestActiveDirectoryUpstreamWatcherControllerSync(t *testing.T) {
 						Filter:             testGroupSearchFilter,
 						GroupNameAttribute: testGroupNameAttrName,
 					},
-					UIDAttributeParsingOverrides: map[string]func(*ldap.Entry) (string, error){"objectGUID": MicrosoftUUIDFromBinary("objectGUID")},
+					UIDAttributeParsingOverrides: map[string]func(*ldap.Entry) (string, error){"objectGUID": microsoftUUIDFromBinaryAttr("objectGUID")},
 					RefreshAttributeChecks: map[string]func(*ldap.Entry, provider.StoredRefreshAttributes) error{
 						"pwdLastSet":                         upstreamldap.AttributeUnchangedSinceLogin("pwdLastSet"),
-						"userAccountControl":                 ValidUserAccountControl,
-						"msDS-User-Account-Control-Computed": ValidComputedUserAccountControl,
+						"userAccountControl":                 validUserAccountControl,
+						"msDS-User-Account-Control-Computed": validComputedUserAccountControl,
 					},
 				},
 			},
@@ -1434,11 +1434,11 @@ func TestActiveDirectoryUpstreamWatcherControllerSync(t *testing.T) {
 						Filter:             testGroupSearchFilter,
 						GroupNameAttribute: testGroupNameAttrName,
 					},
-					UIDAttributeParsingOverrides: map[string]func(*ldap.Entry) (string, error){"objectGUID": MicrosoftUUIDFromBinary("objectGUID")},
+					UIDAttributeParsingOverrides: map[string]func(*ldap.Entry) (string, error){"objectGUID": microsoftUUIDFromBinaryAttr("objectGUID")},
 					RefreshAttributeChecks: map[string]func(*ldap.Entry, provider.StoredRefreshAttributes) error{
 						"pwdLastSet":                         upstreamldap.AttributeUnchangedSinceLogin("pwdLastSet"),
-						"userAccountControl":                 ValidUserAccountControl,
-						"msDS-User-Account-Control-Computed": ValidComputedUserAccountControl,
+						"userAccountControl":                 validUserAccountControl,
+						"msDS-User-Account-Control-Computed": validComputedUserAccountControl,
 					},
 				},
 			},
@@ -1489,11 +1489,11 @@ func TestActiveDirectoryUpstreamWatcherControllerSync(t *testing.T) {
 						Filter:             testGroupSearchFilter,
 						GroupNameAttribute: testGroupNameAttrName,
 					},
-					UIDAttributeParsingOverrides: map[string]func(*ldap.Entry) (string, error){"objectGUID": MicrosoftUUIDFromBinary("objectGUID")},
+					UIDAttributeParsingOverrides: map[string]func(*ldap.Entry) (string, error){"objectGUID": microsoftUUIDFromBinaryAttr("objectGUID")},
 					RefreshAttributeChecks: map[string]func(*ldap.Entry, provider.StoredRefreshAttributes) error{
 						"pwdLastSet":                         upstreamldap.AttributeUnchangedSinceLogin("pwdLastSet"),
-						"userAccountControl":                 ValidUserAccountControl,
-						"msDS-User-Account-Control-Computed": ValidComputedUserAccountControl,
+						"userAccountControl":                 validUserAccountControl,
+						"msDS-User-Account-Control-Computed": validComputedUserAccountControl,
 					},
 				},
 			},
@@ -1690,11 +1690,11 @@ func TestActiveDirectoryUpstreamWatcherControllerSync(t *testing.T) {
 						Filter:             testGroupSearchFilter,
 						GroupNameAttribute: testGroupNameAttrName,
 					},
-					UIDAttributeParsingOverrides: map[string]func(*ldap.Entry) (string, error){"objectGUID": MicrosoftUUIDFromBinary("objectGUID")},
+					UIDAttributeParsingOverrides: map[string]func(*ldap.Entry) (string, error){"objectGUID": microsoftUUIDFromBinaryAttr("objectGUID")},
 					RefreshAttributeChecks: map[string]func(*ldap.Entry, provider.StoredRefreshAttributes) error{
 						"pwdLastSet":                         upstreamldap.AttributeUnchangedSinceLogin("pwdLastSet"),
-						"userAccountControl":                 ValidUserAccountControl,
-						"msDS-User-Account-Control-Computed": ValidComputedUserAccountControl,
+						"userAccountControl":                 validUserAccountControl,
+						"msDS-User-Account-Control-Computed": validComputedUserAccountControl,
 					},
 				},
 			},
@@ -1931,7 +1931,7 @@ func TestGroupSAMAccountNameWithDomainSuffix(t *testing.T) {
 	for _, test := range tests {
 		tt := test
 		t.Run(tt.name, func(t *testing.T) {
-			suffixedSAMAccountName, err := GroupSAMAccountNameWithDomainSuffix(tt.entry)
+			suffixedSAMAccountName, err := groupSAMAccountNameWithDomainSuffix(tt.entry)
 			if tt.wantErr != "" {
 				require.EqualError(t, err, tt.wantErr)
 			} else {
@@ -2074,7 +2074,7 @@ func TestValidUserAccountControl(t *testing.T) {
 	for _, test := range tests {
 		tt := test
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidUserAccountControl(tt.entry, provider.StoredRefreshAttributes{})
+			err := validUserAccountControl(tt.entry, provider.StoredRefreshAttributes{})
 
 			if tt.wantErr != "" {
 				require.Error(t, err)
@@ -2135,7 +2135,7 @@ func TestValidComputedUserAccountControl(t *testing.T) {
 	for _, test := range tests {
 		tt := test
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidComputedUserAccountControl(tt.entry, provider.StoredRefreshAttributes{})
+			err := validComputedUserAccountControl(tt.entry, provider.StoredRefreshAttributes{})
 
 			if tt.wantErr != "" {
 				require.Error(t, err)

--- a/internal/kubeclient/kubeclient_test.go
+++ b/internal/kubeclient/kubeclient_test.go
@@ -19,6 +19,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/net"
 	clientauthenticationv1 "k8s.io/client-go/pkg/apis/clientauthentication/v1"
 	"k8s.io/client-go/rest"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -1109,7 +1110,7 @@ func testUnwrap(t *testing.T, client *Client, serverSubjects [][]byte) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel() // make sure to run in parallel to confirm that our client-go TLS cache busting works (i.e. assert no data races)
 
-			tlsConfig, err := netTLSClientConfig(tt.rt)
+			tlsConfig, err := net.TLSClientConfig(tt.rt)
 			require.NoError(t, err)
 			require.NotNil(t, tlsConfig)
 

--- a/internal/oidc/callback/callback_handler_test.go
+++ b/internal/oidc/callback/callback_handler_test.go
@@ -174,7 +174,7 @@ func TestCallbackEndpoint(t *testing.T) {
 			},
 		},
 		{
-			name:                              "GET with good state and cookie and successful upstream token exchange returns 302 to downstream client callback with its state and code",
+			name:                              "GET with good state and cookie and successful upstream token exchange returns 303 to downstream client callback with its state and code",
 			idps:                              oidctestutil.NewUpstreamIDPListerBuilder().WithOIDC(happyUpstream().Build()),
 			method:                            http.MethodGet,
 			path:                              newRequestPath().WithState(happyState).String(),

--- a/internal/oidc/provider/dynamic_upstream_idp_provider.go
+++ b/internal/oidc/provider/dynamic_upstream_idp_provider.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"net/url"
 	"sync"
-	"time"
 
 	"golang.org/x/oauth2"
 	"k8s.io/apimachinery/pkg/types"
@@ -101,7 +100,6 @@ type StoredRefreshAttributes struct {
 	Username             string
 	Subject              string
 	DN                   string
-	AuthTime             time.Time
 	AdditionalAttributes map[string]string
 }
 

--- a/internal/upstreamldap/upstreamldap_test.go
+++ b/internal/upstreamldap/upstreamldap_test.go
@@ -254,7 +254,7 @@ func TestEndUserAuthentication(t *testing.T) {
 			},
 			wantAuthResponse: expectedAuthResponse(func(r *authenticators.Response) {
 				info := r.User.(*user.DefaultInfo)
-				info.Groups = []string{}
+				info.Groups = nil
 			}),
 		},
 		{
@@ -1410,8 +1410,8 @@ func TestUpstreamRefresh(t *testing.T) {
 									ByteValues: [][]byte{[]byte(testUserSearchResultUIDAttributeValue)},
 								},
 								{
-									Name:   pwdLastSetAttribute,
-									Values: []string{"132801740800000001"},
+									Name:       pwdLastSetAttribute,
+									ByteValues: [][]byte{[]byte("132801740800000001")},
 								},
 							},
 						},
@@ -1812,8 +1812,8 @@ func TestAttributeUnchangedSinceLogin(t *testing.T) {
 				DN: "some-dn",
 				Attributes: []*ldap.EntryAttribute{
 					{
-						Name:   attributeName,
-						Values: []string{"val1", "val2"},
+						Name:       attributeName,
+						ByteValues: [][]byte{[]byte("val1"), []byte("val2")},
 					},
 				},
 			},

--- a/pkg/oidcclient/login_test.go
+++ b/pkg/oidcclient/login_test.go
@@ -900,7 +900,7 @@ func TestLogin(t *testing.T) { // nolint:gocyclo
 				`/authorize?access_type=offline&client_id=test-client-id&code_challenge=VVaezYqum7reIhoavCHD1n2d-piN3r_mywoYj7fCR7g&code_challenge_method=S256&nonce=test-nonce&pinniped_idp_name=some-upstream-name&pinniped_idp_type=ldap&redirect_uri=http%3A%2F%2F127.0.0.1%3A0%2Fcallback&response_type=code&scope=test-scope&state=test-state": some error fetching authorize endpoint`,
 		},
 		{
-			name:     "ldap login when the OIDC provider authorization endpoint returns something other than a 302 redirect",
+			name:     "ldap login when the OIDC provider authorization endpoint returns something other than a redirect",
 			clientID: "test-client-id",
 			opt: func(t *testing.T) Option {
 				return func(h *handlerState) error {
@@ -1193,6 +1193,117 @@ func TestLogin(t *testing.T) { // nolint:gocyclo
 								}, req.URL.Query())
 								return &http.Response{
 									StatusCode: http.StatusFound,
+									Header: http.Header{"Location": []string{
+										fmt.Sprintf("http://127.0.0.1:0/callback?code=%s&state=test-state", fakeAuthCode),
+									}},
+								}, nil
+							default:
+								// Note that "/token" requests should not be made. They are mocked by mocking calls to ExchangeAuthcodeAndValidateTokens().
+								require.FailNow(t, fmt.Sprintf("saw unexpected http call from the CLI: %s", req.URL.String()))
+								return nil, nil
+							}
+						}),
+					})(h))
+					return nil
+				}
+			},
+			issuer: successServer.URL,
+			wantLogs: []string{
+				"\"level\"=4 \"msg\"=\"Pinniped: Performing OIDC discovery\"  \"issuer\"=\"" + successServer.URL + "\"",
+				"\"level\"=4 \"msg\"=\"Pinniped: Read username from environment variable\"  \"name\"=\"PINNIPED_USERNAME\"",
+				"\"level\"=4 \"msg\"=\"Pinniped: Read password from environment variable\"  \"name\"=\"PINNIPED_PASSWORD\"",
+			},
+			wantToken: &testToken,
+		},
+		{
+			name:     "successful ldap login with env vars for username and password, http.StatusSeeOther redirect",
+			clientID: "test-client-id",
+			opt: func(t *testing.T) Option {
+				return func(h *handlerState) error {
+					fakeAuthCode := "test-authcode-value"
+
+					h.getProvider = func(_ *oauth2.Config, _ *oidc.Provider, _ *http.Client) provider.UpstreamOIDCIdentityProviderI {
+						mock := mockUpstream(t)
+						mock.EXPECT().
+							ExchangeAuthcodeAndValidateTokens(
+								gomock.Any(), fakeAuthCode, pkce.Code("test-pkce"), nonce.Nonce("test-nonce"), "http://127.0.0.1:0/callback").
+							Return(&testToken, nil)
+						return mock
+					}
+
+					h.generateState = func() (state.State, error) { return "test-state", nil }
+					h.generatePKCE = func() (pkce.Code, error) { return "test-pkce", nil }
+					h.generateNonce = func() (nonce.Nonce, error) { return "test-nonce", nil }
+					h.getEnv = func(key string) string {
+						switch key {
+						case "PINNIPED_USERNAME":
+							return "some-upstream-username"
+						case "PINNIPED_PASSWORD":
+							return "some-upstream-password"
+						default:
+							return "" // all other env vars are treated as if they are unset
+						}
+					}
+					h.promptForValue = func(_ context.Context, promptLabel string) (string, error) {
+						require.FailNow(t, fmt.Sprintf("saw unexpected prompt from the CLI: %q", promptLabel))
+						return "", nil
+					}
+					h.promptForSecret = func(promptLabel string) (string, error) {
+						require.FailNow(t, fmt.Sprintf("saw unexpected prompt from the CLI: %q", promptLabel))
+						return "", nil
+					}
+
+					cache := &mockSessionCache{t: t, getReturnsToken: nil}
+					cacheKey := SessionCacheKey{
+						Issuer:      successServer.URL,
+						ClientID:    "test-client-id",
+						Scopes:      []string{"test-scope"},
+						RedirectURI: "http://localhost:0/callback",
+					}
+					t.Cleanup(func() {
+						require.Equal(t, []SessionCacheKey{cacheKey}, cache.sawGetKeys)
+						require.Equal(t, []SessionCacheKey{cacheKey}, cache.sawPutKeys)
+						require.Equal(t, []*oidctypes.Token{&testToken}, cache.sawPutTokens)
+					})
+					require.NoError(t, WithSessionCache(cache)(h))
+					require.NoError(t, WithCLISendingCredentials()(h))
+					require.NoError(t, WithUpstreamIdentityProvider("some-upstream-name", "ldap")(h))
+
+					discoveryRequestWasMade := false
+					authorizeRequestWasMade := false
+					t.Cleanup(func() {
+						require.True(t, discoveryRequestWasMade, "should have made an discovery request")
+						require.True(t, authorizeRequestWasMade, "should have made an authorize request")
+					})
+
+					require.NoError(t, WithClient(&http.Client{
+						Transport: roundtripper.Func(func(req *http.Request) (*http.Response, error) {
+							switch req.URL.Scheme + "://" + req.URL.Host + req.URL.Path {
+							case "http://" + successServer.Listener.Addr().String() + "/.well-known/openid-configuration":
+								discoveryRequestWasMade = true
+								return defaultDiscoveryResponse(req)
+							case "http://" + successServer.Listener.Addr().String() + "/authorize":
+								authorizeRequestWasMade = true
+								require.Equal(t, "some-upstream-username", req.Header.Get("Pinniped-Username"))
+								require.Equal(t, "some-upstream-password", req.Header.Get("Pinniped-Password"))
+								require.Equal(t, url.Values{
+									// This is the PKCE challenge which is calculated as base64(sha256("test-pkce")). For example:
+									// $ echo -n test-pkce | shasum -a 256 | cut -d" " -f1 | xxd -r -p | base64 | cut -d"=" -f1
+									// VVaezYqum7reIhoavCHD1n2d+piN3r/mywoYj7fCR7g
+									"code_challenge":        []string{"VVaezYqum7reIhoavCHD1n2d-piN3r_mywoYj7fCR7g"},
+									"code_challenge_method": []string{"S256"},
+									"response_type":         []string{"code"},
+									"scope":                 []string{"test-scope"},
+									"nonce":                 []string{"test-nonce"},
+									"state":                 []string{"test-state"},
+									"access_type":           []string{"offline"},
+									"client_id":             []string{"test-client-id"},
+									"redirect_uri":          []string{"http://127.0.0.1:0/callback"},
+									"pinniped_idp_name":     []string{"some-upstream-name"},
+									"pinniped_idp_type":     []string{"ldap"},
+								}, req.URL.Query())
+								return &http.Response{
+									StatusCode: http.StatusSeeOther,
 									Header: http.Header{"Location": []string{
 										fmt.Sprintf("http://127.0.0.1:0/callback?code=%s&state=test-state", fakeAuthCode),
 									}},

--- a/test/integration/ldap_client_test.go
+++ b/test/integration/ldap_client_test.go
@@ -244,7 +244,7 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 				p.GroupSearch.Base = ""
 			})),
 			wantAuthResponse: &authenticators.Response{
-				User:                   &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{}},
+				User:                   &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: nil},
 				DN:                     "cn=pinny,ou=users,dc=pinniped,dc=dev",
 				ExtraRefreshAttributes: map[string]string{},
 			},
@@ -257,7 +257,7 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 				p.GroupSearch.Base = "ou=users,dc=pinniped,dc=dev" // there are no groups under this part of the tree
 			})),
 			wantAuthResponse: &authenticators.Response{
-				User:                   &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{}},
+				User:                   &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: nil},
 				DN:                     "cn=pinny,ou=users,dc=pinniped,dc=dev",
 				ExtraRefreshAttributes: map[string]string{},
 			},
@@ -328,7 +328,7 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 				p.GroupSearch.Filter = "foobar={}" // foobar is not a valid attribute name for this LDAP server's schema
 			})),
 			wantAuthResponse: &authenticators.Response{
-				User:                   &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{}},
+				User:                   &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: nil},
 				DN:                     "cn=pinny,ou=users,dc=pinniped,dc=dev",
 				ExtraRefreshAttributes: map[string]string{},
 			},


### PR DESCRIPTION
pinniped CLI: allow all forms of http redirects

For password based login on the CLI (i.e. no browser), this change
relaxes the response code check to allow for any redirect code
handled by the Go standard library.  In the future, we can drop the
rewriteStatusSeeOtherToStatusFoundForBrowserless logic from the
server side code.

Signed-off-by: Monis Khan <mok@vmware.com>

Follow-up to #914:

```
Use github.com/felixge/httpsnoop to undo the changes made by
ory/fosite#636 for CLI based login flows. This is required for
backwards compatibility with older versions of our CLI. A
separate change after this will update the CLI to be more
flexible (it is purposefully not part of this change to confirm
that we did not break anything). For all browser login flows, we
now redirect using http.StatusSeeOther instead of http.StatusFound.
```

I have confirmed that adf04d29f77fe54fa7bc3c7f9cf11f258303c13a passes all CI pipelines with no updates required to any integration test.

---

Drop unsafe unwrapper for exec.roundTripper

exec.roundTripper now implements utilnet.RoundTripperWrapper so this unsafe hack is no longer needed.

Signed-off-by: Monis Khan <mok@vmware.com>

Fixes #899

---

Clean up nits in AD code

- Make everything private
- Drop unused AuthTime field
- Use %q format string instead of "%s"
- Only rely on GetRawAttributeValues in AttributeUnchangedSinceLogin

Signed-off-by: Monis Khan <mok@vmware.com>

Addresses https://github.com/vmware-tanzu/pinniped/pull/884#pullrequestreview-828366300

---

**Release note**:

```release-note
NONE
```