### PR TITLE
Regenerate code after updating controller-gen to v0.8.0

### DIFF
--- a/deploy/concierge/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
+++ b/deploy/concierge/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: jwtauthenticators.authentication.concierge.pinniped.dev
 spec:

--- a/deploy/concierge/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
+++ b/deploy/concierge/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: webhookauthenticators.authentication.concierge.pinniped.dev
 spec:

--- a/deploy/concierge/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/deploy/concierge/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: credentialissuers.config.concierge.pinniped.dev
 spec:

--- a/deploy/supervisor/config.supervisor.pinniped.dev_federationdomains.yaml
+++ b/deploy/supervisor/config.supervisor.pinniped.dev_federationdomains.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: federationdomains.config.supervisor.pinniped.dev
 spec:

--- a/deploy/supervisor/idp.supervisor.pinniped.dev_activedirectoryidentityproviders.yaml
+++ b/deploy/supervisor/idp.supervisor.pinniped.dev_activedirectoryidentityproviders.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: activedirectoryidentityproviders.idp.supervisor.pinniped.dev
 spec:

--- a/deploy/supervisor/idp.supervisor.pinniped.dev_ldapidentityproviders.yaml
+++ b/deploy/supervisor/idp.supervisor.pinniped.dev_ldapidentityproviders.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: ldapidentityproviders.idp.supervisor.pinniped.dev
 spec:

--- a/deploy/supervisor/idp.supervisor.pinniped.dev_oidcidentityproviders.yaml
+++ b/deploy/supervisor/idp.supervisor.pinniped.dev_oidcidentityproviders.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: oidcidentityproviders.idp.supervisor.pinniped.dev
 spec:

--- a/generated/1.17/crds/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
+++ b/generated/1.17/crds/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: jwtauthenticators.authentication.concierge.pinniped.dev
 spec:

--- a/generated/1.17/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
+++ b/generated/1.17/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: webhookauthenticators.authentication.concierge.pinniped.dev
 spec:

--- a/generated/1.17/crds/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/generated/1.17/crds/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: credentialissuers.config.concierge.pinniped.dev
 spec:

--- a/generated/1.17/crds/config.supervisor.pinniped.dev_federationdomains.yaml
+++ b/generated/1.17/crds/config.supervisor.pinniped.dev_federationdomains.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: federationdomains.config.supervisor.pinniped.dev
 spec:

--- a/generated/1.17/crds/idp.supervisor.pinniped.dev_activedirectoryidentityproviders.yaml
+++ b/generated/1.17/crds/idp.supervisor.pinniped.dev_activedirectoryidentityproviders.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: activedirectoryidentityproviders.idp.supervisor.pinniped.dev
 spec:

--- a/generated/1.17/crds/idp.supervisor.pinniped.dev_ldapidentityproviders.yaml
+++ b/generated/1.17/crds/idp.supervisor.pinniped.dev_ldapidentityproviders.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: ldapidentityproviders.idp.supervisor.pinniped.dev
 spec:

--- a/generated/1.17/crds/idp.supervisor.pinniped.dev_oidcidentityproviders.yaml
+++ b/generated/1.17/crds/idp.supervisor.pinniped.dev_oidcidentityproviders.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: oidcidentityproviders.idp.supervisor.pinniped.dev
 spec:

--- a/generated/1.18/crds/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
+++ b/generated/1.18/crds/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: jwtauthenticators.authentication.concierge.pinniped.dev
 spec:

--- a/generated/1.18/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
+++ b/generated/1.18/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: webhookauthenticators.authentication.concierge.pinniped.dev
 spec:

--- a/generated/1.18/crds/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/generated/1.18/crds/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: credentialissuers.config.concierge.pinniped.dev
 spec:

--- a/generated/1.18/crds/config.supervisor.pinniped.dev_federationdomains.yaml
+++ b/generated/1.18/crds/config.supervisor.pinniped.dev_federationdomains.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: federationdomains.config.supervisor.pinniped.dev
 spec:

--- a/generated/1.18/crds/idp.supervisor.pinniped.dev_activedirectoryidentityproviders.yaml
+++ b/generated/1.18/crds/idp.supervisor.pinniped.dev_activedirectoryidentityproviders.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: activedirectoryidentityproviders.idp.supervisor.pinniped.dev
 spec:

--- a/generated/1.18/crds/idp.supervisor.pinniped.dev_ldapidentityproviders.yaml
+++ b/generated/1.18/crds/idp.supervisor.pinniped.dev_ldapidentityproviders.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: ldapidentityproviders.idp.supervisor.pinniped.dev
 spec:

--- a/generated/1.18/crds/idp.supervisor.pinniped.dev_oidcidentityproviders.yaml
+++ b/generated/1.18/crds/idp.supervisor.pinniped.dev_oidcidentityproviders.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: oidcidentityproviders.idp.supervisor.pinniped.dev
 spec:

--- a/generated/1.19/crds/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
+++ b/generated/1.19/crds/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: jwtauthenticators.authentication.concierge.pinniped.dev
 spec:

--- a/generated/1.19/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
+++ b/generated/1.19/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: webhookauthenticators.authentication.concierge.pinniped.dev
 spec:

--- a/generated/1.19/crds/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/generated/1.19/crds/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: credentialissuers.config.concierge.pinniped.dev
 spec:

--- a/generated/1.19/crds/config.supervisor.pinniped.dev_federationdomains.yaml
+++ b/generated/1.19/crds/config.supervisor.pinniped.dev_federationdomains.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: federationdomains.config.supervisor.pinniped.dev
 spec:

--- a/generated/1.19/crds/idp.supervisor.pinniped.dev_activedirectoryidentityproviders.yaml
+++ b/generated/1.19/crds/idp.supervisor.pinniped.dev_activedirectoryidentityproviders.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: activedirectoryidentityproviders.idp.supervisor.pinniped.dev
 spec:

--- a/generated/1.19/crds/idp.supervisor.pinniped.dev_ldapidentityproviders.yaml
+++ b/generated/1.19/crds/idp.supervisor.pinniped.dev_ldapidentityproviders.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: ldapidentityproviders.idp.supervisor.pinniped.dev
 spec:

--- a/generated/1.19/crds/idp.supervisor.pinniped.dev_oidcidentityproviders.yaml
+++ b/generated/1.19/crds/idp.supervisor.pinniped.dev_oidcidentityproviders.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: oidcidentityproviders.idp.supervisor.pinniped.dev
 spec:

--- a/generated/1.20/crds/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
+++ b/generated/1.20/crds/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: jwtauthenticators.authentication.concierge.pinniped.dev
 spec:

--- a/generated/1.20/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
+++ b/generated/1.20/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: webhookauthenticators.authentication.concierge.pinniped.dev
 spec:

--- a/generated/1.20/crds/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/generated/1.20/crds/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: credentialissuers.config.concierge.pinniped.dev
 spec:

--- a/generated/1.20/crds/config.supervisor.pinniped.dev_federationdomains.yaml
+++ b/generated/1.20/crds/config.supervisor.pinniped.dev_federationdomains.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: federationdomains.config.supervisor.pinniped.dev
 spec:

--- a/generated/1.20/crds/idp.supervisor.pinniped.dev_activedirectoryidentityproviders.yaml
+++ b/generated/1.20/crds/idp.supervisor.pinniped.dev_activedirectoryidentityproviders.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: activedirectoryidentityproviders.idp.supervisor.pinniped.dev
 spec:

--- a/generated/1.20/crds/idp.supervisor.pinniped.dev_ldapidentityproviders.yaml
+++ b/generated/1.20/crds/idp.supervisor.pinniped.dev_ldapidentityproviders.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: ldapidentityproviders.idp.supervisor.pinniped.dev
 spec:

--- a/generated/1.20/crds/idp.supervisor.pinniped.dev_oidcidentityproviders.yaml
+++ b/generated/1.20/crds/idp.supervisor.pinniped.dev_oidcidentityproviders.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: oidcidentityproviders.idp.supervisor.pinniped.dev
 spec:

--- a/generated/1.21/crds/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
+++ b/generated/1.21/crds/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: jwtauthenticators.authentication.concierge.pinniped.dev
 spec:

--- a/generated/1.21/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
+++ b/generated/1.21/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: webhookauthenticators.authentication.concierge.pinniped.dev
 spec:

--- a/generated/1.21/crds/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/generated/1.21/crds/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: credentialissuers.config.concierge.pinniped.dev
 spec:

--- a/generated/1.21/crds/config.supervisor.pinniped.dev_federationdomains.yaml
+++ b/generated/1.21/crds/config.supervisor.pinniped.dev_federationdomains.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: federationdomains.config.supervisor.pinniped.dev
 spec:

--- a/generated/1.21/crds/idp.supervisor.pinniped.dev_activedirectoryidentityproviders.yaml
+++ b/generated/1.21/crds/idp.supervisor.pinniped.dev_activedirectoryidentityproviders.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: activedirectoryidentityproviders.idp.supervisor.pinniped.dev
 spec:

--- a/generated/1.21/crds/idp.supervisor.pinniped.dev_ldapidentityproviders.yaml
+++ b/generated/1.21/crds/idp.supervisor.pinniped.dev_ldapidentityproviders.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: ldapidentityproviders.idp.supervisor.pinniped.dev
 spec:

--- a/generated/1.21/crds/idp.supervisor.pinniped.dev_oidcidentityproviders.yaml
+++ b/generated/1.21/crds/idp.supervisor.pinniped.dev_oidcidentityproviders.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: oidcidentityproviders.idp.supervisor.pinniped.dev
 spec:

--- a/generated/1.22/crds/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
+++ b/generated/1.22/crds/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: jwtauthenticators.authentication.concierge.pinniped.dev
 spec:

--- a/generated/1.22/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
+++ b/generated/1.22/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: webhookauthenticators.authentication.concierge.pinniped.dev
 spec:

--- a/generated/1.22/crds/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/generated/1.22/crds/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: credentialissuers.config.concierge.pinniped.dev
 spec:

--- a/generated/1.22/crds/config.supervisor.pinniped.dev_federationdomains.yaml
+++ b/generated/1.22/crds/config.supervisor.pinniped.dev_federationdomains.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: federationdomains.config.supervisor.pinniped.dev
 spec:

--- a/generated/1.22/crds/idp.supervisor.pinniped.dev_activedirectoryidentityproviders.yaml
+++ b/generated/1.22/crds/idp.supervisor.pinniped.dev_activedirectoryidentityproviders.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: activedirectoryidentityproviders.idp.supervisor.pinniped.dev
 spec:

--- a/generated/1.22/crds/idp.supervisor.pinniped.dev_ldapidentityproviders.yaml
+++ b/generated/1.22/crds/idp.supervisor.pinniped.dev_ldapidentityproviders.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: ldapidentityproviders.idp.supervisor.pinniped.dev
 spec:

--- a/generated/1.22/crds/idp.supervisor.pinniped.dev_oidcidentityproviders.yaml
+++ b/generated/1.22/crds/idp.supervisor.pinniped.dev_oidcidentityproviders.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: oidcidentityproviders.idp.supervisor.pinniped.dev
 spec:

--- a/generated/1.23/crds/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
+++ b/generated/1.23/crds/authentication.concierge.pinniped.dev_jwtauthenticators.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: jwtauthenticators.authentication.concierge.pinniped.dev
 spec:

--- a/generated/1.23/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
+++ b/generated/1.23/crds/authentication.concierge.pinniped.dev_webhookauthenticators.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: webhookauthenticators.authentication.concierge.pinniped.dev
 spec:

--- a/generated/1.23/crds/config.concierge.pinniped.dev_credentialissuers.yaml
+++ b/generated/1.23/crds/config.concierge.pinniped.dev_credentialissuers.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: credentialissuers.config.concierge.pinniped.dev
 spec:

--- a/generated/1.23/crds/config.supervisor.pinniped.dev_federationdomains.yaml
+++ b/generated/1.23/crds/config.supervisor.pinniped.dev_federationdomains.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: federationdomains.config.supervisor.pinniped.dev
 spec:

--- a/generated/1.23/crds/idp.supervisor.pinniped.dev_activedirectoryidentityproviders.yaml
+++ b/generated/1.23/crds/idp.supervisor.pinniped.dev_activedirectoryidentityproviders.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: activedirectoryidentityproviders.idp.supervisor.pinniped.dev
 spec:

--- a/generated/1.23/crds/idp.supervisor.pinniped.dev_ldapidentityproviders.yaml
+++ b/generated/1.23/crds/idp.supervisor.pinniped.dev_ldapidentityproviders.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: ldapidentityproviders.idp.supervisor.pinniped.dev
 spec:

--- a/generated/1.23/crds/idp.supervisor.pinniped.dev_oidcidentityproviders.yaml
+++ b/generated/1.23/crds/idp.supervisor.pinniped.dev_oidcidentityproviders.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: oidcidentityproviders.idp.supervisor.pinniped.dev
 spec:

--- a/hack/lib/update-codegen.sh
+++ b/hack/lib/update-codegen.sh
@@ -178,8 +178,8 @@ crd-ref-docs \
 
 # Generate CRD YAML
 (cd apis &&
-    controller-gen paths=./supervisor/config/v1alpha1 crd:trivialVersions=true output:crd:artifacts:config=../crds &&
-    controller-gen paths=./supervisor/idp/v1alpha1 crd:trivialVersions=true output:crd:artifacts:config=../crds &&
-    controller-gen paths=./concierge/config/v1alpha1 crd:trivialVersions=true output:crd:artifacts:config=../crds &&
-    controller-gen paths=./concierge/authentication/v1alpha1 crd:trivialVersions=true output:crd:artifacts:config=../crds
+    controller-gen paths=./supervisor/config/v1alpha1 crd output:crd:artifacts:config=../crds &&
+    controller-gen paths=./supervisor/idp/v1alpha1 crd output:crd:artifacts:config=../crds &&
+    controller-gen paths=./concierge/config/v1alpha1 crd output:crd:artifacts:config=../crds &&
+    controller-gen paths=./concierge/authentication/v1alpha1 crd output:crd:artifacts:config=../crds
 )


### PR DESCRIPTION
Regenerate code after updating controller-gen to v0.8.0

Note that v0.8.0 no longer supports the "trivialVersions=true" command-line option, so remove that from update-codegen.sh. It doesn't seem to impact the output (our generated CRD yaml files).

**Release note**:

```release-note
NONE
```
