### PR TITLE
pause community meeting for a little while

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,8 @@
 # Contributing to Pinniped
 
+Pinniped is better because of our contributors and [maintainers](MAINTAINERS.md). It is because of you that we can bring
+great software to the community.
+
 Contributions to Pinniped are welcome. Here are some things to help you get started.
 
 ## Code of Conduct
@@ -14,24 +17,13 @@ See [SCOPE.md](./SCOPE.md) for some guidelines about what we consider in and out
 
 The near-term and mid-term roadmap for the work planned for the project [maintainers](MAINTAINERS.md) is documented in [ROADMAP.md](ROADMAP.md).
 
-## Community Meetings
-
-Pinniped is better because of our contributors and [maintainers](MAINTAINERS.md). It is because of you that we can bring great
-software to the community. Please join us during our online community meetings,
-occurring every first and third Thursday of the month at 9 AM PT / 12 PM ET.
-Use [this Zoom Link](https://go.pinniped.dev/community/zoom)
-to attend and add any agenda items you wish to discuss
-to [the notes document](https://hackmd.io/rd_kVJhjQfOvfAWzK8A3tQ?view).
-Join our [Google Group](https://groups.google.com/g/project-pinniped) to receive invites to this meeting.
-
-If the meeting day falls on a US holiday, please consider that occurrence of the meeting to be canceled.
-
 ## Discussion
 
 Got a question, comment, or idea? Please don't hesitate to reach out
 via GitHub [Discussions](https://github.com/vmware-tanzu/pinniped/discussions),
 GitHub [Issues](https://github.com/vmware-tanzu/pinniped/issues),
-or in the Kubernetes Slack Workspace within the [#pinniped channel](https://kubernetes.slack.com/archives/C01BW364RJA).
+or in the Kubernetes Slack Workspace within the [#pinniped channel](https://go.pinniped.dev/community/slack).
+Join our [Google Group](https://go.pinniped.dev/community/group) to receive updates and meeting invitations.
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -21,26 +21,18 @@ Care to kick the tires? It's easy to [install and try Pinniped](https://pinniped
 Got a question, comment, or idea? Please don't hesitate to reach out
 via GitHub [Discussions](https://github.com/vmware-tanzu/pinniped/discussions),
 GitHub [Issues](https://github.com/vmware-tanzu/pinniped/issues),
-or in the Kubernetes Slack Workspace within the [#pinniped channel](https://kubernetes.slack.com/archives/C01BW364RJA).
+or in the Kubernetes Slack Workspace within the [#pinniped channel](https://go.pinniped.dev/community/slack).
+Join our [Google Group](https://go.pinniped.dev/community/group) to receive updates and meeting invitations.
 
 ## Contributions
+
+Pinniped is better because of our contributors and [maintainers](MAINTAINERS.md). It is because of you that we can bring
+great software to the community.
 
 Want to get involved? Contributions are welcome.
 
 Please see the [contributing guide](CONTRIBUTING.md) for more information about reporting bugs, requesting features,
 building and testing the code, submitting PRs, and other contributor topics.
-
-## Community meetings
-
-Pinniped is better because of our contributors and [maintainers](MAINTAINERS.md). It is because of you that we can bring great
-software to the community. Please join us during our online community meetings, occurring every first and third
-Thursday of the month at 9 AM PT / 12 PM ET.
-
-Use [this Zoom Link](https://go.pinniped.dev/community/zoom) to attend and add any agenda items you wish to
-discuss to [the notes document](https://go.pinniped.dev/community/agenda).
-Join our [Google Group](https://groups.google.com/g/project-pinniped) to receive invites to this meeting.
-
-If the meeting day falls on a US holiday, please consider that occurrence of the meeting to be canceled.
 
 ## Adopters
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,37 +1,40 @@
+## Pinniped Project Roadmap
 
-## **Pinniped Project Roadmap**
+### About this document
 
+This document provides a high-level overview of the next big features the maintainers are planning to work on. This
+should serve as a reference point for Pinniped users and contributors to understand where the project is heading, and
+help determine if a contribution could be conflicting with a longer term plan.
+The [Pinniped project backlog](https://github.com/orgs/vmware-tanzu/projects/43/) is prioritized based on this roadmap,
+and it provides a more granular view of what the maintainers are working on a day-to-day basis.
 
-###
-**About this document**
+### How to help
 
-This document provides a high-level overview of the next big features the maintainers are planning to work on. This should serve as a reference point for Pinniped users and contributors to understand where the project is heading, and help determine if a contribution could be conflicting with a longer term plan. [Pinniped project backlog](https://github.com/orgs/vmware-tanzu/projects/43/) is prioritized based on this roadmap and it provides a more granular view of what the maintainers are working on a day-to-day basis.  
+Discussion on the roadmap is welcomed. If you want to provide suggestions, use cases, and feedback to an item in the
+roadmap, please reach out to the maintainers using one of the methods described in the project's
+[README.md](https://github.com/vmware-tanzu/pinniped#discussion).
+[Contributions](https://github.com/vmware-tanzu/pinniped/blob/main/CONTRIBUTING.md) to Pinniped are also welcomed.
 
-###
-**How to help?**
+### How to add an item to the roadmap
 
-Discussion on the roadmap can take place in [community meetings](https://github.com/vmware-tanzu/pinniped/blob/main/CONTRIBUTING.md#meeting-with-the-maintainers). If you want to provide suggestions, use cases, and feedback to an item in the roadmap, please add them to the [meeting notes](https://hackmd.io/rd_kVJhjQfOvfAWzK8A3tQ) and we will discuss them during community meetings. Please review the roadmap to avoid potential duplicated effort.
-
-###
-**How to add an item to the roadmap?**
-
-One of the most important aspects in any open source community is the concept of proposals. Large changes to the codebase and / or new features should be preceded by a [proposal](https://github.com/vmware-tanzu/pinniped/tree/main/proposals) in our repo.
+One of the most important aspects in any open source community is the concept of proposals. Large changes to the
+codebase and / or new features should be preceded by
+a [proposal](https://github.com/vmware-tanzu/pinniped/tree/main/proposals) in our repo.
 For smaller enhancements, you can open an issue to track that initiative or feature request.
 We work with and rely on community feedback to focus our efforts to improve Pinniped and maintain a healthy roadmap.
 
+### Current Roadmap
 
-###
-**Current Roadmap**
-
-The following table includes the current roadmap for Pinniped. If you have any questions or would like to contribute to Pinniped, please attend a [community meeting](https://github.com/vmware-tanzu/pinniped/blob/main/CONTRIBUTING.md#meeting-with-the-maintainers) to discuss with our team. If you don't know where to start, we are always looking for contributors that will help us reduce technical, automation, and documentation debt. Please take the timelines & dates as proposals and goals. Priorities and requirements change based on community feedback, roadblocks encountered, community contributions, etc. If you depend on a specific item, we encourage you to attend community meetings to get updated status information, or help us deliver that feature by contributing to Pinniped.
-
-
+The following table includes the current roadmap for Pinniped. Please take the timelines and dates as proposals and
+goals. Priorities and requirements change based on community feedback, roadblocks encountered, community contributions,
+etc. If you depend on a specific item, we encourage you to reach out for updated status information, or help us deliver
+that feature by [contributing](https://github.com/vmware-tanzu/pinniped/blob/main/CONTRIBUTING.md) to Pinniped.
 
 Last Updated: May 2022
 |Theme|Description|Timeline|
 |--|--|--|
 |Improving Security Posture|Support Audit logging of security events related to Authentication |May/June 2022|
-|Improving Usability|Support for integrating with UI/Dashboards  |May/June 2022|
+|Improving Usability|Support for integrating with UI/Dashboards |May/June 2022|
 |Improving Security Posture| Secrets Rotation and Management |Q3 2022|
 |Improving Security Posture|Session Management |Q4 2022|
-|Improving Security Posture|TLS hardening contd|Q4 2022| 
+|Improving Security Posture|TLS hardening contd|Q4 2022|

--- a/proposals/README.md
+++ b/proposals/README.md
@@ -37,7 +37,7 @@ subdirectory, create a `README.md` containing the core proposal. Include other f
 understanding of the feature.
 
 To make your new proposal known to all other contributors, please send a link to your new proposal PR on the Kubernetes
-Slack in [#pinniped](https://kubernetes.slack.com/archives/C01BW364RJA)
+Slack in [#pinniped](https://go.pinniped.dev/community/slack)
 or via the [Pinniped mailing list](mailto:project-pinniped@googlegroups.com).
 
 Author(s) of proposals for major changes will give a time period of no less than five (5) working days for comment and
@@ -231,5 +231,5 @@ previous proposals for historical context when appropriate.
 ## Getting Help with the Proposal Process
 
 Please reach out to the maintainers in the Kubernetes Slack Workspace within
-the [#pinniped](https://kubernetes.slack.com/archives/C01BW364RJA) channel or on
+the [#pinniped](https://go.pinniped.dev/community/slack) channel or on
 the [Pinniped mailing list](mailto:project-pinniped@googlegroups.com) with any questions.

--- a/site/config.yaml
+++ b/site/config.yaml
@@ -5,7 +5,7 @@ theme: "pinniped"
 params:
   twitter_url: "https://twitter.com/projectpinniped"
   github_url: "https://github.com/vmware-tanzu/pinniped"
-  slack_url: "https://kubernetes.slack.com/messages/pinniped"
+  slack_url: "https://go.pinniped.dev/community/slack"
   community_url: "https://go.pinniped.dev/community"
   latest_version: v0.18.0
   latest_codegen_version: 1.24

--- a/site/content/community/_index.html
+++ b/site/content/community/_index.html
@@ -35,9 +35,9 @@ layout: section
             </div>
             <div class="content">
                 <h3><a href="{{< param "community_url" >}}">Community Meetings</a></h3>
-                <p>Please join us during our online <a href="https://go.pinniped.dev/community/agenda">Community Meetings</a>, occurring every first and third Thursday of the month at 9 AM PT / 12 PM ET.</p>
-                <p>Use <a href="https://go.pinniped.dev/community/zoom">this Zoom link</a> to attend and add any agenda items you wish to discuss to <a href="https://go.pinniped.dev/community/agenda">the notes document</a>.</p>
-                <p>Join our <a href="https://groups.google.com/u/1/g/project-pinniped">Google Group</a> to receive invites to the meeting</p>
+<!--                <p>Please join us during our online <a href="https://go.pinniped.dev/community/agenda">Community Meetings</a>, occurring every first and third Thursday of the month at 9 AM PT / 12 PM ET.</p>-->
+<!--                <p>Use <a href="https://go.pinniped.dev/community/zoom">this Zoom link</a> to attend and add any agenda items you wish to discuss to <a href="https://go.pinniped.dev/community/agenda">the notes document</a>.</p>-->
+                <p>Join our <a href="https://go.pinniped.dev/community/group">Google Group</a> to receive updates and invites to community meetings</p>
                 <p>Watch previous community meetings on our <a href="https://go.pinniped.dev/community/youtube">YouTube playlist</a></p>
             </div>
         </div>

--- a/site/content/docs/_index.md
+++ b/site/content/docs/_index.md
@@ -9,9 +9,13 @@ menu:
 ---
 
 Pinniped is an authentication service for Kubernetes clusters.
-As a Kubernetes cluster administrator or user, you can learn how Pinniped works, see how to use it on your clusters, and dive into internals of Pinniped's APIs and architecture.
+As a Kubernetes cluster administrator or user, you can learn how Pinniped works, see how to use it on your clusters, and
+dive into internals of Pinniped's APIs and architecture.
 
-Have a question, comment, or idea? Please reach out via [GitHub Discussions](https://github.com/vmware-tanzu/pinniped/discussions) or [join the Pinniped community meetings]({{< ref "/community" >}}).
+Have a question, comment, or idea? Please reach out via
+[GitHub Issues](https://github.com/vmware-tanzu/pinniped/issues),
+[GitHub Discussions](https://github.com/vmware-tanzu/pinniped/discussions),
+or [join the Pinniped community]({{< ref "/community" >}}).
 
 ## New to Pinniped?
 

--- a/site/content/posts/2020-11-12-a-seal-of-approval.md
+++ b/site/content/posts/2020-11-12-a-seal-of-approval.md
@@ -50,7 +50,7 @@ Let’s be clear: We’re not there yet, but that’s where we’re headed with 
 - Create a unified login experience across clusters regardless of provider or distribution
 - Advance the state of the art in Kubernetes login security  
 
-From contributing code to uploading documentation to sharing how you’d like to use Pinniped in the wild, there are many ways to get involved. Feel free to ask questions via [#pinniped](https://kubernetes.slack.com/archives/C01BW364RJA) on Kubernetes Slack, or check out the [Contribute to Pinniped](https://github.com/vmware-tanzu/pinniped/blob/main/CONTRIBUTING.md) page for details on how to contribute to the Pinniped project. There you’ll find out how you can:
+From contributing code to uploading documentation to sharing how you’d like to use Pinniped in the wild, there are many ways to get involved. Feel free to ask questions via [#pinniped](https://go.pinniped.dev/community/slack) on Kubernetes Slack, or check out the [Contribute to Pinniped](https://github.com/vmware-tanzu/pinniped/blob/main/CONTRIBUTING.md) page for details on how to contribute to the Pinniped project. There you’ll find out how you can:
 
 - Propose or request new features
 - Try writing a plugin

--- a/site/content/posts/2021-06-02-first-ldap-release.md
+++ b/site/content/posts/2021-06-02-first-ldap-release.md
@@ -65,7 +65,7 @@ We intend to add features in future releases to make it more convenient to integ
 as an LDAP provider, and to include AD in our automated testing suite. Stay tuned.
 
 In the meantime, please let us know if you run into any issues or concerns using your LDAP system.
-Feel free to ask questions via [#pinniped](https://kubernetes.slack.com/archives/C01BW364RJA) on Kubernetes Slack,
+Feel free to ask questions via [#pinniped](https://go.pinniped.dev/community/slack) on Kubernetes Slack,
 or [create an issue](https://github.com/vmware-tanzu/pinniped/issues/new/choose) on our Github repository.
 
 ### Security Considerations
@@ -143,7 +143,7 @@ The Pinniped community continues to grow, and is a vital part of the project's s
 We thrive on community feedback. Did you try our new LDAP features?
 What else do you need from identity systems for your Kubernetes clusters?
 
-Find us in [#pinniped](https://kubernetes.slack.com/archives/C01BW364RJA) on Kubernetes Slack,
+Find us in [#pinniped](https://go.pinniped.dev/community/slack) on Kubernetes Slack,
 [create an issue](https://github.com/vmware-tanzu/pinniped/issues/new/choose) on our Github repository,
 or start a [Discussion](https://github.com/vmware-tanzu/pinniped/discussions).
 

--- a/site/content/posts/2021-08-27-supporting-ad-oidc-workflows.md
+++ b/site/content/posts/2021-08-27-supporting-ad-oidc-workflows.md
@@ -108,7 +108,7 @@ We thrive on community feedback.
 Did you try our new LDAP or AD features?
 What other configurations do you need for authenticating users to your Kubernetes clusters?
 
-Find us in [#pinniped](https://kubernetes.slack.com/archives/C01BW364RJA) on Kubernetes Slack,
+Find us in [#pinniped](https://go.pinniped.dev/community/slack) on Kubernetes Slack,
 [create an issue](https://github.com/vmware-tanzu/pinniped/issues/new/choose) on our Github repository,
 or start a [Discussion](https://github.com/vmware-tanzu/pinniped/discussions).
 

--- a/site/content/posts/2022-01-18-idp-refresh-tls-ciphers-for-compliance.md
+++ b/site/content/posts/2022-01-18-idp-refresh-tls-ciphers-for-compliance.md
@@ -139,7 +139,7 @@ We thrive on community feedback.
 Did you try our new security hardening features?
 What other configurations do you need for secure authentication of users to your Kubernetes clusters?
 
-Find us in [#pinniped](https://kubernetes.slack.com/archives/C01BW364RJA) on Kubernetes Slack,
+Find us in [#pinniped](https://go.pinniped.dev/community/slack) on Kubernetes Slack,
 [create an issue](https://github.com/vmware-tanzu/pinniped/issues/new/choose) on our Github repository,
 or start a [Discussion](https://github.com/vmware-tanzu/pinniped/discussions).
 

--- a/site/content/posts/2022-04-15-fips-and-more.md
+++ b/site/content/posts/2022-04-15-fips-and-more.md
@@ -58,7 +58,7 @@ Are there other Identity Providers for which you want to see documentation simil
 
 We thrive on community feedback and would like to hear more!  
 
-Reach out to us in [#pinniped](https://kubernetes.slack.com/archives/C01BW364RJA) on Kubernetes Slack,
+Reach out to us in [#pinniped](https://go.pinniped.dev/community/slack) on Kubernetes Slack,
 [create an issue](https://github.com/vmware-tanzu/pinniped/issues/new/choose) on our Github repository,
 or start a [discussion](https://github.com/vmware-tanzu/pinniped/discussions).
 

--- a/site/content/posts/2022-06-01-json-logging-ldap-ui.md
+++ b/site/content/posts/2022-06-01-json-logging-ldap-ui.md
@@ -84,7 +84,7 @@ Have you tried any of our new features? Let us know what you think of our loggin
 
 We thrive on community feedback and would like to hear more!  
 
-Reach out to us in [#pinniped](https://kubernetes.slack.com/archives/C01BW364RJA) on Kubernetes Slack,
+Reach out to us in [#pinniped](https://go.pinniped.dev/community/slack) on Kubernetes Slack,
 [create an issue](https://github.com/vmware-tanzu/pinniped/issues/new/choose) on our Github repository,
 or start a [discussion](https://github.com/vmware-tanzu/pinniped/discussions).
 

--- a/site/redirects/go.pinniped.dev/netlify.toml
+++ b/site/redirects/go.pinniped.dev/netlify.toml
@@ -1,12 +1,12 @@
 [[redirects]]
   from = "/community"
-  to = "https://github.com/vmware-tanzu/pinniped/blob/main/CONTRIBUTING.md#meeting-with-the-maintainers"
+  to = "https://pinniped.dev/community"
   status = 302
   force = true
 
 [[redirects]]
   from = "/community/zoom"
-  to = "https://vmware.zoom.us/j/93798188973?pwd=T3pIMWxReEQvcWljNm1admRoZTFSZz09"
+  to = "https://vmware.zoom.us/j/TodoUpdateThisLink"
   status = 302
   force = true
 

--- a/site/themes/pinniped/layouts/shortcodes/community.html
+++ b/site/themes/pinniped/layouts/shortcodes/community.html
@@ -5,10 +5,14 @@
         It's because of you that we can bring great software to the community.
     </p>
     <p>
-        Please join us during our online community meetings, occurring every first and third Thursday of the month at 9 AM PT / 12 PM ET.
-        Use <a href="https://go.pinniped.dev/community/zoom">this Zoom link</a> to attend and add any agenda items you wish to discuss to <a href="https://go.pinniped.dev/community/agenda">the notes document</a>.
+        Connect with the community on <a href="https://github.com/vmware-tanzu/pinniped">GitHub</a>
+        and <a href="https://go.pinniped.dev/community/slack">Slack</a>.
     </p>
+<!--    <p>-->
+<!--        Please join us during our online community meetings, occurring every first and third Thursday of the month at 9 AM PT / 12 PM ET.-->
+<!--        Use <a href="https://go.pinniped.dev/community/zoom">this Zoom link</a> to attend and add any agenda items you wish to discuss to <a href="https://go.pinniped.dev/community/agenda">the notes document</a>.-->
+<!--    </p>-->
     <p>
-        Join our <a href="https://go.pinniped.dev/community/group">Google Group</a> to receive invites to this meeting.
+        Join our <a href="https://go.pinniped.dev/community/group">Google Group</a> to receive updates and meeting invitations.
     </p>
 </div>


### PR DESCRIPTION
We've decided to pause our biweekly community meetings for a little while. We'll resume them at a later date. In the meantime, we will likely schedule ad hoc public meetings for things like release announcements and community feedback gathering. Please subscribe to our mailing list and Slack channel for meeting updates.

For now, update the web site to remove the schedule details of the biweekly community meetings.

**Release note**:

```release-note
NONE
```
