### PR TITLE
Enforce naming convention for browser based tests

### DIFF
--- a/test/integration/cli_test.go
+++ b/test/integration/cli_test.go
@@ -170,7 +170,7 @@ func deserializeWhoAmIRequest(t *testing.T, data string, apiGroupSuffix string) 
 	return obj.(*identityv1alpha1.WhoAmIRequest)
 }
 
-func TestCLILoginOIDC(t *testing.T) {
+func TestCLILoginOIDC_Browser(t *testing.T) {
 	env := testlib.IntegrationEnv(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)

--- a/test/integration/concierge_credentialrequest_test.go
+++ b/test/integration/concierge_credentialrequest_test.go
@@ -45,10 +45,10 @@ func TestUnsuccessfulCredentialRequest_Parallel(t *testing.T) {
 	require.Equal(t, "authentication failed", *response.Status.Message)
 }
 
-// TestSuccessfulCredentialRequest cannot run in parallel because runPinnipedLoginOIDC uses a fixed port
+// TestSuccessfulCredentialRequest_Browser cannot run in parallel because runPinnipedLoginOIDC uses a fixed port
 // for its localhost listener via --listen-port=env.CLIUpstreamOIDC.CallbackURL.Port() per oidcLoginCommand.
 // Since ports are global to the process, tests using oidcLoginCommand must be run serially.
-func TestSuccessfulCredentialRequest(t *testing.T) {
+func TestSuccessfulCredentialRequest_Browser(t *testing.T) {
 	env := testlib.IntegrationEnv(t).WithCapability(testlib.ClusterSigningKeyIsAvailable)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)

--- a/test/integration/e2e_test.go
+++ b/test/integration/e2e_test.go
@@ -47,8 +47,8 @@ import (
 	"go.pinniped.dev/test/testlib/browsertest"
 )
 
-// TestE2EFullIntegration tests a full integration scenario that combines the supervisor, concierge, and CLI.
-func TestE2EFullIntegration(t *testing.T) { // nolint:gocyclo
+// TestE2EFullIntegration_Browser tests a full integration scenario that combines the supervisor, concierge, and CLI.
+func TestE2EFullIntegration_Browser(t *testing.T) { // nolint:gocyclo
 	env := testlib.IntegrationEnv(t)
 
 	ctx, cancelFunc := context.WithTimeout(context.Background(), 10*time.Minute)

--- a/test/integration/formposthtml_test.go
+++ b/test/integration/formposthtml_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 // safe to run in parallel with serial tests since it only interacts with a test local server, see main_test.go.
-func TestFormPostHTML_Parallel(t *testing.T) {
+func TestFormPostHTML_Browser_Parallel(t *testing.T) {
 	_ = testlib.IntegrationEnv(t)
 
 	// Run a mock callback handler, simulating the one running in the CLI.

--- a/test/integration/supervisor_login_test.go
+++ b/test/integration/supervisor_login_test.go
@@ -47,7 +47,7 @@ import (
 )
 
 // nolint:gocyclo
-func TestSupervisorLogin(t *testing.T) {
+func TestSupervisorLogin_Browser(t *testing.T) {
 	env := testlib.IntegrationEnv(t)
 
 	tests := []struct {


### PR DESCRIPTION
This allows us to target browser based tests with the regex:

```
go test -v -race -count 1 -timeout 0 ./test/integration -run '/_Browser'
```

New tests that call `browsertest.Open` will automatically be forced to follow this convention.

Signed-off-by: Monis Khan <mok@vmware.com>

**Release note**:

```release-note
NONE
```