### PR TITLE
Always attempt to docker pull before codegen

### DIFF
--- a/hack/lib/update-codegen.sh
+++ b/hack/lib/update-codegen.sh
@@ -20,6 +20,7 @@ if [[ -z "${CONTAINED:-}" ]]; then
 
         echo "generating code for ${kubeVersion} using ${CODEGEN_IMAGE}..."
         docker run --rm \
+            --pull always \
             --env CONTAINED=1 \
             --env CODEGEN_LOG_LEVEL="$debug_level" \
             --volume "${ROOT}:/work" \


### PR DESCRIPTION
Today, we docker pull only if the image is missing, but if there is an out of date local image tagged `latest` we won't pull it. We should always attempt to docker pull, meaning unless the sha matches the latest image on ghcr, we will download the new one.