### PR TITLE
Bump to go1.18.1 and fix linter errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.17.8 as build-env
+FROM golang:1.18.1 as build-env
 
 WORKDIR /work
 COPY . .

--- a/cmd/pinniped/cmd/kubeconfig.go
+++ b/cmd/pinniped/cmd/kubeconfig.go
@@ -714,7 +714,7 @@ func validateKubeconfig(ctx context.Context, flags getKubeconfigParams, kubeconf
 func countCACerts(pemData []byte) int {
 	pool := x509.NewCertPool()
 	pool.AppendCertsFromPEM(pemData)
-	return len(pool.Subjects())
+	return len(pool.Subjects()) // nolint: staticcheck  // not system cert pool
 }
 
 func hasPendingStrategy(credentialIssuer *configv1alpha1.CredentialIssuer) bool {

--- a/internal/certauthority/certauthority_test.go
+++ b/internal/certauthority/certauthority_test.go
@@ -206,7 +206,7 @@ func TestPool(t *testing.T) {
 	require.NoError(t, err)
 
 	pool := ca.Pool()
-	require.Len(t, pool.Subjects(), 1)
+	require.Len(t, pool.Subjects(), 1) // nolint: staticcheck  // not system cert pool
 }
 
 type errSigner struct {

--- a/internal/dynamiccert/provider_test.go
+++ b/internal/dynamiccert/provider_test.go
@@ -41,7 +41,7 @@ func TestProviderWithDynamicServingCertificateController(t *testing.T) {
 				cert, err := tls.X509KeyPair(certPEM, keyPEM)
 				require.NoError(t, err)
 
-				return pool.Subjects(), []tls.Certificate{cert}
+				return pool.Subjects(), []tls.Certificate{cert} // nolint: staticcheck  // not system cert pool
 			},
 		},
 		{
@@ -69,7 +69,7 @@ func TestProviderWithDynamicServingCertificateController(t *testing.T) {
 
 				certKey.UnsetCertKeyContent()
 
-				return pool.Subjects(), []tls.Certificate{cert}
+				return pool.Subjects(), []tls.Certificate{cert} // nolint: staticcheck  // not system cert pool
 			},
 		},
 		{
@@ -87,7 +87,7 @@ func TestProviderWithDynamicServingCertificateController(t *testing.T) {
 				cert, err := tls.X509KeyPair(certPEM, keyPEM)
 				require.NoError(t, err)
 
-				return newCA.Pool().Subjects(), []tls.Certificate{cert}
+				return newCA.Pool().Subjects(), []tls.Certificate{cert} // nolint: staticcheck  // not system cert pool
 			},
 		},
 		{
@@ -110,7 +110,7 @@ func TestProviderWithDynamicServingCertificateController(t *testing.T) {
 				ok := pool.AppendCertsFromPEM(ca.CurrentCABundleContent())
 				require.True(t, ok, "should have valid non-empty CA bundle")
 
-				return pool.Subjects(), []tls.Certificate{cert}
+				return pool.Subjects(), []tls.Certificate{cert} // nolint: staticcheck  // not system cert pool
 			},
 		},
 		{
@@ -137,7 +137,7 @@ func TestProviderWithDynamicServingCertificateController(t *testing.T) {
 				err = ca.SetCertKeyContent(newOtherCA.Bundle(), caKey)
 				require.NoError(t, err)
 
-				return newOtherCA.Pool().Subjects(), []tls.Certificate{cert}
+				return newOtherCA.Pool().Subjects(), []tls.Certificate{cert} // nolint: staticcheck  // not system cert pool
 			},
 		},
 	}
@@ -221,7 +221,7 @@ func poolSubjects(pool *x509.CertPool) [][]byte {
 	if pool == nil {
 		return nil
 	}
-	return pool.Subjects()
+	return pool.Subjects() // nolint: staticcheck  // not system cert pool
 }
 
 func TestNewServingCert(t *testing.T) {

--- a/internal/kubeclient/kubeclient_test.go
+++ b/internal/kubeclient/kubeclient_test.go
@@ -949,7 +949,7 @@ func TestUnwrap(t *testing.T) {
 
 	server, restConfig := fakekubeapi.Start(t, nil)
 
-	serverSubjects := server.Client().Transport.(*http.Transport).TLSClientConfig.RootCAs.Subjects()
+	serverSubjects := server.Client().Transport.(*http.Transport).TLSClientConfig.RootCAs.Subjects() // nolint: staticcheck  // not system cert pool
 
 	t.Run("regular client", func(t *testing.T) {
 		t.Parallel() // make sure to run in parallel to confirm that our client-go TLS cache busting works (i.e. assert no data races)
@@ -1121,7 +1121,7 @@ func testUnwrap(t *testing.T, client *Client, serverSubjects [][]byte) {
 			require.Equal(t, secureTLSConfig.NextProtos, tlsConfig.NextProtos)
 
 			// x509.CertPool has some embedded functions that make it hard to compare so just look at the subjects
-			require.Equal(t, serverSubjects, tlsConfig.RootCAs.Subjects())
+			require.Equal(t, serverSubjects, tlsConfig.RootCAs.Subjects()) // nolint: staticcheck  // not system cert pool
 		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: Monis Khan <mok@vmware.com>

**Release note**:

```release-note
Pinniped components are now compiled with Go 1.18.1.
```