### PR TITLE
Supervisor HTTP listener disabled by default and may only bind to loopback interfaces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ FROM gcr.io/distroless/static:nonroot@sha256:80c956fb0836a17a565c43a4026c9c80b20
 COPY --from=build-env /usr/local/bin /usr/local/bin
 
 # Document the default server ports for the various server apps
-EXPOSE 8080 8443 8444 10250
+EXPOSE 8443 8444 10250
 
 # Run as non-root for security posture
 # Use the same non-root user as https://github.com/GoogleContainerTools/distroless/blob/fc3c4eaceb0518900f886aae90407c43be0a42d9/base/base.bzl#L9

--- a/apis/supervisor/config/v1alpha1/types_federationdomain.go.tmpl
+++ b/apis/supervisor/config/v1alpha1/types_federationdomain.go.tmpl
@@ -31,8 +31,9 @@ type FederationDomainTLSSpec struct {
 	// SNI requests do not include port numbers, so all issuers with the same DNS hostname must use the same
 	// SecretName value even if they have different port numbers.
 	//
-	// SecretName is not required when you would like to use only the HTTP endpoints (e.g. when terminating TLS at an
-	// Ingress). It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to
+	// SecretName is not required when you would like to use only the HTTP endpoints (e.g. when the HTTP listener is
+	// configured to listen on loopback interfaces or UNIX domain sockets for traffic from a service mesh sidecar).
+	// It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to
 	// use the default TLS certificate, which is configured elsewhere.
 	//
 	// When your Issuer URL's host is an IP address, then this field is ignored. SNI does not work for IP addresses.

--- a/deploy/supervisor/config.supervisor.pinniped.dev_federationdomains.yaml
+++ b/deploy/supervisor/config.supervisor.pinniped.dev_federationdomains.yaml
@@ -76,12 +76,13 @@ spec:
                       so all issuers with the same DNS hostname must use the same
                       SecretName value even if they have different port numbers. \n
                       SecretName is not required when you would like to use only the
-                      HTTP endpoints (e.g. when terminating TLS at an Ingress). It
-                      is also not required when you would like all requests to this
-                      OIDC Provider's HTTPS endpoints to use the default TLS certificate,
-                      which is configured elsewhere. \n When your Issuer URL's host
-                      is an IP address, then this field is ignored. SNI does not work
-                      for IP addresses."
+                      HTTP endpoints (e.g. when the HTTP listener is configured to
+                      listen on loopback interfaces or UNIX domain sockets for traffic
+                      from a service mesh sidecar). It is also not required when you
+                      would like all requests to this OIDC Provider's HTTPS endpoints
+                      to use the default TLS certificate, which is configured elsewhere.
+                      \n When your Issuer URL's host is an IP address, then this field
+                      is ignored. SNI does not work for IP addresses."
                     type: string
                 type: object
             required:

--- a/deploy/supervisor/deployment.yaml
+++ b/deploy/supervisor/deployment.yaml
@@ -1,4 +1,4 @@
-#! Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+#! Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
 #! SPDX-License-Identifier: Apache-2.0
 
 #@ load("@ytt:data", "data")
@@ -115,8 +115,6 @@ spec:
               readOnly: false  #! writable to allow for socket use
             #@ end
           ports:
-            - containerPort: 8080
-              protocol: TCP
             - containerPort: 8443
               protocol: TCP
           env:

--- a/deploy/supervisor/helpers.lib.yaml
+++ b/deploy/supervisor/helpers.lib.yaml
@@ -52,7 +52,7 @@ _: #@ template.replace(data.values.custom_labels)
 #@       "defaultTLSCertificateSecret": defaultResourceNameWithSuffix("default-tls-certificate"),
 #@     },
 #@     "labels": labels(),
-#@     "insecure_accept_external_unencrypted_http_requests": data.values.deprecated_insecure_accept_external_unencrypted_http_requests
+#@     "insecureAcceptExternalUnencryptedHttpRequests": data.values.deprecated_insecure_accept_external_unencrypted_http_requests
 #@   }
 #@   if data.values.log_level:
 #@     config["logLevel"] = getAndValidateLogLevel()

--- a/deploy/supervisor/helpers.lib.yaml
+++ b/deploy/supervisor/helpers.lib.yaml
@@ -1,4 +1,4 @@
-#! Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+#! Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
 #! SPDX-License-Identifier: Apache-2.0
 
 #@ load("@ytt:data", "data")
@@ -52,6 +52,7 @@ _: #@ template.replace(data.values.custom_labels)
 #@       "defaultTLSCertificateSecret": defaultResourceNameWithSuffix("default-tls-certificate"),
 #@     },
 #@     "labels": labels(),
+#@     "insecure_accept_external_unencrypted_http_requests": data.values.deprecated_insecure_accept_external_unencrypted_http_requests
 #@   }
 #@   if data.values.log_level:
 #@     config["logLevel"] = getAndValidateLogLevel()

--- a/deploy/supervisor/service.yaml
+++ b/deploy/supervisor/service.yaml
@@ -2,19 +2,20 @@
 #! SPDX-License-Identifier: Apache-2.0
 
 #@ load("@ytt:data", "data")
+#@ load("@ytt:assert", "assert")
 #@ load("helpers.lib.yaml", "labels", "deploymentPodLabel", "namespace", "defaultResourceName", "defaultResourceNameWithSuffix")
 
-#@ if data.values.service_http_nodeport_port != "removed":
-#@   fail("value service_http_nodeport_port has been renamed to deprecated_service_http_nodeport_port and will be removed in a future release")
+#@ if hasattr(data.values, "service_http_nodeport_port"):
+#@   assert.fail('value "service_http_nodeport_port" has been renamed to "deprecated_service_http_nodeport_port" and will be removed in a future release')
 #@ end
-#@ if data.values.service_http_nodeport_nodeport != "removed":
-#@   fail("value service_http_nodeport_nodeport has been renamed to deprecated_service_http_nodeport_nodeport and will be removed in a future release")
+#@ if hasattr(data.values, "service_http_nodeport_nodeport"):
+#@   assert.fail('value "service_http_nodeport_nodeport" has been renamed to "deprecated_service_http_nodeport_nodeport" and will be removed in a future release')
 #@ end
-#@ if data.values.service_http_loadbalancer_port != "removed":
-#@   fail("value service_http_loadbalancer_port has been renamed to deprecated_service_http_loadbalancer_port and will be removed in a future release")
+#@ if hasattr(data.values, "service_http_loadbalancer_port"):
+#@   assert.fail('value "service_http_loadbalancer_port" has been renamed to "deprecated_service_http_loadbalancer_port" and will be removed in a future release')
 #@ end
-#@ if data.values.service_http_clusterip_port != "removed":
-#@   fail("value service_http_clusterip_port has been renamed to deprecated_service_http_clusterip_port and will be removed in a future release")
+#@ if hasattr(data.values, "service_http_clusterip_port"):
+#@   assert.fail('value "service_http_clusterip_port" has been renamed to "deprecated_service_http_clusterip_port" and will be removed in a future release')
 #@ end
 
 #@ if data.values.deprecated_service_http_nodeport_port or data.values.service_https_nodeport_port:

--- a/deploy/supervisor/service.yaml
+++ b/deploy/supervisor/service.yaml
@@ -1,10 +1,23 @@
-#! Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+#! Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
 #! SPDX-License-Identifier: Apache-2.0
 
 #@ load("@ytt:data", "data")
 #@ load("helpers.lib.yaml", "labels", "deploymentPodLabel", "namespace", "defaultResourceName", "defaultResourceNameWithSuffix")
 
-#@ if data.values.service_http_nodeport_port or data.values.service_https_nodeport_port:
+#@ if data.values.service_http_nodeport_port != "removed":
+#@   fail("value service_http_nodeport_port has been renamed to deprecated_service_http_nodeport_port and will be removed in a future release")
+#@ end
+#@ if data.values.service_http_nodeport_nodeport != "removed":
+#@   fail("value service_http_nodeport_nodeport has been renamed to deprecated_service_http_nodeport_nodeport and will be removed in a future release")
+#@ end
+#@ if data.values.service_http_loadbalancer_port != "removed":
+#@   fail("value service_http_loadbalancer_port has been renamed to deprecated_service_http_loadbalancer_port and will be removed in a future release")
+#@ end
+#@ if data.values.service_http_clusterip_port != "removed":
+#@   fail("value service_http_clusterip_port has been renamed to deprecated_service_http_clusterip_port and will be removed in a future release")
+#@ end
+
+#@ if data.values.deprecated_service_http_nodeport_port or data.values.service_https_nodeport_port:
 ---
 apiVersion: v1
 kind: Service
@@ -19,13 +32,13 @@ spec:
   type: NodePort
   selector: #@ deploymentPodLabel()
   ports:
-    #@ if data.values.service_http_nodeport_port:
+    #@ if data.values.deprecated_service_http_nodeport_port:
     - name: http
       protocol: TCP
-      port: #@ data.values.service_http_nodeport_port
+      port: #@ data.values.deprecated_service_http_nodeport_port
       targetPort: 8080
-      #@ if data.values.service_http_nodeport_nodeport:
-      nodePort: #@ data.values.service_http_nodeport_nodeport
+      #@ if data.values.deprecated_service_http_nodeport_nodeport:
+      nodePort: #@ data.values.deprecated_service_http_nodeport_nodeport
       #@ end
     #@ end
     #@ if data.values.service_https_nodeport_port:
@@ -39,7 +52,7 @@ spec:
     #@ end
 #@ end
 
-#@ if data.values.service_http_clusterip_port or data.values.service_https_clusterip_port:
+#@ if data.values.deprecated_service_http_clusterip_port or data.values.service_https_clusterip_port:
 ---
 apiVersion: v1
 kind: Service
@@ -54,10 +67,10 @@ spec:
   type: ClusterIP
   selector: #@ deploymentPodLabel()
   ports:
-    #@ if data.values.service_http_clusterip_port:
+    #@ if data.values.deprecated_service_http_clusterip_port:
     - name: http
       protocol: TCP
-      port: #@ data.values.service_http_clusterip_port
+      port: #@ data.values.deprecated_service_http_clusterip_port
       targetPort: 8080
     #@ end
     #@ if data.values.service_https_clusterip_port:
@@ -68,7 +81,7 @@ spec:
     #@ end
 #@ end
 
-#@ if data.values.service_http_loadbalancer_port or data.values.service_https_loadbalancer_port:
+#@ if data.values.deprecated_service_http_loadbalancer_port or data.values.service_https_loadbalancer_port:
 ---
 apiVersion: v1
 kind: Service
@@ -86,10 +99,10 @@ spec:
   loadBalancerIP: #@ data.values.service_loadbalancer_ip
   #@ end
   ports:
-    #@ if data.values.service_http_loadbalancer_port:
+    #@ if data.values.deprecated_service_http_loadbalancer_port:
     - name: http
       protocol: TCP
-      port: #@ data.values.service_http_loadbalancer_port
+      port: #@ data.values.deprecated_service_http_loadbalancer_port
       targetPort: 8080
     #@ end
     #@ if data.values.service_https_loadbalancer_port:

--- a/deploy/supervisor/values.yaml
+++ b/deploy/supervisor/values.yaml
@@ -41,10 +41,6 @@ image_pull_dockerconfigjson: #! e.g. {"auths":{"https://registry.example.com":{"
 #! Note that all port numbers should be numbers (not strings), i.e. use ytt's `--data-value-yaml` instead of `--data-value`.
 #! Several of these values have been deprecated and will be removed in a future release. Their names have been changed to
 #! mark them as deprecated and to make it obvious upon upgrade to anyone who was using them that they have been deprecated.
-service_http_nodeport_port: removed #! this value has been deprecated and renamed to deprecated_service_http_nodeport_port; will be removed in a future release
-service_http_nodeport_nodeport: removed #! this value has been deprecated and renamed to deprecated_service_http_nodeport_nodeport; will be removed in a future release
-service_http_loadbalancer_port: removed #! this value has been deprecated and renamed to deprecated_service_http_loadbalancer_port; will be removed in a future release
-service_http_clusterip_port: removed #! this value has been deprecated and renamed to deprecated_service_http_clusterip_port; will be removed in a future release
 deprecated_service_http_nodeport_port: #! will be removed in a future release; when specified, creates a NodePort Service with this `port` value, with port 8080 as its `targetPort`; e.g. 31234
 deprecated_service_http_nodeport_nodeport: #! will be removed in a future release; the `nodePort` value of the NodePort Service, optional when `deprecated_service_http_nodeport_port` is specified; e.g. 31234
 deprecated_service_http_loadbalancer_port: #! will be removed in a future release; when specified, creates a LoadBalancer Service with this `port` value, with port 8080 as its `targetPort`; e.g. 8443

--- a/deploy/supervisor/values.yaml
+++ b/deploy/supervisor/values.yaml
@@ -1,4 +1,4 @@
-#! Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+#! Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
 #! SPDX-License-Identifier: Apache-2.0
 
 #@data/values
@@ -74,17 +74,17 @@ api_group_suffix: pinniped.dev
 https_proxy: #! e.g. http://proxy.example.com
 no_proxy: "$(KUBERNETES_SERVICE_HOST),169.254.169.254,127.0.0.1,localhost,.svc,.cluster.local" #! do not proxy Kubernetes endpoints
 
-#! Control the https and http listeners of the Supervisor.
+#! Control the HTTP and HTTPS listeners of the Supervisor.
 #!
 #! The schema of this config is as follows:
 #!
 #! endpoints:
 #!   https:
 #!     network: tcp | unix | disabled
-#!     address: interface:port when network=tcp or /pinniped_socket/socketfile.sock when network=unix
+#!     address: host:port when network=tcp or /pinniped_socket/socketfile.sock when network=unix
 #!   http:
 #!     network: same as above
-#!     address: same as above
+#!     address: same as above, except that when network=tcp then the address is only allowed to bind to loopback interfaces
 #!
 #! Setting network to disabled turns off that particular listener.
 #! See https://pkg.go.dev/net#Listen and https://pkg.go.dev/net#Dial for a description of what can be
@@ -98,23 +98,20 @@ no_proxy: "$(KUBERNETES_SERVICE_HOST),169.254.169.254,127.0.0.1,localhost,.svc,.
 #!     network: tcp
 #!     address: :8443
 #!   http:
-#!     network: tcp
-#!     address: :8080
+#!     network: disabled
 #!
-#! These defaults mean: bind to all interfaces using TCP.  Use port 8443 for https and 8080 for http.
-#! The defaults will change over time.  Users should explicitly set this value if they wish to avoid
-#! any changes on upgrade.
+#! These defaults mean: For HTTPS listening, bind to all interfaces using TCP on port 8443.
+#! Disable HTTP listening by default.
 #!
-#! A future version of the Supervisor app may include a breaking change to adjust the default
-#! behavior of the http listener to only listen on 127.0.0.1 (or perhaps even to be disabled).
+#! The HTTP listener can only be bound to loopback interfaces. This allows the listener to accept
+#! traffic from within the pod, e.g. from a service mesh sidecar. The HTTP listener should not be
+#! used to accept traffic from outside the pod, since that would mean that the network traffic could be
+#! transmitted unencrypted. The HTTPS listener should be used instead to accept traffic from outside the pod.
+#! Ingresses and load balancers that terminate TLS connections should re-encrypt the data and route traffic
+#! to the HTTPS listener. Unix domain sockets may also be used for integrations with service meshes.
 #!
-#! Binding the http listener to addresses other than 127.0.0.1 or ::1 is deprecated.
-#!
-#! Unix domain sockets are recommended for integrations with service meshes.  Ingresses that terminate
-#! TLS connections at the edge should re-encrypt the data and route traffic to the https listener.
-#!
-#! Changing the port numbers used must be accompanied with matching changes to the service and deployment
-#! manifests.  Changes to the https listener must be coordinated with the deployment health checks.
+#! Changing the HTTPS port number must be accompanied by matching changes to the service and deployment
+#! manifests. Changes to the HTTPS listener must be coordinated with the deployment health checks.
 #!
 #! Optional.
 endpoints:

--- a/deploy/supervisor/values.yaml
+++ b/deploy/supervisor/values.yaml
@@ -35,26 +35,31 @@ image_tag: latest
 #! Optional.
 image_pull_dockerconfigjson: #! e.g. {"auths":{"https://registry.example.com":{"username":"USERNAME","password":"PASSWORD","auth":"BASE64_ENCODED_USERNAME_COLON_PASSWORD"}}}
 
-#! Specify how to expose the Supervisor app's HTTP and/or HTTPS ports as a Service.
-#! Typically you would set a value for only one of the following service types, for either HTTP or HTTPS depending on your needs.
-#! An HTTP service should not be exposed outside the cluster. It would not be secure to serve OIDC endpoints to end users via HTTP.
-#! Setting any of these values means that a Service of that type will be created.
+#! Specify how to expose the Supervisor app's HTTPS port as a Service.
+#! Typically, you would set a value for only one of the following service types.
+#! Setting any of these values means that a Service of that type will be created. They are all optional.
 #! Note that all port numbers should be numbers (not strings), i.e. use ytt's `--data-value-yaml` instead of `--data-value`.
-service_http_nodeport_port: #! when specified, creates a NodePort Service with this `port` value, with port 8080 as its `targetPort`; e.g. 31234
-service_http_nodeport_nodeport: #! the `nodePort` value of the NodePort Service, optional when `service_http_nodeport_port` is specified; e.g. 31234
-service_http_loadbalancer_port: #! when specified, creates a LoadBalancer Service with this `port` value, with port 8080 as its `targetPort`; e.g. 8443
-service_http_clusterip_port: #! when specified, creates a ClusterIP Service with this `port` value, with port 8080 as its `targetPort`; e.g. 8443
+#! Several of these values have been deprecated and will be removed in a future release. Their names have been changed to
+#! mark them as deprecated and to make it obvious upon upgrade to anyone who was using them that they have been deprecated.
+service_http_nodeport_port: removed #! this value has been deprecated and renamed to deprecated_service_http_nodeport_port; will be removed in a future release
+service_http_nodeport_nodeport: removed #! this value has been deprecated and renamed to deprecated_service_http_nodeport_nodeport; will be removed in a future release
+service_http_loadbalancer_port: removed #! this value has been deprecated and renamed to deprecated_service_http_loadbalancer_port; will be removed in a future release
+service_http_clusterip_port: removed #! this value has been deprecated and renamed to deprecated_service_http_clusterip_port; will be removed in a future release
+deprecated_service_http_nodeport_port: #! will be removed in a future release; when specified, creates a NodePort Service with this `port` value, with port 8080 as its `targetPort`; e.g. 31234
+deprecated_service_http_nodeport_nodeport: #! will be removed in a future release; the `nodePort` value of the NodePort Service, optional when `deprecated_service_http_nodeport_port` is specified; e.g. 31234
+deprecated_service_http_loadbalancer_port: #! will be removed in a future release; when specified, creates a LoadBalancer Service with this `port` value, with port 8080 as its `targetPort`; e.g. 8443
+deprecated_service_http_clusterip_port: #! will be removed in a future release; when specified, creates a ClusterIP Service with this `port` value, with port 8080 as its `targetPort`; e.g. 8443
 service_https_nodeport_port: #! when specified, creates a NodePort Service with this `port` value, with port 8443 as its `targetPort`; e.g. 31243
-service_https_nodeport_nodeport: #! the `nodePort` value of the NodePort Service, optional when `service_http_nodeport_port` is specified; e.g. 31243
+service_https_nodeport_nodeport: #! the `nodePort` value of the NodePort Service, optional when `service_https_nodeport_port` is specified; e.g. 31243
 service_https_loadbalancer_port: #! when specified, creates a LoadBalancer Service with this `port` value, with port 8443 as its `targetPort`; e.g. 8443
 service_https_clusterip_port: #! when specified, creates a ClusterIP Service with this `port` value, with port 8443 as its `targetPort`; e.g. 8443
 #! The `loadBalancerIP` value of the LoadBalancer Service.
-#! Ignored unless service_http_loadbalancer_port and/or service_https_loadbalancer_port are provided.
+#! Ignored unless service_https_loadbalancer_port is provided.
 #! Optional.
 service_loadbalancer_ip: #! e.g. 1.2.3.4
 
-#! Specify the verbosity of logging: info ("nice to know" information), debug (developer
-#! information), trace (timing information), all (kitchen sink).
+#! Specify the verbosity of logging: info ("nice to know" information), debug (developer information), trace (timing information),
+#! or all (kitchen sink). Do not use trace or all on production systems, as credentials may get logged.
 log_level: #! By default, when this value is left unset, only warnings and errors are printed. There is no way to suppress warning and error logs.
 
 run_as_user: 65532 #! run_as_user specifies the user ID that will own the process, see the Dockerfile for the reasoning behind this choice
@@ -115,3 +120,14 @@ no_proxy: "$(KUBERNETES_SERVICE_HOST),169.254.169.254,127.0.0.1,localhost,.svc,.
 #!
 #! Optional.
 endpoints:
+
+#! Optionally override the validation on the endpoints.http value which checks that only loopback interfaces are used.
+#! When deprecated_insecure_accept_external_unencrypted_http_requests is true, the HTTP listener is allowed to bind to any
+#! interface, including interfaces that are listening for traffic from outside the pod. This value is being introduced
+#! to ease the transition to the new loopback interface validation for the HTTP port for any users who need more time
+#! to change their ingress strategy to avoid using plain HTTP into the Supervisor pods.
+#! This value is being introduced and immediately deprecated. It will be removed in some future release, at which time
+#! traffic from outside the pod will need to be sent to the HTTPS listener instead, with no simple workaround available.
+#! Allowed values are true (boolean), "true" (string), false (boolean), and "false" (string). The default is false.
+#! Optional.
+deprecated_insecure_accept_external_unencrypted_http_requests: false

--- a/deploy/supervisor/values.yaml
+++ b/deploy/supervisor/values.yaml
@@ -122,7 +122,7 @@ endpoints:
 #! interface, including interfaces that are listening for traffic from outside the pod. This value is being introduced
 #! to ease the transition to the new loopback interface validation for the HTTP port for any users who need more time
 #! to change their ingress strategy to avoid using plain HTTP into the Supervisor pods.
-#! This value is being introduced and immediately deprecated. It will be removed in some future release, at which time
+#! This value is immediately deprecated upon its introduction. It will be removed in some future release, at which time
 #! traffic from outside the pod will need to be sent to the HTTPS listener instead, with no simple workaround available.
 #! Allowed values are true (boolean), "true" (string), false (boolean), and "false" (string). The default is false.
 #! Optional.

--- a/generated/1.17/README.adoc
+++ b/generated/1.17/README.adoc
@@ -538,7 +538,7 @@ FederationDomainTLSSpec is a struct that describes the TLS configuration for an 
 | *`secretName`* __string__ | SecretName is an optional name of a Secret in the same namespace, of type `kubernetes.io/tls`, which contains the TLS serving certificate for the HTTPS endpoints served by this FederationDomain. When provided, the TLS Secret named here must contain keys named `tls.crt` and `tls.key` that contain the certificate and private key to use for TLS. 
  Server Name Indication (SNI) is an extension to the Transport Layer Security (TLS) supported by all major browsers. 
  SecretName is required if you would like to use different TLS certificates for issuers of different hostnames. SNI requests do not include port numbers, so all issuers with the same DNS hostname must use the same SecretName value even if they have different port numbers. 
- SecretName is not required when you would like to use only the HTTP endpoints (e.g. when terminating TLS at an Ingress). It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to use the default TLS certificate, which is configured elsewhere. 
+ SecretName is not required when you would like to use only the HTTP endpoints (e.g. when the HTTP listener is configured to listen on loopback interfaces or UNIX domain sockets for traffic from a service mesh sidecar). It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to use the default TLS certificate, which is configured elsewhere. 
  When your Issuer URL's host is an IP address, then this field is ignored. SNI does not work for IP addresses.
 |===
 

--- a/generated/1.17/apis/supervisor/config/v1alpha1/types_federationdomain.go
+++ b/generated/1.17/apis/supervisor/config/v1alpha1/types_federationdomain.go
@@ -31,8 +31,9 @@ type FederationDomainTLSSpec struct {
 	// SNI requests do not include port numbers, so all issuers with the same DNS hostname must use the same
 	// SecretName value even if they have different port numbers.
 	//
-	// SecretName is not required when you would like to use only the HTTP endpoints (e.g. when terminating TLS at an
-	// Ingress). It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to
+	// SecretName is not required when you would like to use only the HTTP endpoints (e.g. when the HTTP listener is
+	// configured to listen on loopback interfaces or UNIX domain sockets for traffic from a service mesh sidecar).
+	// It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to
 	// use the default TLS certificate, which is configured elsewhere.
 	//
 	// When your Issuer URL's host is an IP address, then this field is ignored. SNI does not work for IP addresses.

--- a/generated/1.17/crds/config.supervisor.pinniped.dev_federationdomains.yaml
+++ b/generated/1.17/crds/config.supervisor.pinniped.dev_federationdomains.yaml
@@ -76,12 +76,13 @@ spec:
                       so all issuers with the same DNS hostname must use the same
                       SecretName value even if they have different port numbers. \n
                       SecretName is not required when you would like to use only the
-                      HTTP endpoints (e.g. when terminating TLS at an Ingress). It
-                      is also not required when you would like all requests to this
-                      OIDC Provider's HTTPS endpoints to use the default TLS certificate,
-                      which is configured elsewhere. \n When your Issuer URL's host
-                      is an IP address, then this field is ignored. SNI does not work
-                      for IP addresses."
+                      HTTP endpoints (e.g. when the HTTP listener is configured to
+                      listen on loopback interfaces or UNIX domain sockets for traffic
+                      from a service mesh sidecar). It is also not required when you
+                      would like all requests to this OIDC Provider's HTTPS endpoints
+                      to use the default TLS certificate, which is configured elsewhere.
+                      \n When your Issuer URL's host is an IP address, then this field
+                      is ignored. SNI does not work for IP addresses."
                     type: string
                 type: object
             required:

--- a/generated/1.18/README.adoc
+++ b/generated/1.18/README.adoc
@@ -538,7 +538,7 @@ FederationDomainTLSSpec is a struct that describes the TLS configuration for an 
 | *`secretName`* __string__ | SecretName is an optional name of a Secret in the same namespace, of type `kubernetes.io/tls`, which contains the TLS serving certificate for the HTTPS endpoints served by this FederationDomain. When provided, the TLS Secret named here must contain keys named `tls.crt` and `tls.key` that contain the certificate and private key to use for TLS. 
  Server Name Indication (SNI) is an extension to the Transport Layer Security (TLS) supported by all major browsers. 
  SecretName is required if you would like to use different TLS certificates for issuers of different hostnames. SNI requests do not include port numbers, so all issuers with the same DNS hostname must use the same SecretName value even if they have different port numbers. 
- SecretName is not required when you would like to use only the HTTP endpoints (e.g. when terminating TLS at an Ingress). It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to use the default TLS certificate, which is configured elsewhere. 
+ SecretName is not required when you would like to use only the HTTP endpoints (e.g. when the HTTP listener is configured to listen on loopback interfaces or UNIX domain sockets for traffic from a service mesh sidecar). It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to use the default TLS certificate, which is configured elsewhere. 
  When your Issuer URL's host is an IP address, then this field is ignored. SNI does not work for IP addresses.
 |===
 

--- a/generated/1.18/apis/supervisor/config/v1alpha1/types_federationdomain.go
+++ b/generated/1.18/apis/supervisor/config/v1alpha1/types_federationdomain.go
@@ -31,8 +31,9 @@ type FederationDomainTLSSpec struct {
 	// SNI requests do not include port numbers, so all issuers with the same DNS hostname must use the same
 	// SecretName value even if they have different port numbers.
 	//
-	// SecretName is not required when you would like to use only the HTTP endpoints (e.g. when terminating TLS at an
-	// Ingress). It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to
+	// SecretName is not required when you would like to use only the HTTP endpoints (e.g. when the HTTP listener is
+	// configured to listen on loopback interfaces or UNIX domain sockets for traffic from a service mesh sidecar).
+	// It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to
 	// use the default TLS certificate, which is configured elsewhere.
 	//
 	// When your Issuer URL's host is an IP address, then this field is ignored. SNI does not work for IP addresses.

--- a/generated/1.18/crds/config.supervisor.pinniped.dev_federationdomains.yaml
+++ b/generated/1.18/crds/config.supervisor.pinniped.dev_federationdomains.yaml
@@ -76,12 +76,13 @@ spec:
                       so all issuers with the same DNS hostname must use the same
                       SecretName value even if they have different port numbers. \n
                       SecretName is not required when you would like to use only the
-                      HTTP endpoints (e.g. when terminating TLS at an Ingress). It
-                      is also not required when you would like all requests to this
-                      OIDC Provider's HTTPS endpoints to use the default TLS certificate,
-                      which is configured elsewhere. \n When your Issuer URL's host
-                      is an IP address, then this field is ignored. SNI does not work
-                      for IP addresses."
+                      HTTP endpoints (e.g. when the HTTP listener is configured to
+                      listen on loopback interfaces or UNIX domain sockets for traffic
+                      from a service mesh sidecar). It is also not required when you
+                      would like all requests to this OIDC Provider's HTTPS endpoints
+                      to use the default TLS certificate, which is configured elsewhere.
+                      \n When your Issuer URL's host is an IP address, then this field
+                      is ignored. SNI does not work for IP addresses."
                     type: string
                 type: object
             required:

--- a/generated/1.19/README.adoc
+++ b/generated/1.19/README.adoc
@@ -538,7 +538,7 @@ FederationDomainTLSSpec is a struct that describes the TLS configuration for an 
 | *`secretName`* __string__ | SecretName is an optional name of a Secret in the same namespace, of type `kubernetes.io/tls`, which contains the TLS serving certificate for the HTTPS endpoints served by this FederationDomain. When provided, the TLS Secret named here must contain keys named `tls.crt` and `tls.key` that contain the certificate and private key to use for TLS. 
  Server Name Indication (SNI) is an extension to the Transport Layer Security (TLS) supported by all major browsers. 
  SecretName is required if you would like to use different TLS certificates for issuers of different hostnames. SNI requests do not include port numbers, so all issuers with the same DNS hostname must use the same SecretName value even if they have different port numbers. 
- SecretName is not required when you would like to use only the HTTP endpoints (e.g. when terminating TLS at an Ingress). It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to use the default TLS certificate, which is configured elsewhere. 
+ SecretName is not required when you would like to use only the HTTP endpoints (e.g. when the HTTP listener is configured to listen on loopback interfaces or UNIX domain sockets for traffic from a service mesh sidecar). It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to use the default TLS certificate, which is configured elsewhere. 
  When your Issuer URL's host is an IP address, then this field is ignored. SNI does not work for IP addresses.
 |===
 

--- a/generated/1.19/apis/supervisor/config/v1alpha1/types_federationdomain.go
+++ b/generated/1.19/apis/supervisor/config/v1alpha1/types_federationdomain.go
@@ -31,8 +31,9 @@ type FederationDomainTLSSpec struct {
 	// SNI requests do not include port numbers, so all issuers with the same DNS hostname must use the same
 	// SecretName value even if they have different port numbers.
 	//
-	// SecretName is not required when you would like to use only the HTTP endpoints (e.g. when terminating TLS at an
-	// Ingress). It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to
+	// SecretName is not required when you would like to use only the HTTP endpoints (e.g. when the HTTP listener is
+	// configured to listen on loopback interfaces or UNIX domain sockets for traffic from a service mesh sidecar).
+	// It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to
 	// use the default TLS certificate, which is configured elsewhere.
 	//
 	// When your Issuer URL's host is an IP address, then this field is ignored. SNI does not work for IP addresses.

--- a/generated/1.19/crds/config.supervisor.pinniped.dev_federationdomains.yaml
+++ b/generated/1.19/crds/config.supervisor.pinniped.dev_federationdomains.yaml
@@ -76,12 +76,13 @@ spec:
                       so all issuers with the same DNS hostname must use the same
                       SecretName value even if they have different port numbers. \n
                       SecretName is not required when you would like to use only the
-                      HTTP endpoints (e.g. when terminating TLS at an Ingress). It
-                      is also not required when you would like all requests to this
-                      OIDC Provider's HTTPS endpoints to use the default TLS certificate,
-                      which is configured elsewhere. \n When your Issuer URL's host
-                      is an IP address, then this field is ignored. SNI does not work
-                      for IP addresses."
+                      HTTP endpoints (e.g. when the HTTP listener is configured to
+                      listen on loopback interfaces or UNIX domain sockets for traffic
+                      from a service mesh sidecar). It is also not required when you
+                      would like all requests to this OIDC Provider's HTTPS endpoints
+                      to use the default TLS certificate, which is configured elsewhere.
+                      \n When your Issuer URL's host is an IP address, then this field
+                      is ignored. SNI does not work for IP addresses."
                     type: string
                 type: object
             required:

--- a/generated/1.20/README.adoc
+++ b/generated/1.20/README.adoc
@@ -538,7 +538,7 @@ FederationDomainTLSSpec is a struct that describes the TLS configuration for an 
 | *`secretName`* __string__ | SecretName is an optional name of a Secret in the same namespace, of type `kubernetes.io/tls`, which contains the TLS serving certificate for the HTTPS endpoints served by this FederationDomain. When provided, the TLS Secret named here must contain keys named `tls.crt` and `tls.key` that contain the certificate and private key to use for TLS. 
  Server Name Indication (SNI) is an extension to the Transport Layer Security (TLS) supported by all major browsers. 
  SecretName is required if you would like to use different TLS certificates for issuers of different hostnames. SNI requests do not include port numbers, so all issuers with the same DNS hostname must use the same SecretName value even if they have different port numbers. 
- SecretName is not required when you would like to use only the HTTP endpoints (e.g. when terminating TLS at an Ingress). It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to use the default TLS certificate, which is configured elsewhere. 
+ SecretName is not required when you would like to use only the HTTP endpoints (e.g. when the HTTP listener is configured to listen on loopback interfaces or UNIX domain sockets for traffic from a service mesh sidecar). It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to use the default TLS certificate, which is configured elsewhere. 
  When your Issuer URL's host is an IP address, then this field is ignored. SNI does not work for IP addresses.
 |===
 

--- a/generated/1.20/apis/supervisor/config/v1alpha1/types_federationdomain.go
+++ b/generated/1.20/apis/supervisor/config/v1alpha1/types_federationdomain.go
@@ -31,8 +31,9 @@ type FederationDomainTLSSpec struct {
 	// SNI requests do not include port numbers, so all issuers with the same DNS hostname must use the same
 	// SecretName value even if they have different port numbers.
 	//
-	// SecretName is not required when you would like to use only the HTTP endpoints (e.g. when terminating TLS at an
-	// Ingress). It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to
+	// SecretName is not required when you would like to use only the HTTP endpoints (e.g. when the HTTP listener is
+	// configured to listen on loopback interfaces or UNIX domain sockets for traffic from a service mesh sidecar).
+	// It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to
 	// use the default TLS certificate, which is configured elsewhere.
 	//
 	// When your Issuer URL's host is an IP address, then this field is ignored. SNI does not work for IP addresses.

--- a/generated/1.20/crds/config.supervisor.pinniped.dev_federationdomains.yaml
+++ b/generated/1.20/crds/config.supervisor.pinniped.dev_federationdomains.yaml
@@ -76,12 +76,13 @@ spec:
                       so all issuers with the same DNS hostname must use the same
                       SecretName value even if they have different port numbers. \n
                       SecretName is not required when you would like to use only the
-                      HTTP endpoints (e.g. when terminating TLS at an Ingress). It
-                      is also not required when you would like all requests to this
-                      OIDC Provider's HTTPS endpoints to use the default TLS certificate,
-                      which is configured elsewhere. \n When your Issuer URL's host
-                      is an IP address, then this field is ignored. SNI does not work
-                      for IP addresses."
+                      HTTP endpoints (e.g. when the HTTP listener is configured to
+                      listen on loopback interfaces or UNIX domain sockets for traffic
+                      from a service mesh sidecar). It is also not required when you
+                      would like all requests to this OIDC Provider's HTTPS endpoints
+                      to use the default TLS certificate, which is configured elsewhere.
+                      \n When your Issuer URL's host is an IP address, then this field
+                      is ignored. SNI does not work for IP addresses."
                     type: string
                 type: object
             required:

--- a/generated/1.21/README.adoc
+++ b/generated/1.21/README.adoc
@@ -538,7 +538,7 @@ FederationDomainTLSSpec is a struct that describes the TLS configuration for an 
 | *`secretName`* __string__ | SecretName is an optional name of a Secret in the same namespace, of type `kubernetes.io/tls`, which contains the TLS serving certificate for the HTTPS endpoints served by this FederationDomain. When provided, the TLS Secret named here must contain keys named `tls.crt` and `tls.key` that contain the certificate and private key to use for TLS. 
  Server Name Indication (SNI) is an extension to the Transport Layer Security (TLS) supported by all major browsers. 
  SecretName is required if you would like to use different TLS certificates for issuers of different hostnames. SNI requests do not include port numbers, so all issuers with the same DNS hostname must use the same SecretName value even if they have different port numbers. 
- SecretName is not required when you would like to use only the HTTP endpoints (e.g. when terminating TLS at an Ingress). It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to use the default TLS certificate, which is configured elsewhere. 
+ SecretName is not required when you would like to use only the HTTP endpoints (e.g. when the HTTP listener is configured to listen on loopback interfaces or UNIX domain sockets for traffic from a service mesh sidecar). It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to use the default TLS certificate, which is configured elsewhere. 
  When your Issuer URL's host is an IP address, then this field is ignored. SNI does not work for IP addresses.
 |===
 

--- a/generated/1.21/apis/supervisor/config/v1alpha1/types_federationdomain.go
+++ b/generated/1.21/apis/supervisor/config/v1alpha1/types_federationdomain.go
@@ -31,8 +31,9 @@ type FederationDomainTLSSpec struct {
 	// SNI requests do not include port numbers, so all issuers with the same DNS hostname must use the same
 	// SecretName value even if they have different port numbers.
 	//
-	// SecretName is not required when you would like to use only the HTTP endpoints (e.g. when terminating TLS at an
-	// Ingress). It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to
+	// SecretName is not required when you would like to use only the HTTP endpoints (e.g. when the HTTP listener is
+	// configured to listen on loopback interfaces or UNIX domain sockets for traffic from a service mesh sidecar).
+	// It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to
 	// use the default TLS certificate, which is configured elsewhere.
 	//
 	// When your Issuer URL's host is an IP address, then this field is ignored. SNI does not work for IP addresses.

--- a/generated/1.21/crds/config.supervisor.pinniped.dev_federationdomains.yaml
+++ b/generated/1.21/crds/config.supervisor.pinniped.dev_federationdomains.yaml
@@ -76,12 +76,13 @@ spec:
                       so all issuers with the same DNS hostname must use the same
                       SecretName value even if they have different port numbers. \n
                       SecretName is not required when you would like to use only the
-                      HTTP endpoints (e.g. when terminating TLS at an Ingress). It
-                      is also not required when you would like all requests to this
-                      OIDC Provider's HTTPS endpoints to use the default TLS certificate,
-                      which is configured elsewhere. \n When your Issuer URL's host
-                      is an IP address, then this field is ignored. SNI does not work
-                      for IP addresses."
+                      HTTP endpoints (e.g. when the HTTP listener is configured to
+                      listen on loopback interfaces or UNIX domain sockets for traffic
+                      from a service mesh sidecar). It is also not required when you
+                      would like all requests to this OIDC Provider's HTTPS endpoints
+                      to use the default TLS certificate, which is configured elsewhere.
+                      \n When your Issuer URL's host is an IP address, then this field
+                      is ignored. SNI does not work for IP addresses."
                     type: string
                 type: object
             required:

--- a/generated/1.22/README.adoc
+++ b/generated/1.22/README.adoc
@@ -538,7 +538,7 @@ FederationDomainTLSSpec is a struct that describes the TLS configuration for an 
 | *`secretName`* __string__ | SecretName is an optional name of a Secret in the same namespace, of type `kubernetes.io/tls`, which contains the TLS serving certificate for the HTTPS endpoints served by this FederationDomain. When provided, the TLS Secret named here must contain keys named `tls.crt` and `tls.key` that contain the certificate and private key to use for TLS. 
  Server Name Indication (SNI) is an extension to the Transport Layer Security (TLS) supported by all major browsers. 
  SecretName is required if you would like to use different TLS certificates for issuers of different hostnames. SNI requests do not include port numbers, so all issuers with the same DNS hostname must use the same SecretName value even if they have different port numbers. 
- SecretName is not required when you would like to use only the HTTP endpoints (e.g. when terminating TLS at an Ingress). It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to use the default TLS certificate, which is configured elsewhere. 
+ SecretName is not required when you would like to use only the HTTP endpoints (e.g. when the HTTP listener is configured to listen on loopback interfaces or UNIX domain sockets for traffic from a service mesh sidecar). It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to use the default TLS certificate, which is configured elsewhere. 
  When your Issuer URL's host is an IP address, then this field is ignored. SNI does not work for IP addresses.
 |===
 

--- a/generated/1.22/apis/supervisor/config/v1alpha1/types_federationdomain.go
+++ b/generated/1.22/apis/supervisor/config/v1alpha1/types_federationdomain.go
@@ -31,8 +31,9 @@ type FederationDomainTLSSpec struct {
 	// SNI requests do not include port numbers, so all issuers with the same DNS hostname must use the same
 	// SecretName value even if they have different port numbers.
 	//
-	// SecretName is not required when you would like to use only the HTTP endpoints (e.g. when terminating TLS at an
-	// Ingress). It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to
+	// SecretName is not required when you would like to use only the HTTP endpoints (e.g. when the HTTP listener is
+	// configured to listen on loopback interfaces or UNIX domain sockets for traffic from a service mesh sidecar).
+	// It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to
 	// use the default TLS certificate, which is configured elsewhere.
 	//
 	// When your Issuer URL's host is an IP address, then this field is ignored. SNI does not work for IP addresses.

--- a/generated/1.22/crds/config.supervisor.pinniped.dev_federationdomains.yaml
+++ b/generated/1.22/crds/config.supervisor.pinniped.dev_federationdomains.yaml
@@ -76,12 +76,13 @@ spec:
                       so all issuers with the same DNS hostname must use the same
                       SecretName value even if they have different port numbers. \n
                       SecretName is not required when you would like to use only the
-                      HTTP endpoints (e.g. when terminating TLS at an Ingress). It
-                      is also not required when you would like all requests to this
-                      OIDC Provider's HTTPS endpoints to use the default TLS certificate,
-                      which is configured elsewhere. \n When your Issuer URL's host
-                      is an IP address, then this field is ignored. SNI does not work
-                      for IP addresses."
+                      HTTP endpoints (e.g. when the HTTP listener is configured to
+                      listen on loopback interfaces or UNIX domain sockets for traffic
+                      from a service mesh sidecar). It is also not required when you
+                      would like all requests to this OIDC Provider's HTTPS endpoints
+                      to use the default TLS certificate, which is configured elsewhere.
+                      \n When your Issuer URL's host is an IP address, then this field
+                      is ignored. SNI does not work for IP addresses."
                     type: string
                 type: object
             required:

--- a/generated/1.23/README.adoc
+++ b/generated/1.23/README.adoc
@@ -538,7 +538,7 @@ FederationDomainTLSSpec is a struct that describes the TLS configuration for an 
 | *`secretName`* __string__ | SecretName is an optional name of a Secret in the same namespace, of type `kubernetes.io/tls`, which contains the TLS serving certificate for the HTTPS endpoints served by this FederationDomain. When provided, the TLS Secret named here must contain keys named `tls.crt` and `tls.key` that contain the certificate and private key to use for TLS. 
  Server Name Indication (SNI) is an extension to the Transport Layer Security (TLS) supported by all major browsers. 
  SecretName is required if you would like to use different TLS certificates for issuers of different hostnames. SNI requests do not include port numbers, so all issuers with the same DNS hostname must use the same SecretName value even if they have different port numbers. 
- SecretName is not required when you would like to use only the HTTP endpoints (e.g. when terminating TLS at an Ingress). It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to use the default TLS certificate, which is configured elsewhere. 
+ SecretName is not required when you would like to use only the HTTP endpoints (e.g. when the HTTP listener is configured to listen on loopback interfaces or UNIX domain sockets for traffic from a service mesh sidecar). It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to use the default TLS certificate, which is configured elsewhere. 
  When your Issuer URL's host is an IP address, then this field is ignored. SNI does not work for IP addresses.
 |===
 

--- a/generated/1.23/apis/supervisor/config/v1alpha1/types_federationdomain.go
+++ b/generated/1.23/apis/supervisor/config/v1alpha1/types_federationdomain.go
@@ -31,8 +31,9 @@ type FederationDomainTLSSpec struct {
 	// SNI requests do not include port numbers, so all issuers with the same DNS hostname must use the same
 	// SecretName value even if they have different port numbers.
 	//
-	// SecretName is not required when you would like to use only the HTTP endpoints (e.g. when terminating TLS at an
-	// Ingress). It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to
+	// SecretName is not required when you would like to use only the HTTP endpoints (e.g. when the HTTP listener is
+	// configured to listen on loopback interfaces or UNIX domain sockets for traffic from a service mesh sidecar).
+	// It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to
 	// use the default TLS certificate, which is configured elsewhere.
 	//
 	// When your Issuer URL's host is an IP address, then this field is ignored. SNI does not work for IP addresses.

--- a/generated/1.23/crds/config.supervisor.pinniped.dev_federationdomains.yaml
+++ b/generated/1.23/crds/config.supervisor.pinniped.dev_federationdomains.yaml
@@ -76,12 +76,13 @@ spec:
                       so all issuers with the same DNS hostname must use the same
                       SecretName value even if they have different port numbers. \n
                       SecretName is not required when you would like to use only the
-                      HTTP endpoints (e.g. when terminating TLS at an Ingress). It
-                      is also not required when you would like all requests to this
-                      OIDC Provider's HTTPS endpoints to use the default TLS certificate,
-                      which is configured elsewhere. \n When your Issuer URL's host
-                      is an IP address, then this field is ignored. SNI does not work
-                      for IP addresses."
+                      HTTP endpoints (e.g. when the HTTP listener is configured to
+                      listen on loopback interfaces or UNIX domain sockets for traffic
+                      from a service mesh sidecar). It is also not required when you
+                      would like all requests to this OIDC Provider's HTTPS endpoints
+                      to use the default TLS certificate, which is configured elsewhere.
+                      \n When your Issuer URL's host is an IP address, then this field
+                      is ignored. SNI does not work for IP addresses."
                     type: string
                 type: object
             required:

--- a/generated/latest/apis/supervisor/config/v1alpha1/types_federationdomain.go
+++ b/generated/latest/apis/supervisor/config/v1alpha1/types_federationdomain.go
@@ -31,8 +31,9 @@ type FederationDomainTLSSpec struct {
 	// SNI requests do not include port numbers, so all issuers with the same DNS hostname must use the same
 	// SecretName value even if they have different port numbers.
 	//
-	// SecretName is not required when you would like to use only the HTTP endpoints (e.g. when terminating TLS at an
-	// Ingress). It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to
+	// SecretName is not required when you would like to use only the HTTP endpoints (e.g. when the HTTP listener is
+	// configured to listen on loopback interfaces or UNIX domain sockets for traffic from a service mesh sidecar).
+	// It is also not required when you would like all requests to this OIDC Provider's HTTPS endpoints to
 	// use the default TLS certificate, which is configured elsewhere.
 	//
 	// When your Issuer URL's host is an IP address, then this field is ignored. SNI does not work for IP addresses.

--- a/hack/lib/kind-config/single-node.yaml
+++ b/hack/lib/kind-config/single-node.yaml
@@ -13,13 +13,6 @@ nodes:
     - protocol: TCP
       # This same port number is hardcoded in the integration test setup
       # when creating a Service on a kind cluster. It is used to talk to
-      # the supervisor app via HTTP.
-      containerPort: 31234
-      hostPort: 12345
-      listenAddress: 127.0.0.1
-    - protocol: TCP
-      # This same port number is hardcoded in the integration test setup
-      # when creating a Service on a kind cluster. It is used to talk to
       # the Dex app.
       containerPort: 31235
       hostPort: 12346

--- a/hack/prepare-for-integration-tests.sh
+++ b/hack/prepare-for-integration-tests.sh
@@ -187,7 +187,7 @@ fi
 log_note "Checking for running kind cluster..."
 if ! kind get clusters | grep -q -e '^pinniped$'; then
   log_note "Creating a kind cluster..."
-  # Our kind config exposes node port 31234 as 127.0.0.1:12345, 31243 as 127.0.0.1:12344, and 31235 as 127.0.0.1:12346
+  # Our kind config exposes node port 31243 as 127.0.0.1:12344 and 31235 as 127.0.0.1:12346
   ./hack/kind-up.sh
 else
   if ! kubectl cluster-info | grep -E '(master|control plane)' | grep -q 127.0.0.1; then
@@ -290,8 +290,6 @@ supervisor_app_name="pinniped-supervisor"
 supervisor_namespace="supervisor"
 supervisor_custom_labels="{mySupervisorCustomLabelName: mySupervisorCustomLabelValue}"
 log_level="debug"
-service_http_nodeport_port="80"
-service_http_nodeport_nodeport="31234"
 service_https_nodeport_port="443"
 service_https_nodeport_nodeport="31243"
 service_https_clusterip_port="443"
@@ -311,15 +309,10 @@ else
     --data-value "image_tag=$tag" \
     --data-value "log_level=$log_level" \
     --data-value-yaml "custom_labels=$supervisor_custom_labels" \
-    --data-value-yaml "service_http_nodeport_port=$service_http_nodeport_port" \
-    --data-value-yaml "service_http_nodeport_nodeport=$service_http_nodeport_nodeport" \
     --data-value-yaml "service_https_nodeport_port=$service_https_nodeport_port" \
     --data-value-yaml "service_https_nodeport_nodeport=$service_https_nodeport_nodeport" \
     --data-value-yaml "service_https_clusterip_port=$service_https_clusterip_port" \
     >"$manifest"
-    # example of how to disable the http endpoint
-    # this is left enabled for now because our integration tests still rely on it
-    # --data-value-yaml 'endpoints={"http": {"network": "disabled"}}' \
 
   kapp deploy --yes --app "$supervisor_app_name" --diff-changes --file "$manifest"
   kubectl apply --dry-run=client -f "$manifest" # Validate manifest schema.
@@ -392,7 +385,6 @@ export PINNIPED_TEST_WEBHOOK_CA_BUNDLE=${webhook_ca_bundle}
 export PINNIPED_TEST_SUPERVISOR_NAMESPACE=${supervisor_namespace}
 export PINNIPED_TEST_SUPERVISOR_APP_NAME=${supervisor_app_name}
 export PINNIPED_TEST_SUPERVISOR_CUSTOM_LABELS='${supervisor_custom_labels}'
-export PINNIPED_TEST_SUPERVISOR_HTTP_ADDRESS="127.0.0.1:12345"
 export PINNIPED_TEST_SUPERVISOR_HTTPS_ADDRESS="localhost:12344"
 export PINNIPED_TEST_PROXY=http://127.0.0.1:12346
 export PINNIPED_TEST_LDAP_HOST=ldap.tools.svc.cluster.local

--- a/internal/config/supervisor/config.go
+++ b/internal/config/supervisor/config.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package supervisor contains functionality to load/store Config's from/to
@@ -8,6 +8,7 @@ package supervisor
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
 	"strings"
 
 	"k8s.io/utils/pointer"
@@ -66,14 +67,16 @@ func FromPath(path string) (*Config, error) {
 		Address: ":8443",
 	})
 	maybeSetEndpointDefault(&config.Endpoints.HTTP, Endpoint{
-		Network: NetworkTCP,
-		Address: ":8080",
+		Network: NetworkDisabled,
 	})
 
 	if err := validateEndpoint(*config.Endpoints.HTTPS); err != nil {
 		return nil, fmt.Errorf("validate https endpoint: %w", err)
 	}
 	if err := validateEndpoint(*config.Endpoints.HTTP); err != nil {
+		return nil, fmt.Errorf("validate http endpoint: %w", err)
+	}
+	if err := validateAdditionalHTTPEndpointRequirements(*config.Endpoints.HTTP); err != nil {
 		return nil, fmt.Errorf("validate http endpoint: %w", err)
 	}
 	if err := validateAtLeastOneEnabledEndpoint(*config.Endpoints.HTTPS, *config.Endpoints.HTTP); err != nil {
@@ -128,6 +131,16 @@ func validateEndpoint(endpoint Endpoint) error {
 	}
 }
 
+func validateAdditionalHTTPEndpointRequirements(endpoint Endpoint) error {
+	if endpoint.Network == NetworkTCP && !addrIsOnlyOnLoopback(endpoint.Address) {
+		return fmt.Errorf(
+			"http listener address %q for %q network may only bind to loopback interfaces",
+			endpoint.Address,
+			endpoint.Network)
+	}
+	return nil
+}
+
 func validateAtLeastOneEnabledEndpoint(endpoints ...Endpoint) error {
 	for _, endpoint := range endpoints {
 		if endpoint.Network != NetworkDisabled {
@@ -135,4 +148,37 @@ func validateAtLeastOneEnabledEndpoint(endpoints ...Endpoint) error {
 		}
 	}
 	return constable.Error("all endpoints are disabled")
+}
+
+// For tcp networks, the address can be in several formats: host:port, host:, and :port.
+// See address description in https://pkg.go.dev/net#Listen and https://pkg.go.dev/net#Dial.
+// The host may be a literal IP address, or a host name that can be resolved to IP addresses,
+// or a literal unspecified IP address (as in "0.0.0.0:80" or "[::]:80"), or empty.
+// If the host is a literal IPv6 address it must be enclosed in square brackets, as in "[2001:db8::1]:80" or
+// "[fe80::1%zone]:80". The zone specifies the scope of the literal IPv6 address as defined in RFC 4007.
+// The port may be a literal port number or a service name, the value 0, or empty.
+// Returns true if a net.Listen listener at this address would only listen on loopback interfaces.
+// Returns false if the listener would listen on any non-loopback interfaces, or when called with illegal input.
+func addrIsOnlyOnLoopback(addr string) bool {
+	// First try parsing as a `host:port`. net.SplitHostPort allows empty host and empty port.
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		// Illegal input.
+		return false
+	}
+	if host == "" {
+		// Input was :port. This would bind to all interfaces, so it is not only on loopback.
+		return false
+	}
+	if host == "localhost" {
+		// This is only on loopback.
+		return true
+	}
+	// The host could be a hostname, an IPv4 address, or an IPv6 address.
+	ip := net.ParseIP(host)
+	if ip == nil {
+		// The address was not an IP. It must have been some hostname other than "localhost".
+		return false
+	}
+	return ip.IsLoopback()
 }

--- a/internal/config/supervisor/config.go
+++ b/internal/config/supervisor/config.go
@@ -131,9 +131,9 @@ func validateEndpoint(endpoint Endpoint) error {
 	}
 }
 
-func validateAdditionalHTTPEndpointRequirements(endpoint Endpoint, allowExternalHTTP string) error {
+func validateAdditionalHTTPEndpointRequirements(endpoint Endpoint, allowExternalHTTP stringOrBoolAsBool) error {
 	if endpoint.Network == NetworkTCP && !addrIsOnlyOnLoopback(endpoint.Address) {
-		if allowExternalHTTP == "true" {
+		if allowExternalHTTP {
 			// Log that the validation should have been triggered.
 			plog.Warning("Listening on non-loopback interfaces for the HTTP port is deprecated and will be removed " +
 				"in a future release. Your current configuration would not be allowed in that future release. " +

--- a/internal/config/supervisor/types.go
+++ b/internal/config/supervisor/types.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package supervisor
@@ -7,11 +7,12 @@ import "go.pinniped.dev/internal/plog"
 
 // Config contains knobs to setup an instance of the Pinniped Supervisor.
 type Config struct {
-	APIGroupSuffix *string           `json:"apiGroupSuffix,omitempty"`
-	Labels         map[string]string `json:"labels"`
-	NamesConfig    NamesConfigSpec   `json:"names"`
-	LogLevel       plog.LogLevel     `json:"logLevel"`
-	Endpoints      *Endpoints        `json:"endpoints"`
+	APIGroupSuffix    *string           `json:"apiGroupSuffix,omitempty"`
+	Labels            map[string]string `json:"labels"`
+	NamesConfig       NamesConfigSpec   `json:"names"`
+	LogLevel          plog.LogLevel     `json:"logLevel"`
+	Endpoints         *Endpoints        `json:"endpoints"`
+	AllowExternalHTTP string            `json:"insecure_accept_external_unencrypted_http_requests"`
 }
 
 // NamesConfigSpec configures the names of some Kubernetes resources for the Supervisor.

--- a/internal/config/supervisor/types.go
+++ b/internal/config/supervisor/types.go
@@ -3,16 +3,20 @@
 
 package supervisor
 
-import "go.pinniped.dev/internal/plog"
+import (
+	"errors"
+
+	"go.pinniped.dev/internal/plog"
+)
 
 // Config contains knobs to setup an instance of the Pinniped Supervisor.
 type Config struct {
-	APIGroupSuffix    *string           `json:"apiGroupSuffix,omitempty"`
-	Labels            map[string]string `json:"labels"`
-	NamesConfig       NamesConfigSpec   `json:"names"`
-	LogLevel          plog.LogLevel     `json:"logLevel"`
-	Endpoints         *Endpoints        `json:"endpoints"`
-	AllowExternalHTTP string            `json:"insecure_accept_external_unencrypted_http_requests"`
+	APIGroupSuffix    *string            `json:"apiGroupSuffix,omitempty"`
+	Labels            map[string]string  `json:"labels"`
+	NamesConfig       NamesConfigSpec    `json:"names"`
+	LogLevel          plog.LogLevel      `json:"logLevel"`
+	Endpoints         *Endpoints         `json:"endpoints"`
+	AllowExternalHTTP stringOrBoolAsBool `json:"insecureAcceptExternalUnencryptedHttpRequests"`
 }
 
 // NamesConfigSpec configures the names of some Kubernetes resources for the Supervisor.
@@ -28,4 +32,18 @@ type Endpoints struct {
 type Endpoint struct {
 	Network string `json:"network"`
 	Address string `json:"address"`
+}
+
+type stringOrBoolAsBool bool
+
+func (sb *stringOrBoolAsBool) UnmarshalJSON(b []byte) error {
+	switch string(b) {
+	case "true", `"true"`:
+		*sb = true
+	case "false", `"false"`:
+		*sb = false
+	default:
+		return errors.New("invalid value for boolean")
+	}
+	return nil
 }

--- a/site/content/docs/howto/configure-supervisor.md
+++ b/site/content/docs/howto/configure-supervisor.md
@@ -46,26 +46,26 @@ The most common ways are:
   configured with TLS certificates and will terminate the TLS connection itself (see the section about FederationDomain
   below). The LoadBalancer Service should be configured to use the HTTPS port 443 of the Supervisor pods as its `targetPort`.
 
-  *Warning:* Never expose the Supervisor's HTTP port 8080 to the public. It would not be secure for the OIDC protocol
-  to use HTTP, because the user's secret OIDC tokens would be transmitted across the network without encryption.
-
 - Or, define an [Ingress resource](https://kubernetes.io/docs/concepts/services-networking/ingress/).
 
    In this case, the [Ingress typically terminates TLS](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls)
-   and then talks plain HTTP to its backend,
-   which would be a NodePort or LoadBalancer Service in front of the HTTP port 8080 of the Supervisor pods.
-   However, because the Supervisor's endpoints deal with sensitive credentials, it is much better if the
-   traffic is encrypted using TLS all the way into the Supervisor's Pods. Some Ingress implementations
-   may support re-encrypting the traffic before sending it to the backend. If your Ingress controller does not
-   support this, then consider using one of the other configurations described here instead of using an Ingress.
+   and then talks plain HTTP to its backend.
+   However, because the Supervisor's endpoints deal with sensitive credentials, the ingress must be configured to re-encrypt
+   traffic using TLS on the backend (upstream) into the Supervisor's Pods. It would not be secure for the OIDC protocol
+   to use HTTP, because the user's secret OIDC tokens would be transmitted across the network without encryption.
+   If your Ingress controller does not support this feature, then consider using one of the other configurations
+   described here instead of using an Ingress. The backend of the Ingress would typically point to a NodePort or
+   LoadBalancer Service which exposes the HTTPS port 8443 of the Supervisor pods.
 
    The required configuration of the Ingress is specific to your cluster's Ingress Controller, so please refer to the
    documentation from your Kubernetes provider. If you are using a cluster from a cloud provider, then you'll probably
    want to start with that provider's documentation. For example, if your cluster is a Google GKE cluster, refer to
-   the [GKE documentation for Ingress](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress).
+   the [GKE documentation for Ingress](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress) and the
+   [GKE documentation for enabling TLS on the backend of an Ingress](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress-xlb#https_tls_between_load_balancer_and_your_application).
    Otherwise, the Kubernetes documentation provides a list of popular
    [Ingress Controllers](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/), including
-   [Contour](https://projectcontour.io/) and many others.
+   [Contour](https://projectcontour.io/) and many others. Contour is an example of an ingress implementation which
+   [supports TLS on the backend](https://projectcontour.io/docs/main/config/upstream-tls/).
 
 - Or, expose the Supervisor app using a Kubernetes service mesh technology (e.g. [Istio](https://istio.io/)).
 
@@ -133,7 +133,7 @@ spec:
   ports:
   - protocol: TCP
     port: 443
-    targetPort: 8443 # 8443 is the TLS port. Do not expose port 8080.
+    targetPort: 8443 # 8443 is the TLS port.
 ```
 
 ### Example: Creating a NodePort Service

--- a/site/content/docs/howto/configure-supervisor.md
+++ b/site/content/docs/howto/configure-supervisor.md
@@ -55,7 +55,11 @@ The most common ways are:
    to use HTTP, because the user's secret OIDC tokens would be transmitted across the network without encryption.
    If your Ingress controller does not support this feature, then consider using one of the other configurations
    described here instead of using an Ingress. The backend of the Ingress would typically point to a NodePort or
-   LoadBalancer Service which exposes the HTTPS port 8443 of the Supervisor pods.
+   LoadBalancer Service which exposes the HTTPS port 8443 of the Supervisor pods. (Using plain HTTP from the Ingress
+   to the Supervisor pods is deprecated and will be removed in a future release. To aid in transition, it may be enabled
+   using the `insecure_accept_external_unencrypted_http_requests` value in
+   [values.yaml](https://github.com/vmware-tanzu/pinniped/blob/main/deploy/supervisor/values.yaml),
+   until that setting is removed in a future release.)
 
    The required configuration of the Ingress is specific to your cluster's Ingress Controller, so please refer to the
    documentation from your Kubernetes provider. If you are using a cluster from a cloud provider, then you'll probably
@@ -65,7 +69,9 @@ The most common ways are:
    Otherwise, the Kubernetes documentation provides a list of popular
    [Ingress Controllers](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/), including
    [Contour](https://projectcontour.io/) and many others. Contour is an example of an ingress implementation which
-   [supports TLS on the backend](https://projectcontour.io/docs/main/config/upstream-tls/).
+   [supports TLS on the backend](https://projectcontour.io/docs/main/config/upstream-tls/),
+   along with [TLS session proxying and TLS session pass-through](https://projectcontour.io/docs/main/config/tls-termination/)
+   as alternative ways to maintain TLS all the way to the backend service.
 
 - Or, expose the Supervisor app using a Kubernetes service mesh technology (e.g. [Istio](https://istio.io/)).
 

--- a/site/content/docs/howto/configure-supervisor.md
+++ b/site/content/docs/howto/configure-supervisor.md
@@ -29,13 +29,17 @@ It is recommended that the traffic to these endpoints should be encrypted via TL
 Supervisor pods, even when crossing boundaries that are entirely inside the Kubernetes cluster.
 The credentials and tokens that are handled by these endpoints are too sensitive to transmit without encryption.
 
-In all versions of the Supervisor app so far, there are both HTTP and HTTPS ports available for use by default.
+In previous versions of the Supervisor app, there were both HTTP and HTTPS ports available for use by default.
 These ports each host all the Supervisor's endpoints. Unfortunately, this has caused some confusion in the community
 and some blog posts have been written which demonstrate using the HTTP port in such a way that a portion of the traffic's
-path is unencrypted. **Anything which exposes the non-TLS HTTP port outside the Pod should be considered deprecated**.
-A future version of the Supervisor app may include a breaking change to adjust the default behavior of the HTTP port
-to only listen on 127.0.0.1 (or perhaps even to be disabled) to make it more clear that the Supervisor app is not intended
-to receive non-TLS HTTP traffic from outside the Pod.
+path is unencrypted. Newer versions of the Supervisor disable the HTTP port by default to make it more clear that
+the Supervisor app is not intended to receive non-TLS HTTP traffic from outside the Pod. Furthermore, in these newer versions,
+when the HTTP listener is configured to be enabled it may only listen on loopback interfaces for traffic from within its own pod.
+To aid in transition for impacted users, the old behavior of allowing the HTTP listener to receive traffic from
+outside the pod may be re-enabled using the
+`deprecated_insecure_accept_external_unencrypted_http_requests` value in
+[values.yaml](https://github.com/vmware-tanzu/pinniped/blob/main/deploy/supervisor/values.yaml),
+until that setting is removed in a future release.
 
 Because there are many ways to expose TLS services from a Kubernetes cluster, the Supervisor app leaves this up to the user.
 The most common ways are:
@@ -54,12 +58,9 @@ The most common ways are:
    traffic using TLS on the backend (upstream) into the Supervisor's Pods. It would not be secure for the OIDC protocol
    to use HTTP, because the user's secret OIDC tokens would be transmitted across the network without encryption.
    If your Ingress controller does not support this feature, then consider using one of the other configurations
-   described here instead of using an Ingress. The backend of the Ingress would typically point to a NodePort or
-   LoadBalancer Service which exposes the HTTPS port 8443 of the Supervisor pods. (Using plain HTTP from the Ingress
-   to the Supervisor pods is deprecated and will be removed in a future release. To aid in transition, it may be enabled
-   using the `insecure_accept_external_unencrypted_http_requests` value in
-   [values.yaml](https://github.com/vmware-tanzu/pinniped/blob/main/deploy/supervisor/values.yaml),
-   until that setting is removed in a future release.)
+   described here instead of using an Ingress. (Please refer to the paragraph above regarding the deprecation of the HTTP listener for more
+   information.) The backend of the Ingress would typically point to a NodePort or LoadBalancer Service which exposes
+   the HTTPS port 8443 of the Supervisor pods.
 
    The required configuration of the Ingress is specific to your cluster's Ingress Controller, so please refer to the
    documentation from your Kubernetes provider. If you are using a cluster from a cloud provider, then you'll probably
@@ -81,24 +82,25 @@ The most common ways are:
 
    If your service mesh is capable of transparently encrypting traffic all the way into the
    Supervisor Pods, then you should use that capability. In this case, it may make sense to configure the Supervisor's
-   HTTP port to only listen on a Unix domain socket, such as when the service mesh injects a sidecar container that can
-   securely access the socket from within the same Pod.
+   HTTP port to listen on a Unix domain socket, such as when the service mesh injects a sidecar container that can
+   securely access the socket from within the same Pod. Alternatively, the HTTP port can be configured as a TCP listener
+   on loopback interfaces to receive traffic from sidecar containers.
    See the `endpoints` option in [deploy/supervisor/values.yml](https://github.com/vmware-tanzu/pinniped/blob/main/deploy/supervisor/values.yaml)
    for more information.
-   This would prevent any unencrypted traffic from accidentally being transmitted from outside the Pod into the
-   Supervisor app's HTTP port.
+   Using either a Unix domain socket or a loopback interface listener would prevent any unencrypted traffic from
+   accidentally being transmitted from outside the Pod into the Supervisor app's HTTP port.
 
    For example, the following high level steps cover configuring Istio for use with the Supervisor:
 
-   - Update the http listener to use a Unix domain socket
+   - Update the HTTP listener to use a Unix domain socket
      i.e. `--data-value-yaml 'endpoints={"http":{"network":"unix","address":"/pinniped_socket/socketfile.sock"}}'`
    - Arrange for the Istio sidecar to be injected into the Supervisor app with an appropriate `IstioIngressListener`
      i.e `defaultEndpoint: unix:///pinniped_socket/socketfile.sock`
    - Mount the socket volume into the Istio sidecar container by including the appropriate annotation on the Supervisor pods
      i.e. `sidecar.istio.io/userVolumeMount: '{"socket":{"mountPath":"/pinniped_socket"}}'`
-   - Disable the https listener and update the deployment health checks as desired
+   - Disable the HTTPS listener and update the deployment health checks as desired
 
-   For service meshes that do not support Unix domain sockets, the http listener should be configured to listen on 127.0.0.1.
+   For service meshes that do not support Unix domain sockets, the HTTP listener should be configured as a TCP listener on a loopback interface.
 
 ## Creating a Service to expose the Supervisor app's endpoints within the cluster
 

--- a/site/content/docs/tutorials/concierge-and-supervisor-demo.md
+++ b/site/content/docs/tutorials/concierge-and-supervisor-demo.md
@@ -218,7 +218,7 @@ spec:
   ports:
   - protocol: TCP
     port: 443
-    targetPort: 8443 # 8443 is the TLS port. Do not expose port 8080.
+    targetPort: 8443 # 8443 is the TLS port.
 EOF
 ```
 

--- a/test/testlib/env.go
+++ b/test/testlib/env.go
@@ -48,7 +48,6 @@ type TestEnv struct {
 	KubernetesDistribution         KubeDistro                           `json:"kubernetesDistribution"`
 	Capabilities                   map[Capability]bool                  `json:"capabilities"`
 	TestWebhook                    auth1alpha1.WebhookAuthenticatorSpec `json:"testWebhook"`
-	SupervisorHTTPAddress          string                               `json:"supervisorHttpAddress"`
 	SupervisorHTTPSAddress         string                               `json:"supervisorHttpsAddress"`
 	SupervisorHTTPSIngressAddress  string                               `json:"supervisorHttpsIngressAddress"`
 	SupervisorHTTPSIngressCABundle string                               `json:"supervisorHttpsIngressCABundle"`
@@ -207,12 +206,7 @@ func loadEnvVars(t *testing.T, result *TestEnv) {
 	result.SupervisorAppName = needEnv(t, "PINNIPED_TEST_SUPERVISOR_APP_NAME")
 	result.TestWebhook.TLS = &auth1alpha1.TLSSpec{CertificateAuthorityData: needEnv(t, "PINNIPED_TEST_WEBHOOK_CA_BUNDLE")}
 
-	result.SupervisorHTTPAddress = os.Getenv("PINNIPED_TEST_SUPERVISOR_HTTP_ADDRESS")
-	result.SupervisorHTTPSIngressAddress = os.Getenv("PINNIPED_TEST_SUPERVISOR_HTTPS_INGRESS_ADDRESS")
-	require.NotEmptyf(t,
-		result.SupervisorHTTPAddress+result.SupervisorHTTPSIngressAddress,
-		"must specify either PINNIPED_TEST_SUPERVISOR_HTTP_ADDRESS or PINNIPED_TEST_SUPERVISOR_HTTPS_INGRESS_ADDRESS env var (or both) for integration tests",
-	)
+	result.SupervisorHTTPSIngressAddress = needEnv(t, "PINNIPED_TEST_SUPERVISOR_HTTPS_INGRESS_ADDRESS")
 	result.SupervisorHTTPSAddress = needEnv(t, "PINNIPED_TEST_SUPERVISOR_HTTPS_ADDRESS")
 	require.NotRegexp(t, "^[0-9]", result.SupervisorHTTPSAddress,
 		"PINNIPED_TEST_SUPERVISOR_HTTPS_ADDRESS must be a hostname with an optional port and cannot be an IP address",


### PR DESCRIPTION
Disable the Supervisor's HTTP listener by default, and do not allow it to be configured to bind to anything other than loopback interfaces.

This is a breaking change intended to make it difficult to install and configure Pinniped in such a way that the TCP traffic going in and out of the Supervisor pods is not using TLS. That traffic includes credentials and secrets and should be encrypted using TLS.

This PR also deprecates the related `service_http_*` values in values.yaml by renaming them and causing a ytt render error when the old names are used, to make it obvious upon upgrade to any users of these values that they have been deprecated.

Existing installations using an Ingress to route traffic on its backend into the Supervisor's HTTP port without TLS will need to reconfigure the Ingress to instead use TLS on the backend into the Supervisor's HTTPS port before upgrading. If your Ingress controller does not support TLS on the backend, then another means of routing traffic will need to be used.

This PR does not change the configuration options for the HTTPS listener port at all. It also does not change the user's ability to do the following with the HTTP (non-TLS) listener port:
- May still enable or disable the HTTP listening port
- May still configure the HTTP listening port to listen on tcp loopback interfaces (ipv4, ipv6, or both) or on a unix domain socket file for listening for connections from inside the pod, for example connections from a service mesh's sidecar container
- May still choose the port number for the HTTP listening port

In recognition that it may take some users time to adjust to this breaking change, a new `deprecated_insecure_accept_external_unencrypted_http_requests` value has been introduced in `deploy/supervisor/values.yaml`. This can be used to bring back the old behavior by turning the new validation into a warning in the pod logs instead of an error which stops the Supervisor from starting. In some future release, this override will be removed and at that time the validation will always be an error. We plan to give sufficient time, probably several releases, before removing this override option.

If you have feedback regarding this breaking change, please reach out to the maintainers.

Addresses #981.

**Release note**:

```release-note
Breaking change: Disable the Supervisor's HTTP listener by default, and do not allow it to be configured to bind to anything other than loopback interfaces. Also temporarily provide a way to override this new restriction to help ease the transition for impacted users.
```
