### PR TITLE
Use kubeadm.k8s.io/v1beta3 in addition to v1beta2 for kind config

### DIFF
--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2020 the Pinniped contributors. All Rights Reserved.
+# Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -9,4 +9,5 @@ ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 cd "${ROOT}"
 
 # To choose a specific version of kube, add this option to the command below: `--image kindest/node:v1.18.8`.
+# To debug the kind config, add this option to the command below: `-v 10`
 kind create cluster --config "hack/lib/kind-config/single-node.yaml" --name pinniped

--- a/hack/lib/kind-config/single-node.yaml
+++ b/hack/lib/kind-config/single-node.yaml
@@ -24,9 +24,14 @@ nodes:
       containerPort: 31235
       hostPort: 12346
       listenAddress: 127.0.0.1
+# Kind v0.12.0 ignores kubeadm.k8s.io/v1beta2 for Kube v1.23+ but uses it for older versions of Kube.
+# Previous versions of Kind would use kubeadm.k8s.io/v1beta2 for all versions of Kube including 1.23.
+# To try to maximize compatibility with various versions of Kind and Kube, define this
+# ClusterConfiguration twice and hope that Kind will use the one that it likes for the given version
+# of Kube, and ignore the one that it doesn't like. This seems to work, at least for Kind v0.12.0.
 kubeadmConfigPatches:
 - |
-  apiVersion: kubeadm.k8s.io/v1beta3
+  apiVersion: kubeadm.k8s.io/v1beta2
   kind: ClusterConfiguration
   apiServer:
     extraArgs:
@@ -38,4 +43,11 @@ kubeadmConfigPatches:
       # of available endpoints.  This means that over time, all endpoints associated with the service
       # are exercised.  For whatever reason, leaving this as false (i.e. use kube-proxy) appears to
       # hide some network misconfigurations when used internally by the API server aggregation layer.
+      enable-aggregator-routing: "true"
+- |
+  apiVersion: kubeadm.k8s.io/v1beta3
+  kind: ClusterConfiguration
+  apiServer:
+    extraArgs:
+      # See comment above.
       enable-aggregator-routing: "true"

--- a/hack/lib/kind-config/single-node.yaml
+++ b/hack/lib/kind-config/single-node.yaml
@@ -26,7 +26,7 @@ nodes:
       listenAddress: 127.0.0.1
 kubeadmConfigPatches:
 - |
-  apiVersion: kubeadm.k8s.io/v1beta2
+  apiVersion: kubeadm.k8s.io/v1beta3
   kind: ClusterConfiguration
   apiServer:
     extraArgs:


### PR DESCRIPTION
It appears that kind completely ignores kubeadm.k8s.io/v1beta2 config starting in Kind v0.12.0.

You can observe the config being ignored or used by adding `-v 10` to the command-line arguments of `kind create cluster` in `kind-up.sh`.

This PR updates the version used in single-node.yaml, which is the kind config for running Pinniped on a development laptop (used indirectly by `hack/prepare-for-integration-tests.sh`).

**Release note**:

```release-note
NONE
```
