### PR TITLE
Update group memberships during refresh for upstream OIDC providers

### DIFF
--- a/hack/module.sh
+++ b/hack/module.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+# Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -13,7 +13,7 @@ function tidy_cmd() {
 }
 
 function lint_cmd() {
-  echo "golangci-lint run --modules-download-mode=readonly --timeout=10m"
+  echo "golangci-lint run --modules-download-mode=readonly --timeout=15m"
 }
 
 function test_cmd() {

--- a/internal/oidc/downstreamsession/downstream_session.go
+++ b/internal/oidc/downstreamsession/downstream_session.go
@@ -126,7 +126,7 @@ func GetDownstreamIdentityFromUpstreamIDToken(
 		return "", "", nil, err
 	}
 
-	groups, err := getGroupsFromUpstreamIDToken(upstreamIDPConfig, idTokenClaims)
+	groups, err := GetGroupsFromUpstreamIDToken(upstreamIDPConfig, idTokenClaims)
 	if err != nil {
 		return "", "", nil, err
 	}
@@ -231,7 +231,10 @@ func downstreamSubjectFromUpstreamOIDC(upstreamIssuerAsString string, upstreamSu
 	return fmt.Sprintf("%s?%s=%s", upstreamIssuerAsString, oidc.IDTokenSubjectClaim, url.QueryEscape(upstreamSubject))
 }
 
-func getGroupsFromUpstreamIDToken(
+// GetGroupsFromUpstreamIDToken returns mapped group names coerced into a slice of strings.
+// It returns nil when there is no configured groups claim name, or then when the configured claim name is not found
+// in the provided map of claims. It returns an error when the claim exists but its value cannot be parsed.
+func GetGroupsFromUpstreamIDToken(
 	upstreamIDPConfig provider.UpstreamOIDCIdentityProviderI,
 	idTokenClaims map[string]interface{},
 ) ([]string, error) {

--- a/internal/oidc/token/token_handler.go
+++ b/internal/oidc/token/token_handler.go
@@ -169,7 +169,9 @@ func upstreamOIDCRefresh(ctx context.Context, session *psession.PinnipedSession,
 	// and let any old groups memberships in the session remain.
 	refreshedGroups, err := downstreamsession.GetGroupsFromUpstreamIDToken(p, mergedClaims)
 	if err != nil {
-		return err
+		return errorsx.WithStack(errUpstreamRefreshError.WithHintf(
+			"Upstream refresh error while extracting groups claim.").WithWrap(err).
+			WithDebugf("provider name: %q, provider type: %q", s.ProviderName, s.ProviderType))
 	}
 	if refreshedGroups != nil {
 		session.Fosite.Claims.Extra[oidc.DownstreamGroupsClaim] = refreshedGroups


### PR DESCRIPTION
Update the user's group memberships when possible. Note that we won't always have enough information to be able to update it (see code comments). Fixes #863.

**Release note**:

This is a small part of the overall upstream refresh epic.

```release-note
The Pinniped Supervisor will update the user's group memberships when they change in the upstream OIDC provider, when possible. This happens during the downstream refresh, so it will take a few minutes when a user is added/removed to/from a group in the OIDC provider before the change appears on their identity in the Kubernetes cluster.
```
