### PR TITLE
Request offline_access in the concierge with supervisor demo

### DIFF
--- a/site/content/docs/tutorials/concierge-and-supervisor-demo.md
+++ b/site/content/docs/tutorials/concierge-and-supervisor-demo.md
@@ -135,7 +135,7 @@ to authenticate federated identities from the Supervisor.
      claims:
        username: email
      authorizationConfig:
-       additionalScopes: ['email']
+       additionalScopes: ['email', 'offline_access']
      client:
        secretName: my-oidc-identity-provider-client
    EOF


### PR DESCRIPTION
It's a generic config and not OIDC provider specific
but since most providers require it it seems like the
best default.

**Release note**:

<!--
Does this PR introduce a user-facing change?

If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
-->
```release-note
NONE
```
