### PR TITLE
When instructing users how to install the concierge with kubectl apply,

### DIFF
--- a/site/content/docs/howto/install-concierge.md
+++ b/site/content/docs/howto/install-concierge.md
@@ -36,7 +36,7 @@ If you'd prefer to customize the annotations or load balancer IP address, see th
 
 1. Install the latest version of the Concierge into the `pinniped-concierge` namespace with default options:
 
-   - `kubectl apply -f https://get.pinniped.dev/{{< latestversion >}}/install-pinniped-concierge.yaml`
+   - `kubectl apply -f https://get.pinniped.dev/{{< latestversion >}}/install-pinniped-concierge-resources.yaml`
 
 ## With custom options
 

--- a/site/content/docs/tutorials/concierge-and-supervisor-demo.md
+++ b/site/content/docs/tutorials/concierge-and-supervisor-demo.md
@@ -147,13 +147,13 @@ to authenticate federated identities from the Supervisor.
    kubectl apply --context kind-pinniped-concierge \
      -f https://get.pinniped.dev/{{< latestversion >}}/install-pinniped-concierge-crds.yaml
    kubectl apply --context kind-pinniped-concierge \
-     -f https://get.pinniped.dev/{{< latestversion >}}/install-pinniped-concierge.yaml
+     -f https://get.pinniped.dev/{{< latestversion >}}/install-pinniped-concierge-resources.yaml
    ```
 
    The `install-pinniped-concierge-crds.yaml` file contains the Concierge CustomResourceDefinitions.
    These define the custom APIs that you use to configure and interact with the Concierge.
 
-   The `install-pinniped-concierge.yaml` file includes the rest of the Concierge resources with default deployment options.
+   The `install-pinniped-concierge-resources.yaml` file includes the rest of the Concierge resources with default deployment options.
    If you would prefer to customize the available options, please see the [Concierge installation guide]({{< ref "../howto/install-concierge" >}})
    for instructions on how to deploy using `ytt`.
 

--- a/site/content/docs/tutorials/concierge-only-demo.md
+++ b/site/content/docs/tutorials/concierge-only-demo.md
@@ -100,13 +100,13 @@ as the authenticator.
 
    ```sh
    kubectl apply -f https://get.pinniped.dev/{{< latestversion >}}/install-pinniped-concierge-crds.yaml
-   kubectl apply -f https://get.pinniped.dev/{{< latestversion >}}/install-pinniped-concierge.yaml
+   kubectl apply -f https://get.pinniped.dev/{{< latestversion >}}/install-pinniped-concierge-resources.yaml
    ```
 
    The `install-pinniped-concierge-crds.yaml` file contains the Concierge CustomResourceDefinitions.
    These define the custom APIs that you use to configure and interact with the Concierge.
 
-   The `install-pinniped-concierge.yaml` file includes the rest of the Concierge resources with default deployment options.
+   The `install-pinniped-concierge-resources.yaml` file includes the rest of the Concierge resources with default deployment options.
    If you would prefer to customize the available options, please see the [Concierge installation guide]({{< ref "../howto/install-concierge" >}})
    for instructions on how to deploy using `ytt`.
 


### PR DESCRIPTION
reccommend using install-pinniped-concierge-crds.yaml, then
install-pinniped-concierge-resources.yaml.

Previously we recommended install-pinniped-concierge-crds (a subset),
then install-pinniped-concierge (everything concierge related, including
the crds). This works fine for install, but not uninstall. Instead we
should use a separate yaml file that contains everything in
install-pinniped-concierge but *not* in install-pinniped-concierge-crds.

We have been generating this file in CI since a5ced4286b6febc7474b7adee34eeb1b62ec82b7
but we haven't released since then so we haven't been able to recommend
its use. 

<!--
Thank you for submitting a pull request for Pinniped!

Before submitting, please see the guidelines in CONTRIBUTING.md in this repo.

Please note that a project maintainer will need to review and provide an
initial approval on the PR to cause CI tests to automatically start.
Also note that if you push additional commits to the PR, those commits
will need another initial approval before CI will pick them up.

Reminder: Did you remember to run all the linter, unit tests, and integration tests
described in CONTRIBUTING.md on your branch before submitting this PR?

Below is a template to help you describe your PR.
-->

<!--
Provide a summary of your change. Feel free to use paragraphs or a bulleted list, for example:

- Improves performance by 10,000%.
- Fixes all bugs.
- Boils the oceans.

-->

<!--
Does this PR fix one or more reported issues?
If yes, use `Fixes #<issue number>` to automatically close the fixed issue(s) when the PR is merged.
-->

**Release note**:

<!--
Does this PR introduce a user-facing change?

If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
-->
```release-note
NONE
```
