### PR TITLE
Add toleration for new "control-plane" node label for Concierge deploy

### DIFF
--- a/deploy/concierge/deployment.yaml
+++ b/deploy/concierge/deployment.yaml
@@ -1,4 +1,4 @@
-#! Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+#! Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
 #! SPDX-License-Identifier: Apache-2.0
 
 #@ load("@ytt:data", "data")
@@ -221,7 +221,9 @@ spec:
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: node-role.kubernetes.io/master #! Allow running on master nodes too
+        - key: node-role.kubernetes.io/master #! Allow running on master nodes too (name deprecated by kubernetes 1.20).
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane #! The new name for these nodes as of Kubernetes 1.24.
           effect: NoSchedule
       #! "system-cluster-critical" cannot be used outside the kube-system namespace until Kubernetes >= 1.17,
       #! so we skip setting this for now (see https://github.com/kubernetes/kubernetes/issues/60596).


### PR DESCRIPTION
Addresses #1010.

Add toleration for new "control-plane" node label for Concierge deployment, which will be required instead of old "master" name for Kubernetes 1.24+.

**Release note**:

None, as this change won't be noticeable by users. See comment below for more information.

```release-note
NONE
```
