### PR TITLE
Error format of untrusted certificate errors should depend on OS

### DIFF
--- a/cmd/pinniped/cmd/kubeconfig_test.go
+++ b/cmd/pinniped/cmd/kubeconfig_test.go
@@ -955,7 +955,7 @@ func TestGetKubeconfig(t *testing.T) {
 			},
 			wantError: true,
 			wantStderr: func(issuerCABundle string, issuerURL string) string {
-				return fmt.Sprintf("Error: while fetching OIDC discovery data from issuer: Get \"%s/.well-known/openid-configuration\": x509: certificate signed by unknown authority\n", issuerURL)
+				return fmt.Sprintf("Error: while fetching OIDC discovery data from issuer: Get \"%s/.well-known/openid-configuration\": %s\n", issuerURL, testutil.X509UntrustedCertError("Acme Co"))
 			},
 		},
 		{

--- a/internal/controller/authenticator/jwtcachefiller/jwtcachefiller_test.go
+++ b/internal/controller/authenticator/jwtcachefiller/jwtcachefiller_test.go
@@ -36,6 +36,7 @@ import (
 	"go.pinniped.dev/internal/controllerlib"
 	"go.pinniped.dev/internal/crypto/ptls"
 	"go.pinniped.dev/internal/mocks/mocktokenauthenticatorcloser"
+	"go.pinniped.dev/internal/testutil"
 	"go.pinniped.dev/internal/testutil/testlogger"
 	"go.pinniped.dev/internal/testutil/tlsserver"
 )
@@ -293,7 +294,7 @@ func TestController(t *testing.T) {
 					Spec: *missingTLSJWTAuthenticatorSpec,
 				},
 			},
-			wantErr: `failed to build jwt authenticator: could not initialize provider: Get "` + goodIssuer + `/.well-known/openid-configuration": x509: certificate signed by unknown authority`,
+			wantErr: `failed to build jwt authenticator: could not initialize provider: Get "` + goodIssuer + `/.well-known/openid-configuration": ` + testutil.X509UntrustedCertError("Acme Co"),
 		},
 		{
 			name:    "invalid jwt authenticator CA",

--- a/internal/testutil/x509_error.go
+++ b/internal/testutil/x509_error.go
@@ -1,0 +1,19 @@
+// Copyright 2022 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package testutil
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func X509UntrustedCertError(commonName string) string {
+	if runtime.GOOS == "darwin" {
+		// Golang use's macos' x509 verification APIs on darwin.
+		// This output slightly different error messages than golang's
+		// own x509 verification.
+		return fmt.Sprintf(`x509: “%s” certificate is not trusted`, commonName)
+	}
+	return `x509: certificate signed by unknown authority`
+}

--- a/internal/upstreamldap/upstreamldap_test.go
+++ b/internal/upstreamldap/upstreamldap_test.go
@@ -1905,7 +1905,7 @@ func TestRealTLSDialing(t *testing.T) {
 			caBundle:  nil,
 			connProto: TLS,
 			context:   context.Background(),
-			wantError: `LDAP Result Code 200 "Network Error": x509: certificate signed by unknown authority`,
+			wantError: fmt.Sprintf(`LDAP Result Code 200 "Network Error": %s`, testutil.X509UntrustedCertError("Acme Co")),
 		},
 		{
 			name: "cannot connect to host",

--- a/test/integration/ldap_client_test.go
+++ b/test/integration/ldap_client_test.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 
 	"go.pinniped.dev/internal/authenticators"
+	"go.pinniped.dev/internal/testutil"
 	"go.pinniped.dev/internal/upstreamldap"
 	"go.pinniped.dev/test/testlib"
 )
@@ -467,7 +468,7 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 			username:  "pinny",
 			password:  pinnyPassword,
 			provider:  upstreamldap.New(*providerConfig(func(p *upstreamldap.ProviderConfig) { p.CABundle = nil })),
-			wantError: fmt.Sprintf(`error dialing host "127.0.0.1:%s": LDAP Result Code 200 "Network Error": x509: certificate signed by unknown authority`, ldapsLocalhostPort),
+			wantError: fmt.Sprintf(`error dialing host "127.0.0.1:%s": LDAP Result Code 200 "Network Error": %s`, ldapsLocalhostPort, testutil.X509UntrustedCertError("Pinniped Test")),
 		},
 		{
 			name:     "when the CA bundle does not cause the host to be trusted with StartTLS",
@@ -478,7 +479,7 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 				p.ConnectionProtocol = upstreamldap.StartTLS
 				p.CABundle = nil
 			})),
-			wantError: fmt.Sprintf(`error dialing host "127.0.0.1:%s": LDAP Result Code 200 "Network Error": TLS handshake failed (x509: certificate signed by unknown authority)`, ldapLocalhostPort),
+			wantError: fmt.Sprintf(`error dialing host "127.0.0.1:%s": LDAP Result Code 200 "Network Error": TLS handshake failed (%s)`, ldapLocalhostPort, testutil.X509UntrustedCertError("Pinniped Test")),
 		},
 		{
 			name:      "when trying to use TLS to connect to a port which only supports StartTLS",


### PR DESCRIPTION
Go 1.18.1 started using MacOS' x509 verification APIs on Macs
rather than Go's own. The error messages are different.

See this commit for details: https://github.com/golang/go/commit/feb024f4153395e5bbb2a51bb3d1ddc4f5b0d2dc

Signed-off-by: Margo Crawford <margaretc@vmware.com>

<!--
Thank you for submitting a pull request for Pinniped!

Before submitting, please see the guidelines in CONTRIBUTING.md in this repo.

Please note that a project maintainer will need to review and provide an
initial approval on the PR to cause CI tests to automatically start.
Also note that if you push additional commits to the PR, those commits
will need another initial approval before CI will pick them up.

Reminder: Did you remember to run all the linter, unit tests, and integration tests
described in CONTRIBUTING.md on your branch before submitting this PR?

Below is a template to help you describe your PR.
-->

<!--
Provide a summary of your change. Feel free to use paragraphs or a bulleted list, for example:

- Improves performance by 10,000%.
- Fixes all bugs.
- Boils the oceans.

-->

<!--
Does this PR fix one or more reported issues?
If yes, use `Fixes #<issue number>` to automatically close the fixed issue(s) when the PR is merged.
-->

**Release note**:

<!--
Does this PR introduce a user-facing change?

If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
-->
```release-note
NONE
```
No release note needed since the tests were fine on previous go versions.