### PR TITLE
Fix int test that was failing on MacOS, and some small doc changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ Please follow the procedure described in [SECURITY.md](SECURITY.md).
 
 ## CLA
 
-We welcome contributions from everyone but we can only accept them if you sign
+We welcome contributions from everyone but, we can only accept them if you sign
 our Contributor License Agreement (CLA). If you would like to contribute and you
 have not signed it, our CLA-bot will walk you through the process when you open
 a Pull Request. For questions about the CLA process, see the
@@ -82,11 +82,19 @@ tracker.
 ## Building
 
 The [Dockerfile](Dockerfile) at the root of the repo can be used to build and
-package the code. After making a change to the code, rebuild the docker image with the following command.
+package the server-side code. After making a change to the code, rebuild the
+docker image with the following command.
 
 ```bash
 # From the root directory of the repo...
 docker build .
+```
+
+The Pinniped CLI client can be built for local use with the following command.
+
+```bash
+# From the root directory of the repo...
+go build -o pinniped ./cmd/pinniped
 ```
 
 ## Testing
@@ -122,7 +130,7 @@ docker build .
    brew install kind k14s/tap/ytt k14s/tap/kapp kubectl chromedriver nmap && brew cask install docker
    ```
 
-1. Create a kind cluster, compile, create container images, and install Pinniped and supporting dependencies using:
+1. Create a kind cluster, compile, create container images, and install Pinniped and supporting test dependencies using:
 
    ```bash
    ./hack/prepare-for-integration-tests.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ Please follow the procedure described in [SECURITY.md](SECURITY.md).
 
 ## CLA
 
-We welcome contributions from everyone but, we can only accept them if you sign
+We welcome contributions from everyone, but we can only accept them if you sign
 our Contributor License Agreement (CLA). If you would like to contribute and you
 have not signed it, our CLA-bot will walk you through the process when you open
 a Pull Request. For questions about the CLA process, see the

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -31,7 +31,7 @@ A supermajority is defined as two-thirds of members in the group. A supermajorit
 Ideally, all project decisions are resolved by consensus. If impossible, any maintainer may call a vote. Unless otherwise specified in this document, any vote will be decided by a supermajority of maintainers.
 
 ---
-# Proposal Process 
+# Proposal Process
 The proposal process is currently being worked on. No formal process is available at this time. You may reach out to the maintainers in the Kubernetes Slack Workspace within the [#pinniped](https://kubernetes.slack.com/archives/C01BW364RJA) channel or on the [Pinniped mailing list](project-pinniped@googlegroups.com) with any questions you may have or to send us your proposals.
 
 ---

--- a/hack/prepare-for-integration-tests.sh
+++ b/hack/prepare-for-integration-tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+# Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 #
@@ -420,6 +420,7 @@ EOF
 log_note
 log_note "🚀 Ready to run integration tests! For example..."
 log_note "    cd $pinniped_path"
+log_note "    ulimit -n 512"
 log_note '    source /tmp/integration-test-env && go test -v -race -count 1 -timeout 0 ./test/integration'
 log_note
 log_note "Using GoLand? Paste the result of this command into GoLand's run configuration \"Environment\"."

--- a/internal/oidc/provider/formposthtml/form_post.js
+++ b/internal/oidc/provider/formposthtml/form_post.js
@@ -53,8 +53,8 @@ window.onload = () => {
             // Requests made using "no-cors" mode will hide the real response.status by making it 0
             // and the real response.ok by making it false.
             // If the real response was success, then we would like to show the success state.
-            // If the real response was an error, then we wish we could show the manual
-            // state, but we have no way to know that, as long as we are making "no-cors" requests.
+            // If the real response was an error, then we wish we could do something else (maybe show the error?),
+            // but we have no way to know the real response as long as we are making "no-cors" requests.
             // For now, show the success status for all responses.
             // In the future, we could make this request in "cors" mode once old versions of our CLI
             // which did not handle CORS are upgraded out by our users. That would allow us to use


### PR DESCRIPTION
An integration test that was recently added always fails on MacOS. This PR makes it pass, although at the cost of making a slightly weaker assertion in the test.

This PR also notes that integration tests must be run with a ulimit which is higher than the MacOS default.

There are a few tiny doc changes too.

**Release note**:

None. Small test and doc changes only.

```release-note
NONE
```
