### PR TITLE
oidc: add code challenge supported methods to the discovery doc

### DIFF
--- a/internal/oidc/discovery/discovery_handler.go
+++ b/internal/oidc/discovery/discovery_handler.go
@@ -37,6 +37,7 @@ type Metadata struct {
 	TokenEndpointAuthMethodsSupported []string `json:"token_endpoint_auth_methods_supported"`
 	ScopesSupported                   []string `json:"scopes_supported"`
 	ClaimsSupported                   []string `json:"claims_supported"`
+	CodeChallengeMethodsSupported     []string `json:"code_challenge_methods_supported"`
 
 	// ^^^ Optional ^^^
 
@@ -64,6 +65,7 @@ func NewHandler(issuerURL string) http.Handler {
 		SubjectTypesSupported:             []string{"public"},
 		IDTokenSigningAlgValuesSupported:  []string{"ES256"},
 		TokenEndpointAuthMethodsSupported: []string{"client_secret_basic"},
+		CodeChallengeMethodsSupported:     []string{"S256"},
 		ScopesSupported:                   []string{"openid", "offline"},
 		ClaimsSupported:                   []string{"groups"},
 	}

--- a/internal/oidc/discovery/discovery_handler_test.go
+++ b/internal/oidc/discovery/discovery_handler_test.go
@@ -46,6 +46,7 @@ func TestDiscovery(t *testing.T) {
 				"id_token_signing_alg_values_supported": ["ES256"],
 				"token_endpoint_auth_methods_supported": ["client_secret_basic"],
 				"scopes_supported": ["openid", "offline"],
+				"code_challenge_methods_supported": ["S256"],
 				"claims_supported": ["groups"],
 				"discovery.supervisor.pinniped.dev/v1alpha1": {
 					"pinniped_identity_providers_endpoint": "https://some-issuer.com/some/path/v1alpha1/pinniped_identity_providers"

--- a/test/integration/supervisor_discovery_test.go
+++ b/test/integration/supervisor_discovery_test.go
@@ -505,6 +505,7 @@ func requireWellKnownEndpointIsWorking(t *testing.T, supervisorScheme, superviso
       "scopes_supported": ["openid", "offline"],
       "response_types_supported": ["code"],
       "response_modes_supported": ["query", "form_post"],
+      "code_challenge_methods_supported": ["S256"],
       "claims_supported": ["groups"],
       "discovery.supervisor.pinniped.dev/v1alpha1": {"pinniped_identity_providers_endpoint": "%s/v1alpha1/pinniped_identity_providers"},
       "subject_types_supported": ["public"],


### PR DESCRIPTION
Signed-off-by: hectorj2f <hectorf@vmware.com>

<!--
Thank you for submitting a pull request for Pinniped!

Before submitting, please see the guidelines in CONTRIBUTING.md in this repo.

Please note that a project maintainer will need to review and provide an
initial approval on the PR to cause CI tests to automatically start.
Also note that if you push additional commits to the PR, those commits
will need another initial approval before CI will pick them up.

Reminder: Did you remember to run all the linter, unit tests, and integration tests
described in CONTRIBUTING.md on your branch before submitting this PR?

Below is a template to help you describe your PR.
-->

<!--
Provide a summary of your change. Feel free to use paragraphs or a bulleted list, for example:

- Improves performance by 10,000%.
- Fixes all bugs.
- Boils the oceans.

-->

This PR includes the `code_challenge_methods_supported` key, as specified by https://datatracker.ietf.org/doc/html/rfc8414#section-2. If this key is omitted in the document, that'll mean the authorization server does not support PKCE. However the Supervisor does actually support and require PKCE, therefore we should add that key in the discovery document.

<!--
Does this PR fix one or more reported issues?
If yes, use `Fixes #<issue number>` to automatically close the fixed issue(s) when the PR is merged.
-->

Fixes https://github.com/vmware-tanzu/pinniped/issues/1107

**Release note**:

<!--
Does this PR introduce a user-facing change?

If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
-->
```release-note
oidc: add code challenge supported methods to the discovery document.
```
