### PR TITLE
Update to github.com/golangci/golangci-lint/cmd/golangci-lint@v1.44.2

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -34,7 +34,7 @@ linters:
   - godot
   - goheader
   - goimports
-  - golint
+  - revive
   - goprintffuncname
   - gosec
   - misspell
@@ -44,7 +44,7 @@ linters:
   - nolintlint
   - prealloc
   - rowserrcheck
-  - scopelint
+  - exportloopref
   - sqlclosecheck
   - unconvert
   - whitespace

--- a/cmd/pinniped/cmd/kubeconfig.go
+++ b/cmd/pinniped/cmd/kubeconfig.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package cmd
@@ -171,7 +171,6 @@ func kubeconfigCommand(deps kubeconfigDeps) *cobra.Command {
 	return cmd
 }
 
-//nolint:funlen
 func runGetKubeconfig(ctx context.Context, out io.Writer, deps kubeconfigDeps, flags getKubeconfigParams) error {
 	ctx, cancel := context.WithTimeout(ctx, flags.timeout)
 	defer cancel()

--- a/hack/install-linter.sh
+++ b/hack/install-linter.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 the Pinniped contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+cd "${ROOT}"
+
+# Install the same version of the linter that is used in the CI pipelines
+# so you can get the same results when running the linter locally.
+# Whenever the linter is updated in the CI pipelines, it should also be
+# updated here to make local development more convenient.
+go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.44.2
+golangci-lint --version

--- a/internal/config/concierge/types.go
+++ b/internal/config/concierge/types.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package concierge
@@ -28,7 +28,6 @@ type DiscoveryInfoSpec struct {
 }
 
 // APIConfigSpec contains configuration knobs for the Pinniped API.
-//nolint: golint
 type APIConfigSpec struct {
 	ServingCertificateConfig ServingCertificateConfigSpec `json:"servingCertificate"`
 }

--- a/internal/controller/impersonatorconfig/impersonator_config_test.go
+++ b/internal/controller/impersonatorconfig/impersonator_config_test.go
@@ -51,7 +51,7 @@ func TestImpersonatorConfigControllerOptions(t *testing.T) {
 	spec.Run(t, "options", func(t *testing.T, when spec.G, it spec.S) {
 		const installedInNamespace = "some-namespace"
 		const impersonationProxyPort = 8444
-		const credentialIssuerResourceName = "some-credential-issuer-resource-name"
+		const credentialIssuerResourceName = "some-credential-issuer-resource-name" //nolint:gosec // this is not a credential
 		const generatedLoadBalancerServiceName = "some-service-resource-name"
 		const generatedClusterIPServiceName = "some-cluster-ip-resource-name"
 		const tlsSecretName = "some-tls-secret-name" //nolint:gosec // this is not a credential
@@ -254,7 +254,7 @@ func TestImpersonatorConfigControllerSync(t *testing.T) {
 	spec.Run(t, "Sync", func(t *testing.T, when spec.G, it spec.S) {
 		const installedInNamespace = "some-namespace"
 		const impersonationProxyPort = 8444
-		const credentialIssuerResourceName = "some-credential-issuer-resource-name"
+		const credentialIssuerResourceName = "some-credential-issuer-resource-name" //nolint:gosec // this is not a credential
 		const loadBalancerServiceName = "some-service-resource-name"
 		const clusterIPServiceName = "some-cluster-ip-resource-name"
 		const tlsSecretName = "some-tls-secret-name" //nolint:gosec // this is not a credential
@@ -461,7 +461,7 @@ func TestImpersonatorConfigControllerSync(t *testing.T) {
 				rootCAs := x509.NewCertPool()
 				rootCAs.AppendCertsFromPEM(caCrt)
 				tr = &http.Transport{
-					TLSClientConfig: &tls.Config{
+					TLSClientConfig: &tls.Config{ //nolint:gosec // not concerned with TLS MinVersion here
 						// Server's TLS serving cert CA
 						RootCAs: rootCAs,
 						// Client cert which is supposed to work against the server's dynamic CAContentProvider

--- a/internal/controller/supervisorconfig/jwks_writer.go
+++ b/internal/controller/supervisorconfig/jwks_writer.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package supervisorconfig
@@ -51,7 +51,7 @@ const (
 
 // generateKey is stubbed out for the purpose of testing. The default behavior is to generate an EC key.
 //nolint:gochecknoglobals
-var generateKey func(r io.Reader) (interface{}, error) = generateECKey
+var generateKey = generateECKey
 
 func generateECKey(r io.Reader) (interface{}, error) {
 	return ecdsa.GenerateKey(elliptic.P256(), r)

--- a/internal/controller/supervisorconfig/oidcupstreamwatcher/oidc_upstream_watcher.go
+++ b/internal/controller/supervisorconfig/oidcupstreamwatcher/oidc_upstream_watcher.go
@@ -53,7 +53,7 @@ const (
 	oidcValidatorCacheTTL = 15 * time.Minute
 
 	// Constants related to conditions.
-	typeClientCredentialsValid             = "ClientCredentialsValid"
+	typeClientCredentialsValid             = "ClientCredentialsValid" //nolint:gosec // this is not a credential
 	typeAdditionalAuthorizeParametersValid = "AdditionalAuthorizeParametersValid"
 	typeOIDCDiscoverySucceeded             = "OIDCDiscoverySucceeded"
 

--- a/internal/crypto/ptls/ptls_test.go
+++ b/internal/crypto/ptls/ptls_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2021-2022 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package ptls
@@ -55,7 +55,7 @@ func TestMerge(t *testing.T) {
 		{
 			name:          "default no protos",
 			tlsConfigFunc: Default,
-			tlsConfig: &tls.Config{
+			tlsConfig: &tls.Config{ //nolint:gosec // not concerned with TLS MinVersion here
 				ServerName: "something-to-check-passthrough",
 			},
 			want: &tls.Config{
@@ -75,7 +75,7 @@ func TestMerge(t *testing.T) {
 		{
 			name:          "default with protos",
 			tlsConfigFunc: Default,
-			tlsConfig: &tls.Config{
+			tlsConfig: &tls.Config{ //nolint:gosec // not concerned with TLS MinVersion here
 				ServerName: "a different thing for passthrough",
 				NextProtos: []string{"panda"},
 			},
@@ -96,7 +96,7 @@ func TestMerge(t *testing.T) {
 		{
 			name:          "secure no protos",
 			tlsConfigFunc: Secure,
-			tlsConfig: &tls.Config{
+			tlsConfig: &tls.Config{ //nolint:gosec // not concerned with TLS MinVersion here
 				ServerName: "something-to-check-passthrough",
 			},
 			want: &tls.Config{
@@ -113,7 +113,7 @@ func TestMerge(t *testing.T) {
 		{
 			name:          "secure with protos",
 			tlsConfigFunc: Secure,
-			tlsConfig: &tls.Config{
+			tlsConfig: &tls.Config{ //nolint:gosec // not concerned with TLS MinVersion here
 				ServerName: "a different thing for passthrough",
 				NextProtos: []string{"panda"},
 			},
@@ -131,7 +131,7 @@ func TestMerge(t *testing.T) {
 		{
 			name:          "default ldap no protos",
 			tlsConfigFunc: DefaultLDAP,
-			tlsConfig: &tls.Config{
+			tlsConfig: &tls.Config{ //nolint:gosec // not concerned with TLS MinVersion here
 				ServerName: "something-to-check-passthrough",
 			},
 			want: &tls.Config{

--- a/internal/fositestorage/fositestorage.go
+++ b/internal/fositestorage/fositestorage.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package fositestorage
@@ -15,7 +15,7 @@ const (
 	ErrInvalidRequestType     = constable.Error("requester must be of type fosite.Request")
 	ErrInvalidClientType      = constable.Error("requester's client must be of type clientregistry.Client")
 	ErrInvalidSessionType     = constable.Error("requester's session must be of type PinnipedSession")
-	StorageRequestIDLabelName = "storage.pinniped.dev/request-id" //nolint:gosec // this is not a credential
+	StorageRequestIDLabelName = "storage.pinniped.dev/request-id"
 )
 
 func ValidateAndExtractAuthorizeRequest(requester fosite.Requester) (*fosite.Request, error) {

--- a/internal/kubeclient/copied.go
+++ b/internal/kubeclient/copied.go
@@ -1,4 +1,4 @@
-// Copyright 2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2021-2022 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package kubeclient
@@ -15,7 +15,7 @@ import (
 )
 
 // defaultServerUrlFor was copied from k8s.io/client-go/rest/url_utils.go.
-//nolint: golint
+//nolint:revive
 func defaultServerUrlFor(config *restclient.Config) (*url.URL, string, error) {
 	hasCA := len(config.CAFile) != 0 || len(config.CAData) != 0
 	hasCert := len(config.CertFile) != 0 || len(config.CertData) != 0

--- a/internal/net/phttp/debug_test.go
+++ b/internal/net/phttp/debug_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2021-2022 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package phttp
@@ -260,7 +260,7 @@ func Test_safeDebugWrappers_clean(t *testing.T) {
 
 					gotReq = r
 
-					resp, err := rt.RoundTrip(r) //nolint:bodyclose
+					resp, err := rt.RoundTrip(r)
 
 					gotResp = resp
 					gotErr = err

--- a/internal/oidc/callback/callback_handler_test.go
+++ b/internal/oidc/callback/callback_handler_test.go
@@ -1080,7 +1080,7 @@ func TestCallbackEndpoint(t *testing.T) {
 				require.Empty(t, rsp.Body.String())
 			}
 
-			if test.wantRedirectLocationRegexp != "" { //nolint:nestif // don't mind have several sequential if statements in this test
+			if test.wantRedirectLocationRegexp != "" {
 				require.Len(t, rsp.Header().Values("Location"), 1)
 				oidctestutil.RequireAuthCodeRegexpMatch(
 					t,

--- a/internal/oidc/provider/formposthtml/formposthtml.go
+++ b/internal/oidc/provider/formposthtml/formposthtml.go
@@ -1,4 +1,4 @@
-// Copyright 2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2021-2022 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package formposthtml defines HTML templates used by the Supervisor.
@@ -34,7 +34,7 @@ var parsedHTMLTemplate = template.Must(template.New("form_post.gohtml").Funcs(te
 	"minifiedJS":  func() template.JS { return template.JS(minifiedJS) }, //nolint:gosec // This is 100% static input, not attacker-controlled.
 }).Parse(rawHTMLTemplate))
 
-// Generate the CSP header value once since it's effectively constant:
+// Generate the CSP header value once since it's effectively constant.
 var cspValue = strings.Join([]string{
 	`default-src 'none'`,
 	`script-src '` + cspHash(minifiedJS) + `'`,

--- a/internal/testutil/fakekubeapi/fakekubeapi.go
+++ b/internal/testutil/fakekubeapi/fakekubeapi.go
@@ -1,4 +1,4 @@
-// Copyright 2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2021-2022 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package fakekubeapi contains a *very* simple httptest.Server that can be used to stand in for
@@ -193,7 +193,7 @@ func encodeObj(w http.ResponseWriter, r *http.Request, obj runtime.Object) error
 		return httperr.Newf(http.StatusInternalServerError, "unable to find serialier with content-type %s", mediaType)
 	}
 
-	data, err := runtime.Encode(serializerInfo.Serializer, obj.(runtime.Object))
+	data, err := runtime.Encode(serializerInfo.Serializer, obj)
 	if err != nil {
 		return httperr.Wrap(http.StatusInternalServerError, "decode obj", err)
 	}

--- a/internal/testutil/tempdir_go1.14.go
+++ b/internal/testutil/tempdir_go1.14.go
@@ -1,6 +1,7 @@
-// Copyright 2020 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+//nolint:goimports // not an import
 // +build go1.14
 
 package testutil

--- a/internal/testutil/testlogger/stdr_copied.go
+++ b/internal/testutil/testlogger/stdr_copied.go
@@ -33,7 +33,7 @@ type logger struct {
 
 func (l logger) clone() logger {
 	out := l
-	l.values = copySlice(l.values)
+	l.values = copySlice(l.values) //nolint:staticcheck // ignore ineffective assignment warning
 	return out
 }
 

--- a/test/integration/cli_test.go
+++ b/test/integration/cli_test.go
@@ -412,6 +412,7 @@ func oidcLoginCommand(ctx context.Context, t *testing.T, pinnipedExe string, ses
 	env := testlib.IntegrationEnv(t)
 	callbackURL, err := url.Parse(env.CLIUpstreamOIDC.CallbackURL)
 	require.NoError(t, err)
+	//nolint:gosec // not worried about these potentially tainted inputs
 	cmd := exec.CommandContext(ctx, pinnipedExe, "login", "oidc",
 		"--issuer", env.CLIUpstreamOIDC.Issuer,
 		"--client-id", env.CLIUpstreamOIDC.ClientID,

--- a/test/integration/concierge_impersonation_proxy_test.go
+++ b/test/integration/concierge_impersonation_proxy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package integration
@@ -2059,7 +2059,7 @@ func requireDisabledStrategy(ctx context.Context, t *testing.T, env *testlib.Tes
 			// There will be other strategy types in the list, so ignore those.
 			if strategy.Type == conciergev1alpha.ImpersonationProxyStrategyType &&
 				strategy.Status == conciergev1alpha.ErrorStrategyStatus &&
-				strategy.Reason == conciergev1alpha.DisabledStrategyReason { //nolint:nestif
+				strategy.Reason == conciergev1alpha.DisabledStrategyReason {
 				return true, nil // found it, continue the test!
 			} else if strategy.Type == conciergev1alpha.ImpersonationProxyStrategyType {
 				t.Logf("Waiting for disabled impersonation proxy strategy on %s: found status %s with reason %s and message: %s",
@@ -2222,7 +2222,6 @@ func kubectlCommand(timeout context.Context, t *testing.T, kubeconfigPath string
 	t.Helper()
 
 	allArgs := append([]string{"--kubeconfig", kubeconfigPath}, args...)
-	//nolint:gosec // we are not performing malicious argument injection against ourselves
 	kubectlCmd := exec.CommandContext(timeout, "kubectl", allArgs...)
 	var stdout, stderr syncBuffer
 	kubectlCmd.Stdout = &stdout

--- a/test/integration/supervisor_discovery_test.go
+++ b/test/integration/supervisor_discovery_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package integration
@@ -279,7 +279,7 @@ func TestSupervisorTLSTerminationWithDefaultCerts_Disruptive(t *testing.T) {
 }
 
 func defaultTLSCertSecretName(env *testlib.TestEnv) string {
-	return env.SupervisorAppName + "-default-tls-certificate" //nolint:gosec // this is not a hardcoded credential
+	return env.SupervisorAppName + "-default-tls-certificate"
 }
 
 func createTLSCertificateSecret(ctx context.Context, t *testing.T, ns string, hostname string, ips []net.IP, secretName string, kubeClient kubernetes.Interface) *certauthority.CA {

--- a/test/integration/supervisor_healthz_test.go
+++ b/test/integration/supervisor_healthz_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package integration
@@ -75,7 +75,7 @@ func httpGet(ctx context.Context, t *testing.T, client *http.Client, url string,
 	)
 	require.NoError(t, err)
 
-	response, err := client.Do(req) //nolint:bodyclose
+	response, err := client.Do(req)
 	require.NoError(t, err)
 	require.Equal(t, expectedStatus, response.StatusCode)
 

--- a/test/integration/supervisor_login_test.go
+++ b/test/integration/supervisor_login_test.go
@@ -1700,7 +1700,7 @@ func testSupervisorLogin(
 	// Create an HTTP client that can reach the downstream discovery endpoint using the CA certs.
 	httpClient := &http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{RootCAs: ca.Pool()},
+			TLSClientConfig: &tls.Config{RootCAs: ca.Pool()}, //nolint:gosec // not concerned with TLS MinVersion here
 			Proxy: func(req *http.Request) (*url.URL, error) {
 				if strings.HasPrefix(req.URL.Host, "127.0.0.1") {
 					// don't proxy requests to localhost to avoid proxying calls to our local callback listener

--- a/test/testlib/assertions.go
+++ b/test/testlib/assertions.go
@@ -1,4 +1,4 @@
-// Copyright 2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2021-2022 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package testlib
@@ -30,7 +30,7 @@ type (
 	}
 )
 
-// loopTestingT implements require.TestingT:
+// loopTestingT implements require.TestingT.
 var _ require.TestingT = (*loopTestingT)(nil)
 
 // Errorf is called by the assert.Assertions methods to record an error.

--- a/test/testlib/env.go
+++ b/test/testlib/env.go
@@ -100,7 +100,7 @@ type TestLDAPUpstream struct {
 	TestUserUniqueIDAttributeName                   string   `json:"testUserUniqueIDAttributeName"`
 	TestUserUniqueIDAttributeValue                  string   `json:"testUserUniqueIDAttributeValue"`
 	TestUserDirectGroupsCNs                         []string `json:"testUserDirectGroupsCNs"`
-	TestUserDirectGroupsDNs                         []string `json:"testUserDirectGroupsDNs"` //nolint:golint // this is "distinguished names", not "DNS"
+	TestUserDirectGroupsDNs                         []string `json:"testUserDirectGroupsDNs"` //nolint:revive // this is "distinguished names", not "DNS"
 	TestUserSAMAccountNameValue                     string   `json:"testUserSAMAccountNameValue"`
 	TestUserPrincipalNameValue                      string   `json:"testUserPrincipalNameValue"`
 	TestUserIndirectGroupsSAMAccountNames           []string `json:"TestUserIndirectGroupsSAMAccountNames"`

--- a/test/testlib/iplookup_go1.14.go
+++ b/test/testlib/iplookup_go1.14.go
@@ -1,6 +1,7 @@
-// Copyright 2020 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+//nolint:goimports // not an import
 // +build go1.14
 
 package testlib


### PR DESCRIPTION
Update linter to github.com/golangci/golangci-lint/cmd/golangci-lint@v1.44.2

- Two of the linters changed their names
- Updated code and nolint comments to make all linters pass with 1.44.2
- Added a new hack/install-linter.sh script to help developers install
  the expected version of the linter for local development

**Release note**:

```release-note
NONE
```
