### PR TITLE
Add the new `username` scope to the Supervisor and exclude usernames from dynamic clients which are not granted the scope, and other dynamic client related changes

### DIFF
--- a/apis/supervisor/oidc/types_supervisor_oidc.go.tmpl
+++ b/apis/supervisor/oidc/types_supervisor_oidc.go.tmpl
@@ -15,11 +15,68 @@ const (
 	// or an LDAPIdentityProvider.
 	AuthorizePasswordHeaderName = "Pinniped-Password" //nolint:gosec // this is not a credential
 
-	// AuthorizeUpstreamIDPNameParamName is the name of the HTTP request parameter which can be used to help select which
-	// identity provider should be used for authentication by sending the name of the desired identity provider.
+	// AuthorizeUpstreamIDPNameParamName is the name of the HTTP request parameter which can be used to help select
+	// which identity provider should be used for authentication by sending the name of the desired identity provider.
 	AuthorizeUpstreamIDPNameParamName = "pinniped_idp_name"
 
-	// AuthorizeUpstreamIDPTypeParamName is the name of the HTTP request parameter which can be used to help select which
-	// identity provider should be used for authentication by sending the type of the desired identity provider.
+	// AuthorizeUpstreamIDPTypeParamName is the name of the HTTP request parameter which can be used to help select
+	// which identity provider should be used for authentication by sending the type of the desired identity provider.
 	AuthorizeUpstreamIDPTypeParamName = "pinniped_idp_type"
+
+	// IDTokenClaimIssuer is name of the issuer claim defined by the OIDC spec.
+	IDTokenClaimIssuer = "iss"
+
+	// IDTokenClaimSubject is name of the subject claim defined by the OIDC spec.
+	IDTokenClaimSubject = "sub"
+
+	// IDTokenClaimAuthorizedParty is name of the authorized party claim defined by the OIDC spec.
+	IDTokenClaimAuthorizedParty = "azp"
+
+	// IDTokenClaimUsername is the name of a custom claim in the downstream ID token whose value will contain the user's
+	// username which was mapped from the upstream identity provider.
+	IDTokenClaimUsername = "username"
+
+	// IDTokenClaimGroups is the name of a custom claim in the downstream ID token whose value will contain the user's
+	// group names which were mapped from the upstream identity provider.
+	IDTokenClaimGroups = "groups"
+
+	// GrantTypeAuthorizationCode is the name of the grant type for authorization code flows defined by the OIDC spec.
+	GrantTypeAuthorizationCode = "authorization_code"
+
+	// GrantTypeRefreshToken is the name of the grant type for refresh flow defined by the OIDC spec.
+	GrantTypeRefreshToken = "refresh_token"
+
+	// GrantTypeTokenExchange is the name of a custom grant type for RFC8693 token exchanges.
+	GrantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange" //nolint:gosec // this is not a credential
+
+	// ScopeOpenID is name of the openid scope defined by the OIDC spec.
+	ScopeOpenID = "openid"
+
+	// ScopeOfflineAccess is name of the offline access scope defined by the OIDC spec, used for requesting refresh
+	// tokens.
+	ScopeOfflineAccess = "offline_access"
+
+	// ScopeEmail is name of the email scope defined by the OIDC spec.
+	ScopeEmail = "email"
+
+	// ScopeProfile is name of the profile scope defined by the OIDC spec.
+	ScopeProfile = "profile"
+
+	// ScopeUsername is the name of a custom scope that determines whether the username claim will be returned inside
+	// ID tokens.
+	ScopeUsername = "username"
+
+	// ScopeGroups is the name of a custom scope that determines whether the groups claim will be returned inside
+	// ID tokens.
+	ScopeGroups = "groups"
+
+	// ScopeRequestAudience is the name of a custom scope that determines whether a RFC8693 token exchange is allowed to
+	// be used to request a different audience.
+	ScopeRequestAudience = "pinniped:request-audience"
+
+	// ClientIDPinnipedCLI is the client ID of the statically defined public OIDC client which is used by the CLI.
+	ClientIDPinnipedCLI = "pinniped-cli"
+
+	// ClientIDRequiredOIDCClientPrefix is the required prefix for the metadata.name of OIDCClient CRs.
+	ClientIDRequiredOIDCClientPrefix = "client.oauth.pinniped.dev-"
 )

--- a/cmd/pinniped/cmd/kubeconfig.go
+++ b/cmd/pinniped/cmd/kubeconfig.go
@@ -331,6 +331,9 @@ func newExecConfig(deps kubeconfigDeps, flags getKubeconfigParams) (*clientcmdap
 		execConfig.Args = append(execConfig.Args, "--debug-session-cache")
 	}
 	if flags.oidc.requestAudience != "" {
+		if strings.Contains(flags.oidc.requestAudience, ".pinniped.dev") {
+			return nil, fmt.Errorf("request audience is not allowed to include the substring '.pinniped.dev': %s", flags.oidc.requestAudience)
+		}
 		execConfig.Args = append(execConfig.Args, "--request-audience="+flags.oidc.requestAudience)
 	}
 	if flags.oidc.upstreamIDPName != "" {

--- a/cmd/pinniped/cmd/kubeconfig_test.go
+++ b/cmd/pinniped/cmd/kubeconfig_test.go
@@ -142,7 +142,7 @@ func TestGetKubeconfig(t *testing.T) {
 				      --oidc-issuer string                       OpenID Connect issuer URL (default: autodiscover)
 				      --oidc-listen-port uint16                  TCP port for localhost listener (authorization code flow only)
 				      --oidc-request-audience string             Request a token with an alternate audience using RFC8693 token exchange
-				      --oidc-scopes strings                      OpenID Connect scopes to request during login (default [offline_access,openid,pinniped:request-audience])
+				      --oidc-scopes strings                      OpenID Connect scopes to request during login (default [offline_access,openid,pinniped:request-audience,username,groups])
 				      --oidc-session-cache string                Path to OpenID Connect session cache file
 				      --oidc-skip-browser                        During OpenID Connect login, skip opening the browser (just print the URL)
 				  -o, --output string                            Output file path (default: stdout)
@@ -1290,7 +1290,7 @@ func TestGetKubeconfig(t *testing.T) {
 						  - oidc
 						  - --issuer=%s
 						  - --client-id=pinniped-cli
-						  - --scopes=offline_access,openid,pinniped:request-audience
+						  - --scopes=offline_access,openid,pinniped:request-audience,username,groups
 						  - --ca-bundle-data=%s
 						  - --upstream-identity-provider-name=some-ldap-idp
 						  - --upstream-identity-provider-type=ldap
@@ -1496,7 +1496,7 @@ func TestGetKubeconfig(t *testing.T) {
 						  - --concierge-ca-bundle-data=ZmFrZS1jZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YS12YWx1ZQ==
 						  - --issuer=%s
 						  - --client-id=pinniped-cli
-						  - --scopes=offline_access,openid,pinniped:request-audience
+						  - --scopes=offline_access,openid,pinniped:request-audience,username,groups
 						  - --ca-bundle-data=%s
 						  - --request-audience=test-audience
 						  command: '.../path/to/pinniped'
@@ -1577,7 +1577,7 @@ func TestGetKubeconfig(t *testing.T) {
 						  - --credential-cache=/path/to/cache/dir/credentials.yaml
 						  - --issuer=%s
 						  - --client-id=pinniped-cli
-						  - --scopes=offline_access,openid,pinniped:request-audience
+						  - --scopes=offline_access,openid,pinniped:request-audience,username,groups
 						  - --skip-browser
 						  - --skip-listen
 						  - --listen-port=1234
@@ -1695,7 +1695,7 @@ func TestGetKubeconfig(t *testing.T) {
 						  - --concierge-ca-bundle-data=%s
 						  - --issuer=%s
 						  - --client-id=pinniped-cli
-						  - --scopes=offline_access,openid,pinniped:request-audience
+						  - --scopes=offline_access,openid,pinniped:request-audience,username,groups
 						  - --ca-bundle-data=%s
 						  - --request-audience=test-audience
 						  command: '.../path/to/pinniped'
@@ -1804,7 +1804,7 @@ func TestGetKubeconfig(t *testing.T) {
 						  - --concierge-ca-bundle-data=dGVzdC1jb25jaWVyZ2UtY2E=
 						  - --issuer=%s
 						  - --client-id=pinniped-cli
-						  - --scopes=offline_access,openid,pinniped:request-audience
+						  - --scopes=offline_access,openid,pinniped:request-audience,username,groups
 						  - --ca-bundle-data=%s
 						  - --request-audience=test-audience
 						  command: '.../path/to/pinniped'
@@ -1881,7 +1881,7 @@ func TestGetKubeconfig(t *testing.T) {
 						  - --concierge-ca-bundle-data=ZmFrZS1jZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YS12YWx1ZQ==
 						  - --issuer=%s
 						  - --client-id=pinniped-cli
-						  - --scopes=offline_access,openid,pinniped:request-audience
+						  - --scopes=offline_access,openid,pinniped:request-audience,username,groups
 						  - --ca-bundle-data=%s
 						  - --request-audience=test-audience
 						  - --upstream-identity-provider-name=some-ldap-idp
@@ -1960,7 +1960,7 @@ func TestGetKubeconfig(t *testing.T) {
 						  - --concierge-ca-bundle-data=ZmFrZS1jZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YS12YWx1ZQ==
 						  - --issuer=%s
 						  - --client-id=pinniped-cli
-						  - --scopes=offline_access,openid,pinniped:request-audience
+						  - --scopes=offline_access,openid,pinniped:request-audience,username,groups
 						  - --ca-bundle-data=%s
 						  - --request-audience=test-audience
 						  - --upstream-identity-provider-name=some-oidc-idp
@@ -2037,7 +2037,7 @@ func TestGetKubeconfig(t *testing.T) {
 						  - --concierge-ca-bundle-data=ZmFrZS1jZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YS12YWx1ZQ==
 						  - --issuer=%s
 						  - --client-id=pinniped-cli
-						  - --scopes=offline_access,openid,pinniped:request-audience
+						  - --scopes=offline_access,openid,pinniped:request-audience,username,groups
 						  - --ca-bundle-data=%s
 						  - --request-audience=test-audience
 						  command: '.../path/to/pinniped'
@@ -2110,7 +2110,7 @@ func TestGetKubeconfig(t *testing.T) {
 						  - --concierge-ca-bundle-data=ZmFrZS1jZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YS12YWx1ZQ==
 						  - --issuer=%s
 						  - --client-id=pinniped-cli
-						  - --scopes=offline_access,openid,pinniped:request-audience
+						  - --scopes=offline_access,openid,pinniped:request-audience,username,groups
 						  - --ca-bundle-data=%s
 						  - --request-audience=test-audience
 						  command: '.../path/to/pinniped'
@@ -2190,7 +2190,7 @@ func TestGetKubeconfig(t *testing.T) {
 						  - --concierge-ca-bundle-data=ZmFrZS1jZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YS12YWx1ZQ==
 						  - --issuer=%s
 						  - --client-id=pinniped-cli
-						  - --scopes=offline_access,openid,pinniped:request-audience
+						  - --scopes=offline_access,openid,pinniped:request-audience,username,groups
 						  - --ca-bundle-data=%s
 						  - --request-audience=test-audience
 						  command: '.../path/to/pinniped'
@@ -2265,7 +2265,7 @@ func TestGetKubeconfig(t *testing.T) {
 						  - --concierge-ca-bundle-data=ZmFrZS1jZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YS12YWx1ZQ==
 						  - --issuer=%s
 						  - --client-id=pinniped-cli
-						  - --scopes=offline_access,openid,pinniped:request-audience
+						  - --scopes=offline_access,openid,pinniped:request-audience,username,groups
 						  - --ca-bundle-data=%s
 						  - --request-audience=test-audience
 						  - --upstream-identity-provider-name=some-oidc-idp
@@ -2348,7 +2348,7 @@ func TestGetKubeconfig(t *testing.T) {
 						  - --concierge-ca-bundle-data=ZmFrZS1jZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YS12YWx1ZQ==
 						  - --issuer=%s
 						  - --client-id=pinniped-cli
-						  - --scopes=offline_access,openid,pinniped:request-audience
+						  - --scopes=offline_access,openid,pinniped:request-audience,username,groups
 						  - --ca-bundle-data=%s
 						  - --request-audience=test-audience
 						  - --upstream-identity-provider-name=some-oidc-idp
@@ -2408,7 +2408,7 @@ func TestGetKubeconfig(t *testing.T) {
 						  - oidc
 						  - --issuer=%s
 						  - --client-id=pinniped-cli
-						  - --scopes=offline_access,openid,pinniped:request-audience
+						  - --scopes=offline_access,openid,pinniped:request-audience,username,groups
 						  - --ca-bundle-data=%s
 						  - --upstream-identity-provider-name=some-ldap-idp
 						  - --upstream-identity-provider-type=ldap
@@ -2469,7 +2469,7 @@ func TestGetKubeconfig(t *testing.T) {
 						  - oidc
 						  - --issuer=%s
 						  - --client-id=pinniped-cli
-						  - --scopes=offline_access,openid,pinniped:request-audience
+						  - --scopes=offline_access,openid,pinniped:request-audience,username,groups
 						  - --ca-bundle-data=%s
 						  - --upstream-identity-provider-name=some-ldap-idp
 						  - --upstream-identity-provider-type=ldap
@@ -2530,7 +2530,7 @@ func TestGetKubeconfig(t *testing.T) {
 						  - oidc
 						  - --issuer=%s
 						  - --client-id=pinniped-cli
-						  - --scopes=offline_access,openid,pinniped:request-audience
+						  - --scopes=offline_access,openid,pinniped:request-audience,username,groups
 						  - --ca-bundle-data=%s
 						  - --upstream-identity-provider-name=some-ldap-idp
 						  - --upstream-identity-provider-type=ldap
@@ -2592,7 +2592,7 @@ func TestGetKubeconfig(t *testing.T) {
 						  - oidc
 						  - --issuer=%s
 						  - --client-id=pinniped-cli
-						  - --scopes=offline_access,openid,pinniped:request-audience
+						  - --scopes=offline_access,openid,pinniped:request-audience,username,groups
 						  - --ca-bundle-data=%s
 						  - --upstream-identity-provider-name=some-ldap-idp
 						  - --upstream-identity-provider-type=ldap
@@ -2654,7 +2654,7 @@ func TestGetKubeconfig(t *testing.T) {
 						  - oidc
 						  - --issuer=%s
 						  - --client-id=pinniped-cli
-						  - --scopes=offline_access,openid,pinniped:request-audience
+						  - --scopes=offline_access,openid,pinniped:request-audience,username,groups
 						  - --ca-bundle-data=%s
 						  - --upstream-identity-provider-name=some-ldap-idp
 						  - --upstream-identity-provider-type=ldap
@@ -2715,7 +2715,7 @@ func TestGetKubeconfig(t *testing.T) {
 						  - oidc
 						  - --issuer=%s
 						  - --client-id=pinniped-cli
-						  - --scopes=offline_access,openid,pinniped:request-audience
+						  - --scopes=offline_access,openid,pinniped:request-audience,username,groups
 						  - --ca-bundle-data=%s
 						  - --upstream-identity-provider-name=some-ldap-idp
 						  - --upstream-identity-provider-type=ldap
@@ -2775,7 +2775,7 @@ func TestGetKubeconfig(t *testing.T) {
 						  - oidc
 						  - --issuer=%s
 						  - --client-id=pinniped-cli
-						  - --scopes=offline_access,openid,pinniped:request-audience
+						  - --scopes=offline_access,openid,pinniped:request-audience,username,groups
 						  - --ca-bundle-data=%s
 						  - --upstream-identity-provider-name=some-ldap-idp
 						  - --upstream-identity-provider-type=ldap

--- a/cmd/pinniped/cmd/login_oidc.go
+++ b/cmd/pinniped/cmd/login_oidc.go
@@ -16,12 +16,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientauthv1beta1 "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
 
 	idpdiscoveryv1alpha1 "go.pinniped.dev/generated/latest/apis/supervisor/idpdiscovery/v1alpha1"
+	oidcapi "go.pinniped.dev/generated/latest/apis/supervisor/oidc"
 	"go.pinniped.dev/internal/execcredcache"
 	"go.pinniped.dev/internal/groupsuffix"
 	"go.pinniped.dev/internal/net/phttp"
@@ -98,9 +98,9 @@ func oidcLoginCommand(deps oidcLoginCommandDeps) *cobra.Command {
 		conciergeNamespace string // unused now
 	)
 	cmd.Flags().StringVar(&flags.issuer, "issuer", "", "OpenID Connect issuer URL")
-	cmd.Flags().StringVar(&flags.clientID, "client-id", "pinniped-cli", "OpenID Connect client ID")
+	cmd.Flags().StringVar(&flags.clientID, "client-id", oidcapi.ClientIDPinnipedCLI, "OpenID Connect client ID")
 	cmd.Flags().Uint16Var(&flags.listenPort, "listen-port", 0, "TCP port for localhost listener (authorization code flow only)")
-	cmd.Flags().StringSliceVar(&flags.scopes, "scopes", []string{oidc.ScopeOfflineAccess, oidc.ScopeOpenID, "pinniped:request-audience"}, "OIDC scopes to request during login")
+	cmd.Flags().StringSliceVar(&flags.scopes, "scopes", []string{oidcapi.ScopeOfflineAccess, oidcapi.ScopeOpenID, oidcapi.ScopeRequestAudience, oidcapi.ScopeUsername, oidcapi.ScopeGroups}, "OIDC scopes to request during login")
 	cmd.Flags().BoolVar(&flags.skipBrowser, "skip-browser", false, "Skip opening the browser (just print the URL)")
 	cmd.Flags().BoolVar(&flags.skipListen, "skip-listen", false, "Skip starting a localhost callback listener (manual copy/paste flow only)")
 	cmd.Flags().StringVar(&flags.sessionCachePath, "session-cache", filepath.Join(mustGetConfigDir(), "sessions.yaml"), "Path to session cache file")

--- a/cmd/pinniped/cmd/login_oidc_test.go
+++ b/cmd/pinniped/cmd/login_oidc_test.go
@@ -80,7 +80,7 @@ func TestLoginOIDCCommand(t *testing.T) {
 				      --issuer string                            OpenID Connect issuer URL
 				      --listen-port uint16                       TCP port for localhost listener (authorization code flow only)
 				      --request-audience string                  Request a token with an alternate audience using RFC8693 token exchange
-				      --scopes strings                           OIDC scopes to request during login (default [offline_access,openid,pinniped:request-audience])
+				      --scopes strings                           OIDC scopes to request during login (default [offline_access,openid,pinniped:request-audience,username,groups])
 				      --session-cache string                     Path to session cache file (default "` + cfgDir + `/sessions.yaml")
 				      --skip-browser                             Skip opening the browser (just print the URL)
 					  --upstream-identity-provider-flow string   The type of client flow to use with the upstream identity provider during login with a Supervisor (e.g. 'browser_authcode', 'cli_password')

--- a/generated/1.17/apis/supervisor/oidc/types_supervisor_oidc.go
+++ b/generated/1.17/apis/supervisor/oidc/types_supervisor_oidc.go
@@ -15,11 +15,68 @@ const (
 	// or an LDAPIdentityProvider.
 	AuthorizePasswordHeaderName = "Pinniped-Password" //nolint:gosec // this is not a credential
 
-	// AuthorizeUpstreamIDPNameParamName is the name of the HTTP request parameter which can be used to help select which
-	// identity provider should be used for authentication by sending the name of the desired identity provider.
+	// AuthorizeUpstreamIDPNameParamName is the name of the HTTP request parameter which can be used to help select
+	// which identity provider should be used for authentication by sending the name of the desired identity provider.
 	AuthorizeUpstreamIDPNameParamName = "pinniped_idp_name"
 
-	// AuthorizeUpstreamIDPTypeParamName is the name of the HTTP request parameter which can be used to help select which
-	// identity provider should be used for authentication by sending the type of the desired identity provider.
+	// AuthorizeUpstreamIDPTypeParamName is the name of the HTTP request parameter which can be used to help select
+	// which identity provider should be used for authentication by sending the type of the desired identity provider.
 	AuthorizeUpstreamIDPTypeParamName = "pinniped_idp_type"
+
+	// IDTokenClaimIssuer is name of the issuer claim defined by the OIDC spec.
+	IDTokenClaimIssuer = "iss"
+
+	// IDTokenClaimSubject is name of the subject claim defined by the OIDC spec.
+	IDTokenClaimSubject = "sub"
+
+	// IDTokenClaimAuthorizedParty is name of the authorized party claim defined by the OIDC spec.
+	IDTokenClaimAuthorizedParty = "azp"
+
+	// IDTokenClaimUsername is the name of a custom claim in the downstream ID token whose value will contain the user's
+	// username which was mapped from the upstream identity provider.
+	IDTokenClaimUsername = "username"
+
+	// IDTokenClaimGroups is the name of a custom claim in the downstream ID token whose value will contain the user's
+	// group names which were mapped from the upstream identity provider.
+	IDTokenClaimGroups = "groups"
+
+	// GrantTypeAuthorizationCode is the name of the grant type for authorization code flows defined by the OIDC spec.
+	GrantTypeAuthorizationCode = "authorization_code"
+
+	// GrantTypeRefreshToken is the name of the grant type for refresh flow defined by the OIDC spec.
+	GrantTypeRefreshToken = "refresh_token"
+
+	// GrantTypeTokenExchange is the name of a custom grant type for RFC8693 token exchanges.
+	GrantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange" //nolint:gosec // this is not a credential
+
+	// ScopeOpenID is name of the openid scope defined by the OIDC spec.
+	ScopeOpenID = "openid"
+
+	// ScopeOfflineAccess is name of the offline access scope defined by the OIDC spec, used for requesting refresh
+	// tokens.
+	ScopeOfflineAccess = "offline_access"
+
+	// ScopeEmail is name of the email scope defined by the OIDC spec.
+	ScopeEmail = "email"
+
+	// ScopeProfile is name of the profile scope defined by the OIDC spec.
+	ScopeProfile = "profile"
+
+	// ScopeUsername is the name of a custom scope that determines whether the username claim will be returned inside
+	// ID tokens.
+	ScopeUsername = "username"
+
+	// ScopeGroups is the name of a custom scope that determines whether the groups claim will be returned inside
+	// ID tokens.
+	ScopeGroups = "groups"
+
+	// ScopeRequestAudience is the name of a custom scope that determines whether a RFC8693 token exchange is allowed to
+	// be used to request a different audience.
+	ScopeRequestAudience = "pinniped:request-audience"
+
+	// ClientIDPinnipedCLI is the client ID of the statically defined public OIDC client which is used by the CLI.
+	ClientIDPinnipedCLI = "pinniped-cli"
+
+	// ClientIDRequiredOIDCClientPrefix is the required prefix for the metadata.name of OIDCClient CRs.
+	ClientIDRequiredOIDCClientPrefix = "client.oauth.pinniped.dev-"
 )

--- a/generated/1.18/apis/supervisor/oidc/types_supervisor_oidc.go
+++ b/generated/1.18/apis/supervisor/oidc/types_supervisor_oidc.go
@@ -15,11 +15,68 @@ const (
 	// or an LDAPIdentityProvider.
 	AuthorizePasswordHeaderName = "Pinniped-Password" //nolint:gosec // this is not a credential
 
-	// AuthorizeUpstreamIDPNameParamName is the name of the HTTP request parameter which can be used to help select which
-	// identity provider should be used for authentication by sending the name of the desired identity provider.
+	// AuthorizeUpstreamIDPNameParamName is the name of the HTTP request parameter which can be used to help select
+	// which identity provider should be used for authentication by sending the name of the desired identity provider.
 	AuthorizeUpstreamIDPNameParamName = "pinniped_idp_name"
 
-	// AuthorizeUpstreamIDPTypeParamName is the name of the HTTP request parameter which can be used to help select which
-	// identity provider should be used for authentication by sending the type of the desired identity provider.
+	// AuthorizeUpstreamIDPTypeParamName is the name of the HTTP request parameter which can be used to help select
+	// which identity provider should be used for authentication by sending the type of the desired identity provider.
 	AuthorizeUpstreamIDPTypeParamName = "pinniped_idp_type"
+
+	// IDTokenClaimIssuer is name of the issuer claim defined by the OIDC spec.
+	IDTokenClaimIssuer = "iss"
+
+	// IDTokenClaimSubject is name of the subject claim defined by the OIDC spec.
+	IDTokenClaimSubject = "sub"
+
+	// IDTokenClaimAuthorizedParty is name of the authorized party claim defined by the OIDC spec.
+	IDTokenClaimAuthorizedParty = "azp"
+
+	// IDTokenClaimUsername is the name of a custom claim in the downstream ID token whose value will contain the user's
+	// username which was mapped from the upstream identity provider.
+	IDTokenClaimUsername = "username"
+
+	// IDTokenClaimGroups is the name of a custom claim in the downstream ID token whose value will contain the user's
+	// group names which were mapped from the upstream identity provider.
+	IDTokenClaimGroups = "groups"
+
+	// GrantTypeAuthorizationCode is the name of the grant type for authorization code flows defined by the OIDC spec.
+	GrantTypeAuthorizationCode = "authorization_code"
+
+	// GrantTypeRefreshToken is the name of the grant type for refresh flow defined by the OIDC spec.
+	GrantTypeRefreshToken = "refresh_token"
+
+	// GrantTypeTokenExchange is the name of a custom grant type for RFC8693 token exchanges.
+	GrantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange" //nolint:gosec // this is not a credential
+
+	// ScopeOpenID is name of the openid scope defined by the OIDC spec.
+	ScopeOpenID = "openid"
+
+	// ScopeOfflineAccess is name of the offline access scope defined by the OIDC spec, used for requesting refresh
+	// tokens.
+	ScopeOfflineAccess = "offline_access"
+
+	// ScopeEmail is name of the email scope defined by the OIDC spec.
+	ScopeEmail = "email"
+
+	// ScopeProfile is name of the profile scope defined by the OIDC spec.
+	ScopeProfile = "profile"
+
+	// ScopeUsername is the name of a custom scope that determines whether the username claim will be returned inside
+	// ID tokens.
+	ScopeUsername = "username"
+
+	// ScopeGroups is the name of a custom scope that determines whether the groups claim will be returned inside
+	// ID tokens.
+	ScopeGroups = "groups"
+
+	// ScopeRequestAudience is the name of a custom scope that determines whether a RFC8693 token exchange is allowed to
+	// be used to request a different audience.
+	ScopeRequestAudience = "pinniped:request-audience"
+
+	// ClientIDPinnipedCLI is the client ID of the statically defined public OIDC client which is used by the CLI.
+	ClientIDPinnipedCLI = "pinniped-cli"
+
+	// ClientIDRequiredOIDCClientPrefix is the required prefix for the metadata.name of OIDCClient CRs.
+	ClientIDRequiredOIDCClientPrefix = "client.oauth.pinniped.dev-"
 )

--- a/generated/1.19/apis/supervisor/oidc/types_supervisor_oidc.go
+++ b/generated/1.19/apis/supervisor/oidc/types_supervisor_oidc.go
@@ -15,11 +15,68 @@ const (
 	// or an LDAPIdentityProvider.
 	AuthorizePasswordHeaderName = "Pinniped-Password" //nolint:gosec // this is not a credential
 
-	// AuthorizeUpstreamIDPNameParamName is the name of the HTTP request parameter which can be used to help select which
-	// identity provider should be used for authentication by sending the name of the desired identity provider.
+	// AuthorizeUpstreamIDPNameParamName is the name of the HTTP request parameter which can be used to help select
+	// which identity provider should be used for authentication by sending the name of the desired identity provider.
 	AuthorizeUpstreamIDPNameParamName = "pinniped_idp_name"
 
-	// AuthorizeUpstreamIDPTypeParamName is the name of the HTTP request parameter which can be used to help select which
-	// identity provider should be used for authentication by sending the type of the desired identity provider.
+	// AuthorizeUpstreamIDPTypeParamName is the name of the HTTP request parameter which can be used to help select
+	// which identity provider should be used for authentication by sending the type of the desired identity provider.
 	AuthorizeUpstreamIDPTypeParamName = "pinniped_idp_type"
+
+	// IDTokenClaimIssuer is name of the issuer claim defined by the OIDC spec.
+	IDTokenClaimIssuer = "iss"
+
+	// IDTokenClaimSubject is name of the subject claim defined by the OIDC spec.
+	IDTokenClaimSubject = "sub"
+
+	// IDTokenClaimAuthorizedParty is name of the authorized party claim defined by the OIDC spec.
+	IDTokenClaimAuthorizedParty = "azp"
+
+	// IDTokenClaimUsername is the name of a custom claim in the downstream ID token whose value will contain the user's
+	// username which was mapped from the upstream identity provider.
+	IDTokenClaimUsername = "username"
+
+	// IDTokenClaimGroups is the name of a custom claim in the downstream ID token whose value will contain the user's
+	// group names which were mapped from the upstream identity provider.
+	IDTokenClaimGroups = "groups"
+
+	// GrantTypeAuthorizationCode is the name of the grant type for authorization code flows defined by the OIDC spec.
+	GrantTypeAuthorizationCode = "authorization_code"
+
+	// GrantTypeRefreshToken is the name of the grant type for refresh flow defined by the OIDC spec.
+	GrantTypeRefreshToken = "refresh_token"
+
+	// GrantTypeTokenExchange is the name of a custom grant type for RFC8693 token exchanges.
+	GrantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange" //nolint:gosec // this is not a credential
+
+	// ScopeOpenID is name of the openid scope defined by the OIDC spec.
+	ScopeOpenID = "openid"
+
+	// ScopeOfflineAccess is name of the offline access scope defined by the OIDC spec, used for requesting refresh
+	// tokens.
+	ScopeOfflineAccess = "offline_access"
+
+	// ScopeEmail is name of the email scope defined by the OIDC spec.
+	ScopeEmail = "email"
+
+	// ScopeProfile is name of the profile scope defined by the OIDC spec.
+	ScopeProfile = "profile"
+
+	// ScopeUsername is the name of a custom scope that determines whether the username claim will be returned inside
+	// ID tokens.
+	ScopeUsername = "username"
+
+	// ScopeGroups is the name of a custom scope that determines whether the groups claim will be returned inside
+	// ID tokens.
+	ScopeGroups = "groups"
+
+	// ScopeRequestAudience is the name of a custom scope that determines whether a RFC8693 token exchange is allowed to
+	// be used to request a different audience.
+	ScopeRequestAudience = "pinniped:request-audience"
+
+	// ClientIDPinnipedCLI is the client ID of the statically defined public OIDC client which is used by the CLI.
+	ClientIDPinnipedCLI = "pinniped-cli"
+
+	// ClientIDRequiredOIDCClientPrefix is the required prefix for the metadata.name of OIDCClient CRs.
+	ClientIDRequiredOIDCClientPrefix = "client.oauth.pinniped.dev-"
 )

--- a/generated/1.20/apis/supervisor/oidc/types_supervisor_oidc.go
+++ b/generated/1.20/apis/supervisor/oidc/types_supervisor_oidc.go
@@ -15,11 +15,68 @@ const (
 	// or an LDAPIdentityProvider.
 	AuthorizePasswordHeaderName = "Pinniped-Password" //nolint:gosec // this is not a credential
 
-	// AuthorizeUpstreamIDPNameParamName is the name of the HTTP request parameter which can be used to help select which
-	// identity provider should be used for authentication by sending the name of the desired identity provider.
+	// AuthorizeUpstreamIDPNameParamName is the name of the HTTP request parameter which can be used to help select
+	// which identity provider should be used for authentication by sending the name of the desired identity provider.
 	AuthorizeUpstreamIDPNameParamName = "pinniped_idp_name"
 
-	// AuthorizeUpstreamIDPTypeParamName is the name of the HTTP request parameter which can be used to help select which
-	// identity provider should be used for authentication by sending the type of the desired identity provider.
+	// AuthorizeUpstreamIDPTypeParamName is the name of the HTTP request parameter which can be used to help select
+	// which identity provider should be used for authentication by sending the type of the desired identity provider.
 	AuthorizeUpstreamIDPTypeParamName = "pinniped_idp_type"
+
+	// IDTokenClaimIssuer is name of the issuer claim defined by the OIDC spec.
+	IDTokenClaimIssuer = "iss"
+
+	// IDTokenClaimSubject is name of the subject claim defined by the OIDC spec.
+	IDTokenClaimSubject = "sub"
+
+	// IDTokenClaimAuthorizedParty is name of the authorized party claim defined by the OIDC spec.
+	IDTokenClaimAuthorizedParty = "azp"
+
+	// IDTokenClaimUsername is the name of a custom claim in the downstream ID token whose value will contain the user's
+	// username which was mapped from the upstream identity provider.
+	IDTokenClaimUsername = "username"
+
+	// IDTokenClaimGroups is the name of a custom claim in the downstream ID token whose value will contain the user's
+	// group names which were mapped from the upstream identity provider.
+	IDTokenClaimGroups = "groups"
+
+	// GrantTypeAuthorizationCode is the name of the grant type for authorization code flows defined by the OIDC spec.
+	GrantTypeAuthorizationCode = "authorization_code"
+
+	// GrantTypeRefreshToken is the name of the grant type for refresh flow defined by the OIDC spec.
+	GrantTypeRefreshToken = "refresh_token"
+
+	// GrantTypeTokenExchange is the name of a custom grant type for RFC8693 token exchanges.
+	GrantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange" //nolint:gosec // this is not a credential
+
+	// ScopeOpenID is name of the openid scope defined by the OIDC spec.
+	ScopeOpenID = "openid"
+
+	// ScopeOfflineAccess is name of the offline access scope defined by the OIDC spec, used for requesting refresh
+	// tokens.
+	ScopeOfflineAccess = "offline_access"
+
+	// ScopeEmail is name of the email scope defined by the OIDC spec.
+	ScopeEmail = "email"
+
+	// ScopeProfile is name of the profile scope defined by the OIDC spec.
+	ScopeProfile = "profile"
+
+	// ScopeUsername is the name of a custom scope that determines whether the username claim will be returned inside
+	// ID tokens.
+	ScopeUsername = "username"
+
+	// ScopeGroups is the name of a custom scope that determines whether the groups claim will be returned inside
+	// ID tokens.
+	ScopeGroups = "groups"
+
+	// ScopeRequestAudience is the name of a custom scope that determines whether a RFC8693 token exchange is allowed to
+	// be used to request a different audience.
+	ScopeRequestAudience = "pinniped:request-audience"
+
+	// ClientIDPinnipedCLI is the client ID of the statically defined public OIDC client which is used by the CLI.
+	ClientIDPinnipedCLI = "pinniped-cli"
+
+	// ClientIDRequiredOIDCClientPrefix is the required prefix for the metadata.name of OIDCClient CRs.
+	ClientIDRequiredOIDCClientPrefix = "client.oauth.pinniped.dev-"
 )

--- a/generated/1.21/apis/supervisor/oidc/types_supervisor_oidc.go
+++ b/generated/1.21/apis/supervisor/oidc/types_supervisor_oidc.go
@@ -15,11 +15,68 @@ const (
 	// or an LDAPIdentityProvider.
 	AuthorizePasswordHeaderName = "Pinniped-Password" //nolint:gosec // this is not a credential
 
-	// AuthorizeUpstreamIDPNameParamName is the name of the HTTP request parameter which can be used to help select which
-	// identity provider should be used for authentication by sending the name of the desired identity provider.
+	// AuthorizeUpstreamIDPNameParamName is the name of the HTTP request parameter which can be used to help select
+	// which identity provider should be used for authentication by sending the name of the desired identity provider.
 	AuthorizeUpstreamIDPNameParamName = "pinniped_idp_name"
 
-	// AuthorizeUpstreamIDPTypeParamName is the name of the HTTP request parameter which can be used to help select which
-	// identity provider should be used for authentication by sending the type of the desired identity provider.
+	// AuthorizeUpstreamIDPTypeParamName is the name of the HTTP request parameter which can be used to help select
+	// which identity provider should be used for authentication by sending the type of the desired identity provider.
 	AuthorizeUpstreamIDPTypeParamName = "pinniped_idp_type"
+
+	// IDTokenClaimIssuer is name of the issuer claim defined by the OIDC spec.
+	IDTokenClaimIssuer = "iss"
+
+	// IDTokenClaimSubject is name of the subject claim defined by the OIDC spec.
+	IDTokenClaimSubject = "sub"
+
+	// IDTokenClaimAuthorizedParty is name of the authorized party claim defined by the OIDC spec.
+	IDTokenClaimAuthorizedParty = "azp"
+
+	// IDTokenClaimUsername is the name of a custom claim in the downstream ID token whose value will contain the user's
+	// username which was mapped from the upstream identity provider.
+	IDTokenClaimUsername = "username"
+
+	// IDTokenClaimGroups is the name of a custom claim in the downstream ID token whose value will contain the user's
+	// group names which were mapped from the upstream identity provider.
+	IDTokenClaimGroups = "groups"
+
+	// GrantTypeAuthorizationCode is the name of the grant type for authorization code flows defined by the OIDC spec.
+	GrantTypeAuthorizationCode = "authorization_code"
+
+	// GrantTypeRefreshToken is the name of the grant type for refresh flow defined by the OIDC spec.
+	GrantTypeRefreshToken = "refresh_token"
+
+	// GrantTypeTokenExchange is the name of a custom grant type for RFC8693 token exchanges.
+	GrantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange" //nolint:gosec // this is not a credential
+
+	// ScopeOpenID is name of the openid scope defined by the OIDC spec.
+	ScopeOpenID = "openid"
+
+	// ScopeOfflineAccess is name of the offline access scope defined by the OIDC spec, used for requesting refresh
+	// tokens.
+	ScopeOfflineAccess = "offline_access"
+
+	// ScopeEmail is name of the email scope defined by the OIDC spec.
+	ScopeEmail = "email"
+
+	// ScopeProfile is name of the profile scope defined by the OIDC spec.
+	ScopeProfile = "profile"
+
+	// ScopeUsername is the name of a custom scope that determines whether the username claim will be returned inside
+	// ID tokens.
+	ScopeUsername = "username"
+
+	// ScopeGroups is the name of a custom scope that determines whether the groups claim will be returned inside
+	// ID tokens.
+	ScopeGroups = "groups"
+
+	// ScopeRequestAudience is the name of a custom scope that determines whether a RFC8693 token exchange is allowed to
+	// be used to request a different audience.
+	ScopeRequestAudience = "pinniped:request-audience"
+
+	// ClientIDPinnipedCLI is the client ID of the statically defined public OIDC client which is used by the CLI.
+	ClientIDPinnipedCLI = "pinniped-cli"
+
+	// ClientIDRequiredOIDCClientPrefix is the required prefix for the metadata.name of OIDCClient CRs.
+	ClientIDRequiredOIDCClientPrefix = "client.oauth.pinniped.dev-"
 )

--- a/generated/1.22/apis/supervisor/oidc/types_supervisor_oidc.go
+++ b/generated/1.22/apis/supervisor/oidc/types_supervisor_oidc.go
@@ -15,11 +15,68 @@ const (
 	// or an LDAPIdentityProvider.
 	AuthorizePasswordHeaderName = "Pinniped-Password" //nolint:gosec // this is not a credential
 
-	// AuthorizeUpstreamIDPNameParamName is the name of the HTTP request parameter which can be used to help select which
-	// identity provider should be used for authentication by sending the name of the desired identity provider.
+	// AuthorizeUpstreamIDPNameParamName is the name of the HTTP request parameter which can be used to help select
+	// which identity provider should be used for authentication by sending the name of the desired identity provider.
 	AuthorizeUpstreamIDPNameParamName = "pinniped_idp_name"
 
-	// AuthorizeUpstreamIDPTypeParamName is the name of the HTTP request parameter which can be used to help select which
-	// identity provider should be used for authentication by sending the type of the desired identity provider.
+	// AuthorizeUpstreamIDPTypeParamName is the name of the HTTP request parameter which can be used to help select
+	// which identity provider should be used for authentication by sending the type of the desired identity provider.
 	AuthorizeUpstreamIDPTypeParamName = "pinniped_idp_type"
+
+	// IDTokenClaimIssuer is name of the issuer claim defined by the OIDC spec.
+	IDTokenClaimIssuer = "iss"
+
+	// IDTokenClaimSubject is name of the subject claim defined by the OIDC spec.
+	IDTokenClaimSubject = "sub"
+
+	// IDTokenClaimAuthorizedParty is name of the authorized party claim defined by the OIDC spec.
+	IDTokenClaimAuthorizedParty = "azp"
+
+	// IDTokenClaimUsername is the name of a custom claim in the downstream ID token whose value will contain the user's
+	// username which was mapped from the upstream identity provider.
+	IDTokenClaimUsername = "username"
+
+	// IDTokenClaimGroups is the name of a custom claim in the downstream ID token whose value will contain the user's
+	// group names which were mapped from the upstream identity provider.
+	IDTokenClaimGroups = "groups"
+
+	// GrantTypeAuthorizationCode is the name of the grant type for authorization code flows defined by the OIDC spec.
+	GrantTypeAuthorizationCode = "authorization_code"
+
+	// GrantTypeRefreshToken is the name of the grant type for refresh flow defined by the OIDC spec.
+	GrantTypeRefreshToken = "refresh_token"
+
+	// GrantTypeTokenExchange is the name of a custom grant type for RFC8693 token exchanges.
+	GrantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange" //nolint:gosec // this is not a credential
+
+	// ScopeOpenID is name of the openid scope defined by the OIDC spec.
+	ScopeOpenID = "openid"
+
+	// ScopeOfflineAccess is name of the offline access scope defined by the OIDC spec, used for requesting refresh
+	// tokens.
+	ScopeOfflineAccess = "offline_access"
+
+	// ScopeEmail is name of the email scope defined by the OIDC spec.
+	ScopeEmail = "email"
+
+	// ScopeProfile is name of the profile scope defined by the OIDC spec.
+	ScopeProfile = "profile"
+
+	// ScopeUsername is the name of a custom scope that determines whether the username claim will be returned inside
+	// ID tokens.
+	ScopeUsername = "username"
+
+	// ScopeGroups is the name of a custom scope that determines whether the groups claim will be returned inside
+	// ID tokens.
+	ScopeGroups = "groups"
+
+	// ScopeRequestAudience is the name of a custom scope that determines whether a RFC8693 token exchange is allowed to
+	// be used to request a different audience.
+	ScopeRequestAudience = "pinniped:request-audience"
+
+	// ClientIDPinnipedCLI is the client ID of the statically defined public OIDC client which is used by the CLI.
+	ClientIDPinnipedCLI = "pinniped-cli"
+
+	// ClientIDRequiredOIDCClientPrefix is the required prefix for the metadata.name of OIDCClient CRs.
+	ClientIDRequiredOIDCClientPrefix = "client.oauth.pinniped.dev-"
 )

--- a/generated/1.23/apis/supervisor/oidc/types_supervisor_oidc.go
+++ b/generated/1.23/apis/supervisor/oidc/types_supervisor_oidc.go
@@ -15,11 +15,68 @@ const (
 	// or an LDAPIdentityProvider.
 	AuthorizePasswordHeaderName = "Pinniped-Password" //nolint:gosec // this is not a credential
 
-	// AuthorizeUpstreamIDPNameParamName is the name of the HTTP request parameter which can be used to help select which
-	// identity provider should be used for authentication by sending the name of the desired identity provider.
+	// AuthorizeUpstreamIDPNameParamName is the name of the HTTP request parameter which can be used to help select
+	// which identity provider should be used for authentication by sending the name of the desired identity provider.
 	AuthorizeUpstreamIDPNameParamName = "pinniped_idp_name"
 
-	// AuthorizeUpstreamIDPTypeParamName is the name of the HTTP request parameter which can be used to help select which
-	// identity provider should be used for authentication by sending the type of the desired identity provider.
+	// AuthorizeUpstreamIDPTypeParamName is the name of the HTTP request parameter which can be used to help select
+	// which identity provider should be used for authentication by sending the type of the desired identity provider.
 	AuthorizeUpstreamIDPTypeParamName = "pinniped_idp_type"
+
+	// IDTokenClaimIssuer is name of the issuer claim defined by the OIDC spec.
+	IDTokenClaimIssuer = "iss"
+
+	// IDTokenClaimSubject is name of the subject claim defined by the OIDC spec.
+	IDTokenClaimSubject = "sub"
+
+	// IDTokenClaimAuthorizedParty is name of the authorized party claim defined by the OIDC spec.
+	IDTokenClaimAuthorizedParty = "azp"
+
+	// IDTokenClaimUsername is the name of a custom claim in the downstream ID token whose value will contain the user's
+	// username which was mapped from the upstream identity provider.
+	IDTokenClaimUsername = "username"
+
+	// IDTokenClaimGroups is the name of a custom claim in the downstream ID token whose value will contain the user's
+	// group names which were mapped from the upstream identity provider.
+	IDTokenClaimGroups = "groups"
+
+	// GrantTypeAuthorizationCode is the name of the grant type for authorization code flows defined by the OIDC spec.
+	GrantTypeAuthorizationCode = "authorization_code"
+
+	// GrantTypeRefreshToken is the name of the grant type for refresh flow defined by the OIDC spec.
+	GrantTypeRefreshToken = "refresh_token"
+
+	// GrantTypeTokenExchange is the name of a custom grant type for RFC8693 token exchanges.
+	GrantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange" //nolint:gosec // this is not a credential
+
+	// ScopeOpenID is name of the openid scope defined by the OIDC spec.
+	ScopeOpenID = "openid"
+
+	// ScopeOfflineAccess is name of the offline access scope defined by the OIDC spec, used for requesting refresh
+	// tokens.
+	ScopeOfflineAccess = "offline_access"
+
+	// ScopeEmail is name of the email scope defined by the OIDC spec.
+	ScopeEmail = "email"
+
+	// ScopeProfile is name of the profile scope defined by the OIDC spec.
+	ScopeProfile = "profile"
+
+	// ScopeUsername is the name of a custom scope that determines whether the username claim will be returned inside
+	// ID tokens.
+	ScopeUsername = "username"
+
+	// ScopeGroups is the name of a custom scope that determines whether the groups claim will be returned inside
+	// ID tokens.
+	ScopeGroups = "groups"
+
+	// ScopeRequestAudience is the name of a custom scope that determines whether a RFC8693 token exchange is allowed to
+	// be used to request a different audience.
+	ScopeRequestAudience = "pinniped:request-audience"
+
+	// ClientIDPinnipedCLI is the client ID of the statically defined public OIDC client which is used by the CLI.
+	ClientIDPinnipedCLI = "pinniped-cli"
+
+	// ClientIDRequiredOIDCClientPrefix is the required prefix for the metadata.name of OIDCClient CRs.
+	ClientIDRequiredOIDCClientPrefix = "client.oauth.pinniped.dev-"
 )

--- a/generated/1.24/apis/supervisor/oidc/types_supervisor_oidc.go
+++ b/generated/1.24/apis/supervisor/oidc/types_supervisor_oidc.go
@@ -15,11 +15,68 @@ const (
 	// or an LDAPIdentityProvider.
 	AuthorizePasswordHeaderName = "Pinniped-Password" //nolint:gosec // this is not a credential
 
-	// AuthorizeUpstreamIDPNameParamName is the name of the HTTP request parameter which can be used to help select which
-	// identity provider should be used for authentication by sending the name of the desired identity provider.
+	// AuthorizeUpstreamIDPNameParamName is the name of the HTTP request parameter which can be used to help select
+	// which identity provider should be used for authentication by sending the name of the desired identity provider.
 	AuthorizeUpstreamIDPNameParamName = "pinniped_idp_name"
 
-	// AuthorizeUpstreamIDPTypeParamName is the name of the HTTP request parameter which can be used to help select which
-	// identity provider should be used for authentication by sending the type of the desired identity provider.
+	// AuthorizeUpstreamIDPTypeParamName is the name of the HTTP request parameter which can be used to help select
+	// which identity provider should be used for authentication by sending the type of the desired identity provider.
 	AuthorizeUpstreamIDPTypeParamName = "pinniped_idp_type"
+
+	// IDTokenClaimIssuer is name of the issuer claim defined by the OIDC spec.
+	IDTokenClaimIssuer = "iss"
+
+	// IDTokenClaimSubject is name of the subject claim defined by the OIDC spec.
+	IDTokenClaimSubject = "sub"
+
+	// IDTokenClaimAuthorizedParty is name of the authorized party claim defined by the OIDC spec.
+	IDTokenClaimAuthorizedParty = "azp"
+
+	// IDTokenClaimUsername is the name of a custom claim in the downstream ID token whose value will contain the user's
+	// username which was mapped from the upstream identity provider.
+	IDTokenClaimUsername = "username"
+
+	// IDTokenClaimGroups is the name of a custom claim in the downstream ID token whose value will contain the user's
+	// group names which were mapped from the upstream identity provider.
+	IDTokenClaimGroups = "groups"
+
+	// GrantTypeAuthorizationCode is the name of the grant type for authorization code flows defined by the OIDC spec.
+	GrantTypeAuthorizationCode = "authorization_code"
+
+	// GrantTypeRefreshToken is the name of the grant type for refresh flow defined by the OIDC spec.
+	GrantTypeRefreshToken = "refresh_token"
+
+	// GrantTypeTokenExchange is the name of a custom grant type for RFC8693 token exchanges.
+	GrantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange" //nolint:gosec // this is not a credential
+
+	// ScopeOpenID is name of the openid scope defined by the OIDC spec.
+	ScopeOpenID = "openid"
+
+	// ScopeOfflineAccess is name of the offline access scope defined by the OIDC spec, used for requesting refresh
+	// tokens.
+	ScopeOfflineAccess = "offline_access"
+
+	// ScopeEmail is name of the email scope defined by the OIDC spec.
+	ScopeEmail = "email"
+
+	// ScopeProfile is name of the profile scope defined by the OIDC spec.
+	ScopeProfile = "profile"
+
+	// ScopeUsername is the name of a custom scope that determines whether the username claim will be returned inside
+	// ID tokens.
+	ScopeUsername = "username"
+
+	// ScopeGroups is the name of a custom scope that determines whether the groups claim will be returned inside
+	// ID tokens.
+	ScopeGroups = "groups"
+
+	// ScopeRequestAudience is the name of a custom scope that determines whether a RFC8693 token exchange is allowed to
+	// be used to request a different audience.
+	ScopeRequestAudience = "pinniped:request-audience"
+
+	// ClientIDPinnipedCLI is the client ID of the statically defined public OIDC client which is used by the CLI.
+	ClientIDPinnipedCLI = "pinniped-cli"
+
+	// ClientIDRequiredOIDCClientPrefix is the required prefix for the metadata.name of OIDCClient CRs.
+	ClientIDRequiredOIDCClientPrefix = "client.oauth.pinniped.dev-"
 )

--- a/generated/latest/apis/supervisor/oidc/types_supervisor_oidc.go
+++ b/generated/latest/apis/supervisor/oidc/types_supervisor_oidc.go
@@ -15,11 +15,68 @@ const (
 	// or an LDAPIdentityProvider.
 	AuthorizePasswordHeaderName = "Pinniped-Password" //nolint:gosec // this is not a credential
 
-	// AuthorizeUpstreamIDPNameParamName is the name of the HTTP request parameter which can be used to help select which
-	// identity provider should be used for authentication by sending the name of the desired identity provider.
+	// AuthorizeUpstreamIDPNameParamName is the name of the HTTP request parameter which can be used to help select
+	// which identity provider should be used for authentication by sending the name of the desired identity provider.
 	AuthorizeUpstreamIDPNameParamName = "pinniped_idp_name"
 
-	// AuthorizeUpstreamIDPTypeParamName is the name of the HTTP request parameter which can be used to help select which
-	// identity provider should be used for authentication by sending the type of the desired identity provider.
+	// AuthorizeUpstreamIDPTypeParamName is the name of the HTTP request parameter which can be used to help select
+	// which identity provider should be used for authentication by sending the type of the desired identity provider.
 	AuthorizeUpstreamIDPTypeParamName = "pinniped_idp_type"
+
+	// IDTokenClaimIssuer is name of the issuer claim defined by the OIDC spec.
+	IDTokenClaimIssuer = "iss"
+
+	// IDTokenClaimSubject is name of the subject claim defined by the OIDC spec.
+	IDTokenClaimSubject = "sub"
+
+	// IDTokenClaimAuthorizedParty is name of the authorized party claim defined by the OIDC spec.
+	IDTokenClaimAuthorizedParty = "azp"
+
+	// IDTokenClaimUsername is the name of a custom claim in the downstream ID token whose value will contain the user's
+	// username which was mapped from the upstream identity provider.
+	IDTokenClaimUsername = "username"
+
+	// IDTokenClaimGroups is the name of a custom claim in the downstream ID token whose value will contain the user's
+	// group names which were mapped from the upstream identity provider.
+	IDTokenClaimGroups = "groups"
+
+	// GrantTypeAuthorizationCode is the name of the grant type for authorization code flows defined by the OIDC spec.
+	GrantTypeAuthorizationCode = "authorization_code"
+
+	// GrantTypeRefreshToken is the name of the grant type for refresh flow defined by the OIDC spec.
+	GrantTypeRefreshToken = "refresh_token"
+
+	// GrantTypeTokenExchange is the name of a custom grant type for RFC8693 token exchanges.
+	GrantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange" //nolint:gosec // this is not a credential
+
+	// ScopeOpenID is name of the openid scope defined by the OIDC spec.
+	ScopeOpenID = "openid"
+
+	// ScopeOfflineAccess is name of the offline access scope defined by the OIDC spec, used for requesting refresh
+	// tokens.
+	ScopeOfflineAccess = "offline_access"
+
+	// ScopeEmail is name of the email scope defined by the OIDC spec.
+	ScopeEmail = "email"
+
+	// ScopeProfile is name of the profile scope defined by the OIDC spec.
+	ScopeProfile = "profile"
+
+	// ScopeUsername is the name of a custom scope that determines whether the username claim will be returned inside
+	// ID tokens.
+	ScopeUsername = "username"
+
+	// ScopeGroups is the name of a custom scope that determines whether the groups claim will be returned inside
+	// ID tokens.
+	ScopeGroups = "groups"
+
+	// ScopeRequestAudience is the name of a custom scope that determines whether a RFC8693 token exchange is allowed to
+	// be used to request a different audience.
+	ScopeRequestAudience = "pinniped:request-audience"
+
+	// ClientIDPinnipedCLI is the client ID of the statically defined public OIDC client which is used by the CLI.
+	ClientIDPinnipedCLI = "pinniped-cli"
+
+	// ClientIDRequiredOIDCClientPrefix is the required prefix for the metadata.name of OIDCClient CRs.
+	ClientIDRequiredOIDCClientPrefix = "client.oauth.pinniped.dev-"
 )

--- a/internal/controller/authenticator/jwtcachefiller/jwtcachefiller.go
+++ b/internal/controller/authenticator/jwtcachefiller/jwtcachefiller.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/klog/v2"
 
 	auth1alpha1 "go.pinniped.dev/generated/latest/apis/concierge/authentication/v1alpha1"
+	oidcapi "go.pinniped.dev/generated/latest/apis/supervisor/oidc"
 	authinformers "go.pinniped.dev/generated/latest/client/concierge/informers/externalversions/authentication/v1alpha1"
 	pinnipedcontroller "go.pinniped.dev/internal/controller"
 	pinnipedauthenticator "go.pinniped.dev/internal/controller/authenticator"
@@ -32,8 +33,8 @@ import (
 // These default values come from the way that the Supervisor issues and signs tokens. We make these
 // the defaults for a JWTAuthenticator so that they can easily integrate with the Supervisor.
 const (
-	defaultUsernameClaim = "username"
-	defaultGroupsClaim   = "groups"
+	defaultUsernameClaim = oidcapi.IDTokenClaimUsername
+	defaultGroupsClaim   = oidcapi.IDTokenClaimGroups
 )
 
 // defaultSupportedSigningAlgos returns the default signing algos that this JWTAuthenticator

--- a/internal/controller/supervisorconfig/oidcclientwatcher/oidc_client_watcher.go
+++ b/internal/controller/supervisorconfig/oidcclientwatcher/oidc_client_watcher.go
@@ -15,6 +15,7 @@ import (
 	corev1informers "k8s.io/client-go/informers/core/v1"
 
 	"go.pinniped.dev/generated/latest/apis/supervisor/config/v1alpha1"
+	oidcapi "go.pinniped.dev/generated/latest/apis/supervisor/oidc"
 	pinnipedclientset "go.pinniped.dev/generated/latest/client/supervisor/clientset/versioned"
 	configInformers "go.pinniped.dev/generated/latest/client/supervisor/informers/externalversions/config/v1alpha1"
 	pinnipedcontroller "go.pinniped.dev/internal/controller"
@@ -27,7 +28,7 @@ import (
 
 const (
 	secretTypeToObserve       = "storage.pinniped.dev/oidc-client-secret" //nolint:gosec // this is not a credential
-	oidcClientPrefixToObserve = "client.oauth.pinniped.dev-"              //nolint:gosec // this is not a credential
+	oidcClientPrefixToObserve = oidcapi.ClientIDRequiredOIDCClientPrefix
 )
 
 type oidcClientWatcherController struct {

--- a/internal/controller/supervisorstorage/garbage_collector.go
+++ b/internal/controller/supervisorstorage/garbage_collector.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"time"
 
-	coreosoidc "github.com/coreos/go-oidc/v3/oidc"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -17,8 +16,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/clock"
 	clocktesting "k8s.io/utils/clock/testing"
-	"k8s.io/utils/strings/slices"
 
+	oidcapi "go.pinniped.dev/generated/latest/apis/supervisor/oidc"
 	pinnipedcontroller "go.pinniped.dev/internal/controller"
 	"go.pinniped.dev/internal/controllerlib"
 	"go.pinniped.dev/internal/crud"
@@ -204,7 +203,7 @@ func (c *garbageCollectorController) maybeRevokeUpstreamOIDCToken(ctx context.Co
 			return err
 		}
 		pinnipedSession := accessTokenSession.Request.Session.(*psession.PinnipedSession)
-		if slices.Contains(accessTokenSession.Request.GetGrantedScopes(), coreosoidc.ScopeOfflineAccess) {
+		if accessTokenSession.Request.GetGrantedScopes().Has(oidcapi.ScopeOfflineAccess) {
 			return nil
 		}
 		return c.tryRevokeUpstreamOIDCToken(ctx, pinnipedSession.Custom, secret)

--- a/internal/controller/supervisorstorage/garbage_collector_test.go
+++ b/internal/controller/supervisorstorage/garbage_collector_test.go
@@ -263,13 +263,14 @@ func TestGarbageCollectorControllerSync(t *testing.T) {
 		when("there are valid, expired authcode secrets which contain upstream refresh tokens", func() {
 			it.Before(func() {
 				activeOIDCAuthcodeSession := &authorizationcode.Session{
-					Version: "2",
+					Version: "3",
 					Active:  true,
 					Request: &fosite.Request{
 						ID:     "request-id-1",
 						Client: &clientregistry.Client{},
 						Session: &psession.PinnipedSession{
 							Custom: &psession.CustomSessionData{
+								Username:     "should be ignored by garbage collector",
 								ProviderUID:  "upstream-oidc-provider-uid",
 								ProviderName: "upstream-oidc-provider-name",
 								ProviderType: psession.ProviderTypeOIDC,
@@ -307,13 +308,14 @@ func TestGarbageCollectorControllerSync(t *testing.T) {
 				r.NoError(kubeClient.Tracker().Add(activeOIDCAuthcodeSessionSecret))
 
 				inactiveOIDCAuthcodeSession := &authorizationcode.Session{
-					Version: "2",
+					Version: "3",
 					Active:  false,
 					Request: &fosite.Request{
 						ID:     "request-id-2",
 						Client: &clientregistry.Client{},
 						Session: &psession.PinnipedSession{
 							Custom: &psession.CustomSessionData{
+								Username:     "should be ignored by garbage collector",
 								ProviderUID:  "upstream-oidc-provider-uid",
 								ProviderName: "upstream-oidc-provider-name",
 								ProviderType: psession.ProviderTypeOIDC,
@@ -385,13 +387,14 @@ func TestGarbageCollectorControllerSync(t *testing.T) {
 		when("there are valid, expired authcode secrets which contain upstream access tokens", func() {
 			it.Before(func() {
 				activeOIDCAuthcodeSession := &authorizationcode.Session{
-					Version: "2",
+					Version: "3",
 					Active:  true,
 					Request: &fosite.Request{
 						ID:     "request-id-1",
 						Client: &clientregistry.Client{},
 						Session: &psession.PinnipedSession{
 							Custom: &psession.CustomSessionData{
+								Username:     "should be ignored by garbage collector",
 								ProviderUID:  "upstream-oidc-provider-uid",
 								ProviderName: "upstream-oidc-provider-name",
 								ProviderType: psession.ProviderTypeOIDC,
@@ -429,13 +432,14 @@ func TestGarbageCollectorControllerSync(t *testing.T) {
 				r.NoError(kubeClient.Tracker().Add(activeOIDCAuthcodeSessionSecret))
 
 				inactiveOIDCAuthcodeSession := &authorizationcode.Session{
-					Version: "2",
+					Version: "3",
 					Active:  false,
 					Request: &fosite.Request{
 						ID:     "request-id-2",
 						Client: &clientregistry.Client{},
 						Session: &psession.PinnipedSession{
 							Custom: &psession.CustomSessionData{
+								Username:     "should be ignored by garbage collector",
 								ProviderUID:  "upstream-oidc-provider-uid",
 								ProviderName: "upstream-oidc-provider-name",
 								ProviderType: psession.ProviderTypeOIDC,
@@ -507,13 +511,14 @@ func TestGarbageCollectorControllerSync(t *testing.T) {
 		when("there is an invalid, expired authcode secret", func() {
 			it.Before(func() {
 				invalidOIDCAuthcodeSession := &authorizationcode.Session{
-					Version: "2",
+					Version: "3",
 					Active:  true,
 					Request: &fosite.Request{
 						ID:     "", // it is invalid for there to be a missing request ID
 						Client: &clientregistry.Client{},
 						Session: &psession.PinnipedSession{
 							Custom: &psession.CustomSessionData{
+								Username:     "should be ignored by garbage collector",
 								ProviderUID:  "upstream-oidc-provider-uid",
 								ProviderName: "upstream-oidc-provider-name",
 								ProviderType: psession.ProviderTypeOIDC,
@@ -575,13 +580,14 @@ func TestGarbageCollectorControllerSync(t *testing.T) {
 		when("there is a valid, expired authcode secret but its upstream name does not match any existing upstream", func() {
 			it.Before(func() {
 				wrongProviderNameOIDCAuthcodeSession := &authorizationcode.Session{
-					Version: "2",
+					Version: "3",
 					Active:  true,
 					Request: &fosite.Request{
 						ID:     "request-id-1",
 						Client: &clientregistry.Client{},
 						Session: &psession.PinnipedSession{
 							Custom: &psession.CustomSessionData{
+								Username:     "should be ignored by garbage collector",
 								ProviderUID:  "upstream-oidc-provider-uid",
 								ProviderName: "upstream-oidc-provider-name-will-not-match",
 								ProviderType: psession.ProviderTypeOIDC,
@@ -645,13 +651,14 @@ func TestGarbageCollectorControllerSync(t *testing.T) {
 		when("there is a valid, expired authcode secret but its upstream UID does not match any existing upstream", func() {
 			it.Before(func() {
 				wrongProviderNameOIDCAuthcodeSession := &authorizationcode.Session{
-					Version: "2",
+					Version: "3",
 					Active:  true,
 					Request: &fosite.Request{
 						ID:     "request-id-1",
 						Client: &clientregistry.Client{},
 						Session: &psession.PinnipedSession{
 							Custom: &psession.CustomSessionData{
+								Username:     "should be ignored by garbage collector",
 								ProviderUID:  "upstream-oidc-provider-uid-will-not-match",
 								ProviderName: "upstream-oidc-provider-name",
 								ProviderType: psession.ProviderTypeOIDC,
@@ -715,13 +722,14 @@ func TestGarbageCollectorControllerSync(t *testing.T) {
 		when("there is a valid, recently expired authcode secret but the upstream revocation fails", func() {
 			it.Before(func() {
 				activeOIDCAuthcodeSession := &authorizationcode.Session{
-					Version: "2",
+					Version: "3",
 					Active:  true,
 					Request: &fosite.Request{
 						ID:     "request-id-1",
 						Client: &clientregistry.Client{},
 						Session: &psession.PinnipedSession{
 							Custom: &psession.CustomSessionData{
+								Username:     "should be ignored by garbage collector",
 								ProviderUID:  "upstream-oidc-provider-uid",
 								ProviderName: "upstream-oidc-provider-name",
 								ProviderType: psession.ProviderTypeOIDC,
@@ -819,13 +827,14 @@ func TestGarbageCollectorControllerSync(t *testing.T) {
 		when("there is a valid, long-since expired authcode secret but the upstream revocation fails", func() {
 			it.Before(func() {
 				activeOIDCAuthcodeSession := &authorizationcode.Session{
-					Version: "2",
+					Version: "3",
 					Active:  true,
 					Request: &fosite.Request{
 						ID:     "request-id-1",
 						Client: &clientregistry.Client{},
 						Session: &psession.PinnipedSession{
 							Custom: &psession.CustomSessionData{
+								Username:     "should be ignored by garbage collector",
 								ProviderUID:  "upstream-oidc-provider-uid",
 								ProviderName: "upstream-oidc-provider-name",
 								ProviderType: psession.ProviderTypeOIDC,
@@ -897,13 +906,14 @@ func TestGarbageCollectorControllerSync(t *testing.T) {
 		when("there are valid, expired access token secrets which contain upstream refresh tokens", func() {
 			it.Before(func() {
 				offlineAccessGrantedOIDCAccessTokenSession := &accesstoken.Session{
-					Version: "2",
+					Version: "3",
 					Request: &fosite.Request{
 						GrantedScope: fosite.Arguments{"scope1", "scope2", "offline_access"},
 						ID:           "request-id-1",
 						Client:       &clientregistry.Client{},
 						Session: &psession.PinnipedSession{
 							Custom: &psession.CustomSessionData{
+								Username:     "should be ignored by garbage collector",
 								ProviderUID:  "upstream-oidc-provider-uid",
 								ProviderName: "upstream-oidc-provider-name",
 								ProviderType: psession.ProviderTypeOIDC,
@@ -941,13 +951,14 @@ func TestGarbageCollectorControllerSync(t *testing.T) {
 				r.NoError(kubeClient.Tracker().Add(offlineAccessGrantedOIDCAccessTokenSessionSecret))
 
 				offlineAccessNotGrantedOIDCAccessTokenSession := &accesstoken.Session{
-					Version: "2",
+					Version: "3",
 					Request: &fosite.Request{
 						GrantedScope: fosite.Arguments{"scope1", "scope2"},
 						ID:           "request-id-2",
 						Client:       &clientregistry.Client{},
 						Session: &psession.PinnipedSession{
 							Custom: &psession.CustomSessionData{
+								Username:     "should be ignored by garbage collector",
 								ProviderUID:  "upstream-oidc-provider-uid",
 								ProviderName: "upstream-oidc-provider-name",
 								ProviderType: psession.ProviderTypeOIDC,
@@ -1019,13 +1030,14 @@ func TestGarbageCollectorControllerSync(t *testing.T) {
 		when("there are valid, expired access token secrets which contain upstream access tokens", func() {
 			it.Before(func() {
 				offlineAccessGrantedOIDCAccessTokenSession := &accesstoken.Session{
-					Version: "2",
+					Version: "3",
 					Request: &fosite.Request{
 						GrantedScope: fosite.Arguments{"scope1", "scope2", "offline_access"},
 						ID:           "request-id-1",
 						Client:       &clientregistry.Client{},
 						Session: &psession.PinnipedSession{
 							Custom: &psession.CustomSessionData{
+								Username:     "should be ignored by garbage collector",
 								ProviderUID:  "upstream-oidc-provider-uid",
 								ProviderName: "upstream-oidc-provider-name",
 								ProviderType: psession.ProviderTypeOIDC,
@@ -1063,13 +1075,14 @@ func TestGarbageCollectorControllerSync(t *testing.T) {
 				r.NoError(kubeClient.Tracker().Add(offlineAccessGrantedOIDCAccessTokenSessionSecret))
 
 				offlineAccessNotGrantedOIDCAccessTokenSession := &accesstoken.Session{
-					Version: "2",
+					Version: "3",
 					Request: &fosite.Request{
 						GrantedScope: fosite.Arguments{"scope1", "scope2"},
 						ID:           "request-id-2",
 						Client:       &clientregistry.Client{},
 						Session: &psession.PinnipedSession{
 							Custom: &psession.CustomSessionData{
+								Username:     "should be ignored by garbage collector",
 								ProviderUID:  "upstream-oidc-provider-uid",
 								ProviderName: "upstream-oidc-provider-name",
 								ProviderType: psession.ProviderTypeOIDC,
@@ -1141,12 +1154,13 @@ func TestGarbageCollectorControllerSync(t *testing.T) {
 		when("there are valid, expired refresh secrets which contain upstream refresh tokens", func() {
 			it.Before(func() {
 				oidcRefreshSession := &refreshtoken.Session{
-					Version: "2",
+					Version: "3",
 					Request: &fosite.Request{
 						ID:     "request-id-1",
 						Client: &clientregistry.Client{},
 						Session: &psession.PinnipedSession{
 							Custom: &psession.CustomSessionData{
+								Username:     "should be ignored by garbage collector",
 								ProviderUID:  "upstream-oidc-provider-uid",
 								ProviderName: "upstream-oidc-provider-name",
 								ProviderType: psession.ProviderTypeOIDC,
@@ -1217,12 +1231,13 @@ func TestGarbageCollectorControllerSync(t *testing.T) {
 		when("there are valid, expired refresh secrets which contain upstream access tokens", func() {
 			it.Before(func() {
 				oidcRefreshSession := &refreshtoken.Session{
-					Version: "2",
+					Version: "3",
 					Request: &fosite.Request{
 						ID:     "request-id-1",
 						Client: &clientregistry.Client{},
 						Session: &psession.PinnipedSession{
 							Custom: &psession.CustomSessionData{
+								Username:     "should be ignored by garbage collector",
 								ProviderUID:  "upstream-oidc-provider-uid",
 								ProviderName: "upstream-oidc-provider-name",
 								ProviderType: psession.ProviderTypeOIDC,

--- a/internal/fositestorage/accesstoken/accesstoken.go
+++ b/internal/fositestorage/accesstoken/accesstoken.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package accesstoken
@@ -29,7 +29,8 @@ const (
 
 	// Version 1 was the initial release of storage.
 	// Version 2 is when we switched to storing psession.PinnipedSession inside the fosite request.
-	accessTokenStorageVersion = "2"
+	// Version 3 is when we added the Username field to the psession.CustomSessionData.
+	accessTokenStorageVersion = "3"
 )
 
 type RevocationStorage interface {

--- a/internal/fositestorage/accesstoken/accesstoken_test.go
+++ b/internal/fositestorage/accesstoken/accesstoken_test.go
@@ -53,7 +53,7 @@ func TestAccessTokenStorage(t *testing.T) {
 				},
 			},
 			Data: map[string][]byte{
-				"pinniped-storage-data":    []byte(`{"request":{"id":"abcd-1","requestedAt":"0001-01-01T00:00:00Z","client":{"id":"pinny","redirect_uris":null,"grant_types":null,"response_types":null,"scopes":null,"audience":null,"public":true,"jwks_uri":"where","jwks":null,"token_endpoint_auth_method":"something","request_uris":null,"request_object_signing_alg":"","token_endpoint_auth_signing_alg":""},"scopes":null,"grantedScopes":null,"form":{"key":["val"]},"session":{"fosite":{"Claims":null,"Headers":null,"ExpiresAt":null,"Username":"snorlax","Subject":"panda"},"custom":{"providerUID":"fake-provider-uid","providerName":"fake-provider-name","providerType":"fake-provider-type","warnings":null,"oidc":{"upstreamRefreshToken":"fake-upstream-refresh-token","upstreamAccessToken":"","upstreamSubject":"some-subject","upstreamIssuer":"some-issuer"}}},"requestedAudience":null,"grantedAudience":null},"version":"2"}`),
+				"pinniped-storage-data":    []byte(`{"request":{"id":"abcd-1","requestedAt":"0001-01-01T00:00:00Z","client":{"id":"pinny","redirect_uris":null,"grant_types":null,"response_types":null,"scopes":null,"audience":null,"public":true,"jwks_uri":"where","jwks":null,"token_endpoint_auth_method":"something","request_uris":null,"request_object_signing_alg":"","token_endpoint_auth_signing_alg":""},"scopes":null,"grantedScopes":null,"form":{"key":["val"]},"session":{"fosite":{"Claims":null,"Headers":null,"ExpiresAt":null,"Username":"snorlax","Subject":"panda"},"custom":{"username":"fake-username","providerUID":"fake-provider-uid","providerName":"fake-provider-name","providerType":"fake-provider-type","warnings":null,"oidc":{"upstreamRefreshToken":"fake-upstream-refresh-token","upstreamAccessToken":"","upstreamSubject":"some-subject","upstreamIssuer":"some-issuer"}}},"requestedAudience":null,"grantedAudience":null},"version":"3"}`),
 				"pinniped-storage-version": []byte("1"),
 			},
 			Type: "storage.pinniped.dev/access-token",
@@ -122,7 +122,7 @@ func TestAccessTokenStorageRevocation(t *testing.T) {
 				},
 			},
 			Data: map[string][]byte{
-				"pinniped-storage-data":    []byte(`{"request":{"id":"abcd-1","requestedAt":"0001-01-01T00:00:00Z","client":{"id":"pinny","redirect_uris":null,"grant_types":null,"response_types":null,"scopes":null,"audience":null,"public":true,"jwks_uri":"where","jwks":null,"token_endpoint_auth_method":"something","request_uris":null,"request_object_signing_alg":"","token_endpoint_auth_signing_alg":""},"scopes":null,"grantedScopes":null,"form":{"key":["val"]},"session":{"fosite":{"Claims":null,"Headers":null,"ExpiresAt":null,"Username":"snorlax","Subject":"panda"},"custom":{"providerUID":"fake-provider-uid","providerName":"fake-provider-name","providerType":"fake-provider-type","warnings":null,"oidc":{"upstreamRefreshToken":"fake-upstream-refresh-token","upstreamAccessToken":"","upstreamSubject":"some-subject","upstreamIssuer":"some-issuer"}}},"requestedAudience":null,"grantedAudience":null},"version":"2"}`),
+				"pinniped-storage-data":    []byte(`{"request":{"id":"abcd-1","requestedAt":"0001-01-01T00:00:00Z","client":{"id":"pinny","redirect_uris":null,"grant_types":null,"response_types":null,"scopes":null,"audience":null,"public":true,"jwks_uri":"where","jwks":null,"token_endpoint_auth_method":"something","request_uris":null,"request_object_signing_alg":"","token_endpoint_auth_signing_alg":""},"scopes":null,"grantedScopes":null,"form":{"key":["val"]},"session":{"fosite":{"Claims":null,"Headers":null,"ExpiresAt":null,"Username":"snorlax","Subject":"panda"},"custom":{"username":"fake-username","providerUID":"fake-provider-uid","providerName":"fake-provider-name","providerType":"fake-provider-type","warnings":null,"oidc":{"upstreamRefreshToken":"fake-upstream-refresh-token","upstreamAccessToken":"","upstreamSubject":"some-subject","upstreamIssuer":"some-issuer"}}},"requestedAudience":null,"grantedAudience":null},"version":"3"}`),
 				"pinniped-storage-version": []byte("1"),
 			},
 			Type: "storage.pinniped.dev/access-token",
@@ -195,7 +195,7 @@ func TestWrongVersion(t *testing.T) {
 
 	_, err = storage.GetAccessTokenSession(ctx, "fancy-signature", nil)
 
-	require.EqualError(t, err, "access token request data has wrong version: access token session for fancy-signature has version not-the-right-version instead of 2")
+	require.EqualError(t, err, "access token request data has wrong version: access token session for fancy-signature has version not-the-right-version instead of 3")
 }
 
 func TestNilSessionRequest(t *testing.T) {
@@ -213,7 +213,7 @@ func TestNilSessionRequest(t *testing.T) {
 			},
 		},
 		Data: map[string][]byte{
-			"pinniped-storage-data":    []byte(`{"nonsense-key": "nonsense-value","version":"2"}`),
+			"pinniped-storage-data":    []byte(`{"nonsense-key": "nonsense-value","version":"3"}`),
 			"pinniped-storage-version": []byte("1"),
 		},
 		Type: "storage.pinniped.dev/access-token",
@@ -297,13 +297,13 @@ func TestReadFromSecret(t *testing.T) {
 					},
 				},
 				Data: map[string][]byte{
-					"pinniped-storage-data":    []byte(`{"request":{"id":"abcd-1","session":{"fosite":{"Claims":null,"Headers":null,"ExpiresAt":null,"Username":"snorlax","Subject":"panda"},"custom":{"providerUID":"fake-provider-uid","providerName":"fake-provider-name","providerType":"fake-provider-type","oidc":{"upstreamRefreshToken":"fake-upstream-refresh-token"}}}},"version":"2","active": true}`),
+					"pinniped-storage-data":    []byte(`{"request":{"id":"abcd-1","session":{"fosite":{"Claims":null,"Headers":null,"ExpiresAt":null,"Username":"snorlax","Subject":"panda"},"custom":{"username":"fake-username","providerUID":"fake-provider-uid","providerName":"fake-provider-name","providerType":"fake-provider-type","oidc":{"upstreamRefreshToken":"fake-upstream-refresh-token"}}}},"version":"3","active": true}`),
 					"pinniped-storage-version": []byte("1"),
 				},
 				Type: "storage.pinniped.dev/access-token",
 			},
 			wantSession: &Session{
-				Version: "2",
+				Version: "3",
 				Request: &fosite.Request{
 					ID:     "abcd-1",
 					Client: &clientregistry.Client{},
@@ -313,6 +313,7 @@ func TestReadFromSecret(t *testing.T) {
 							Subject:  "panda",
 						},
 						Custom: &psession.CustomSessionData{
+							Username:     "fake-username",
 							ProviderUID:  "fake-provider-uid",
 							ProviderName: "fake-provider-name",
 							ProviderType: "fake-provider-type",
@@ -335,7 +336,7 @@ func TestReadFromSecret(t *testing.T) {
 					},
 				},
 				Data: map[string][]byte{
-					"pinniped-storage-data":    []byte(`{"request":{"id":"abcd-1"},"version":"2","active": true}`),
+					"pinniped-storage-data":    []byte(`{"request":{"id":"abcd-1"},"version":"3","active": true}`),
 					"pinniped-storage-version": []byte("1"),
 				},
 				Type: "storage.pinniped.dev/not-access-token",
@@ -358,7 +359,7 @@ func TestReadFromSecret(t *testing.T) {
 				},
 				Type: "storage.pinniped.dev/access-token",
 			},
-			wantErr: "access token request data has wrong version: access token session has version wrong-version-here instead of 2",
+			wantErr: "access token request data has wrong version: access token session has version wrong-version-here instead of 3",
 		},
 		{
 			name: "missing request",
@@ -371,7 +372,7 @@ func TestReadFromSecret(t *testing.T) {
 					},
 				},
 				Data: map[string][]byte{
-					"pinniped-storage-data":    []byte(`{"version":"2","active": true}`),
+					"pinniped-storage-data":    []byte(`{"version":"3","active": true}`),
 					"pinniped-storage-version": []byte("1"),
 				},
 				Type: "storage.pinniped.dev/access-token",

--- a/internal/fositestorage/authorizationcode/authorizationcode.go
+++ b/internal/fositestorage/authorizationcode/authorizationcode.go
@@ -30,7 +30,8 @@ const (
 
 	// Version 1 was the initial release of storage.
 	// Version 2 is when we switched to storing psession.PinnipedSession inside the fosite request.
-	authorizeCodeStorageVersion = "2"
+	// Version 3 is when we added the Username field to the psession.CustomSessionData.
+	authorizeCodeStorageVersion = "3"
 )
 
 var _ oauth2.AuthorizeCodeStorage = &authorizeCodeStorage{}
@@ -366,45 +367,43 @@ const ExpectedAuthorizeCodeSessionJSONFromFuzzing = `{
 				"Subject": "\u0026¥潝邎Ȗ莅ŝǔ盕戙鵮碡ʯiŬŽ"
 			},
 			"custom": {
-				"providerUID": "Ĝ眧Ĭ",
-				"providerName": "ŉ2ƋŢ觛ǂ焺nŐǛ",
-				"providerType": "ɥ闣ʬ橳(ý綃ʃʚƟ覣k眐4",
+				"username": "Ĝ眧Ĭ",
+				"providerUID": "ŉ2ƋŢ觛ǂ焺nŐǛ",
+				"providerName": "ɥ闣ʬ橳(ý綃ʃʚƟ覣k眐4",
+				"providerType": "ȣ掘ʃƸ澺淗a紽ǒ|鰽",
 				"warnings": [
-					"掘ʃƸ澺淗a紽ǒ|鰽ŋ猊",
-					"毇妬\u003e6鉢緋uƴŤȱʀļÂ?"
+					"t毇妬\u003e6鉢緋uƴŤȱʀļÂ",
+					"虝27就伒犘c钡ɏȫ齁š"
 				],
 				"oidc": {
-					"upstreamRefreshToken": "\u003cƬb",
-					"upstreamAccessToken": "犘c钡ɏȫ",
-					"upstreamSubject": "鬌",
-					"upstreamIssuer": "%OpKȱ藚ɏ¬Ê蒭堜"
+					"upstreamRefreshToken": "OpKȱ藚ɏ¬Ê蒭堜]ȗ韚ʫ繕ȫ碰+ʫ",
+					"upstreamAccessToken": "k9帴",
+					"upstreamSubject": "磊ůď逳鞪?3)藵睋邔\u0026Ű惫蜀Ģ",
+					"upstreamIssuer": "4İ"
 				},
 				"ldap": {
-					"userDN": "ȗ韚ʫ繕ȫ碰+",
+					"userDN": "×",
 					"extraRefreshAttributes": {
-						"+î艔垎0": "ĝ",
-						"4İ": "墀jMʥ",
-						"k9帴": "磊ůď逳鞪?3)藵睋邔\u0026Ű惫蜀Ģ"
+						"ʥ笿0D": "s"
 					}
 				},
 				"activedirectory": {
-					"userDN": "%Ä摱ìÓȐĨf跞@)¿,ɭS隑i",
+					"userDN": "ĝ",
 					"extraRefreshAttributes": {
-						" 皦pSǬŝ社Vƅȭǝ*擦28ǅ": "vư",
-						"艱iYn面@yȝƋ鬯犦獢9c5¤.岵": "浛a齙\\蹼偦歛"
+						"IȽ齤士bEǎ": "跞@)¿,ɭS隑ip偶宾儮猷V麹",
+						"ȝƋ鬯犦獢9c5¤.岵": "浛a齙\\蹼偦歛"
 					}
 				}
 			}
 		},
 		"requestedAudience": [
-			"置b",
-			"筫MN\u0026錝D肁Ŷɽ蔒PR}Ųʓl{"
+			" 皦pSǬŝ社Vƅȭǝ*擦28ǅ",
+			"vư"
 		],
 		"grantedAudience": [
-			"jÃ轘屔挝",
-			"Œų崓ļ憽-蹐È_¸]fś",
-			"ɵʮGɃɫ囤1+,Ȳ"
+			"置b",
+			"筫MN\u0026錝D肁Ŷɽ蔒PR}Ųʓl{"
 		]
 	},
-	"version": "2"
+	"version": "3"
 }`

--- a/internal/fositestorage/authorizationcode/authorizationcode_test.go
+++ b/internal/fositestorage/authorizationcode/authorizationcode_test.go
@@ -65,7 +65,7 @@ func TestAuthorizationCodeStorage(t *testing.T) {
 				},
 			},
 			Data: map[string][]byte{
-				"pinniped-storage-data":    []byte(`{"active":true,"request":{"id":"abcd-1","requestedAt":"0001-01-01T00:00:00Z","client":{"id":"pinny","redirect_uris":null,"grant_types":null,"response_types":null,"scopes":null,"audience":null,"public":true,"jwks_uri":"where","jwks":null,"token_endpoint_auth_method":"something","request_uris":null,"request_object_signing_alg":"","token_endpoint_auth_signing_alg":""},"scopes":null,"grantedScopes":null,"form":{"key":["val"]},"session":{"fosite":{"Claims":null,"Headers":null,"ExpiresAt":null,"Username":"snorlax","Subject":"panda"},"custom":{"providerUID":"fake-provider-uid","providerName":"fake-provider-name","providerType":"fake-provider-type","warnings":null,"oidc":{"upstreamRefreshToken":"fake-upstream-refresh-token","upstreamAccessToken":"","upstreamSubject":"some-subject","upstreamIssuer":"some-issuer"}}},"requestedAudience":null,"grantedAudience":null},"version":"2"}`),
+				"pinniped-storage-data":    []byte(`{"active":true,"request":{"id":"abcd-1","requestedAt":"0001-01-01T00:00:00Z","client":{"id":"pinny","redirect_uris":null,"grant_types":null,"response_types":null,"scopes":null,"audience":null,"public":true,"jwks_uri":"where","jwks":null,"token_endpoint_auth_method":"something","request_uris":null,"request_object_signing_alg":"","token_endpoint_auth_signing_alg":""},"scopes":null,"grantedScopes":null,"form":{"key":["val"]},"session":{"fosite":{"Claims":null,"Headers":null,"ExpiresAt":null,"Username":"snorlax","Subject":"panda"},"custom":{"username":"fake-username","providerUID":"fake-provider-uid","providerName":"fake-provider-name","providerType":"fake-provider-type","warnings":null,"oidc":{"upstreamRefreshToken":"fake-upstream-refresh-token","upstreamAccessToken":"","upstreamSubject":"some-subject","upstreamIssuer":"some-issuer"}}},"requestedAudience":null,"grantedAudience":null},"version":"3"}`),
 				"pinniped-storage-version": []byte("1"),
 			},
 			Type: "storage.pinniped.dev/authcode",
@@ -84,7 +84,7 @@ func TestAuthorizationCodeStorage(t *testing.T) {
 				},
 			},
 			Data: map[string][]byte{
-				"pinniped-storage-data":    []byte(`{"active":false,"request":{"id":"abcd-1","requestedAt":"0001-01-01T00:00:00Z","client":{"id":"pinny","redirect_uris":null,"grant_types":null,"response_types":null,"scopes":null,"audience":null,"public":true,"jwks_uri":"where","jwks":null,"token_endpoint_auth_method":"something","request_uris":null,"request_object_signing_alg":"","token_endpoint_auth_signing_alg":""},"scopes":null,"grantedScopes":null,"form":{"key":["val"]},"session":{"fosite":{"Claims":null,"Headers":null,"ExpiresAt":null,"Username":"snorlax","Subject":"panda"},"custom":{"providerUID":"fake-provider-uid","providerName":"fake-provider-name","providerType":"fake-provider-type","warnings":null,"oidc":{"upstreamRefreshToken":"fake-upstream-refresh-token","upstreamAccessToken":"","upstreamSubject":"some-subject","upstreamIssuer":"some-issuer"}}},"requestedAudience":null,"grantedAudience":null},"version":"2"}`),
+				"pinniped-storage-data":    []byte(`{"active":false,"request":{"id":"abcd-1","requestedAt":"0001-01-01T00:00:00Z","client":{"id":"pinny","redirect_uris":null,"grant_types":null,"response_types":null,"scopes":null,"audience":null,"public":true,"jwks_uri":"where","jwks":null,"token_endpoint_auth_method":"something","request_uris":null,"request_object_signing_alg":"","token_endpoint_auth_signing_alg":""},"scopes":null,"grantedScopes":null,"form":{"key":["val"]},"session":{"fosite":{"Claims":null,"Headers":null,"ExpiresAt":null,"Username":"snorlax","Subject":"panda"},"custom":{"username":"fake-username","providerUID":"fake-provider-uid","providerName":"fake-provider-name","providerType":"fake-provider-type","warnings":null,"oidc":{"upstreamRefreshToken":"fake-upstream-refresh-token","upstreamAccessToken":"","upstreamSubject":"some-subject","upstreamIssuer":"some-issuer"}}},"requestedAudience":null,"grantedAudience":null},"version":"3"}`),
 				"pinniped-storage-version": []byte("1"),
 			},
 			Type: "storage.pinniped.dev/authcode",
@@ -202,7 +202,7 @@ func TestWrongVersion(t *testing.T) {
 
 	_, err = storage.GetAuthorizeCodeSession(ctx, "fancy-signature", nil)
 
-	require.EqualError(t, err, "authorization request data has wrong version: authorization code session for fancy-signature has version not-the-right-version instead of 2")
+	require.EqualError(t, err, "authorization request data has wrong version: authorization code session for fancy-signature has version not-the-right-version instead of 3")
 }
 
 func TestNilSessionRequest(t *testing.T) {
@@ -217,7 +217,7 @@ func TestNilSessionRequest(t *testing.T) {
 			},
 		},
 		Data: map[string][]byte{
-			"pinniped-storage-data":    []byte(`{"nonsense-key": "nonsense-value", "version":"2", "active": true}`),
+			"pinniped-storage-data":    []byte(`{"nonsense-key": "nonsense-value", "version":"3", "active": true}`),
 			"pinniped-storage-version": []byte("1"),
 		},
 		Type: "storage.pinniped.dev/authcode",
@@ -384,7 +384,7 @@ func TestFuzzAndJSONNewValidEmptyAuthorizeCodeSession(t *testing.T) {
 
 	// set these to match CreateAuthorizeCodeSession so that .JSONEq works
 	validSession.Active = true
-	validSession.Version = "2"
+	validSession.Version = "3"
 
 	validSessionJSONBytes, err := json.MarshalIndent(validSession, "", "\t")
 	require.NoError(t, err)
@@ -419,13 +419,13 @@ func TestReadFromSecret(t *testing.T) {
 					},
 				},
 				Data: map[string][]byte{
-					"pinniped-storage-data":    []byte(`{"request":{"id":"abcd-1","session":{"fosite":{"Claims":null,"Headers":null,"ExpiresAt":null,"Username":"snorlax","Subject":"panda"},"custom":{"providerUID":"fake-provider-uid","providerName":"fake-provider-name","providerType":"fake-provider-type","oidc":{"upstreamRefreshToken":"fake-upstream-refresh-token"}}}},"version":"2","active": true}`),
+					"pinniped-storage-data":    []byte(`{"request":{"id":"abcd-1","session":{"fosite":{"Claims":null,"Headers":null,"ExpiresAt":null,"Username":"snorlax","Subject":"panda"},"custom":{"username":"fake-username","providerUID":"fake-provider-uid","providerName":"fake-provider-name","providerType":"fake-provider-type","oidc":{"upstreamRefreshToken":"fake-upstream-refresh-token"}}}},"version":"3","active": true}`),
 					"pinniped-storage-version": []byte("1"),
 				},
 				Type: "storage.pinniped.dev/authcode",
 			},
 			wantSession: &Session{
-				Version: "2",
+				Version: "3",
 				Active:  true,
 				Request: &fosite.Request{
 					ID:     "abcd-1",
@@ -436,6 +436,7 @@ func TestReadFromSecret(t *testing.T) {
 							Subject:  "panda",
 						},
 						Custom: &psession.CustomSessionData{
+							Username:     "fake-username",
 							ProviderUID:  "fake-provider-uid",
 							ProviderName: "fake-provider-name",
 							ProviderType: "fake-provider-type",
@@ -458,7 +459,7 @@ func TestReadFromSecret(t *testing.T) {
 					},
 				},
 				Data: map[string][]byte{
-					"pinniped-storage-data":    []byte(`{"request":{"id":"abcd-1"},"version":"2","active": true}`),
+					"pinniped-storage-data":    []byte(`{"request":{"id":"abcd-1"},"version":"3","active": true}`),
 					"pinniped-storage-version": []byte("1"),
 				},
 				Type: "storage.pinniped.dev/not-authcode",
@@ -481,7 +482,7 @@ func TestReadFromSecret(t *testing.T) {
 				},
 				Type: "storage.pinniped.dev/authcode",
 			},
-			wantErr: "authorization request data has wrong version: authorization code session has version wrong-version-here instead of 2",
+			wantErr: "authorization request data has wrong version: authorization code session has version wrong-version-here instead of 3",
 		},
 		{
 			name: "missing request",
@@ -494,7 +495,7 @@ func TestReadFromSecret(t *testing.T) {
 					},
 				},
 				Data: map[string][]byte{
-					"pinniped-storage-data":    []byte(`{"version":"2","active": true}`),
+					"pinniped-storage-data":    []byte(`{"version":"3","active": true}`),
 					"pinniped-storage-version": []byte("1"),
 				},
 				Type: "storage.pinniped.dev/authcode",

--- a/internal/fositestorage/openidconnect/openidconnect.go
+++ b/internal/fositestorage/openidconnect/openidconnect.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package openidconnect
@@ -30,7 +30,8 @@ const (
 
 	// Version 1 was the initial release of storage.
 	// Version 2 is when we switched to storing psession.PinnipedSession inside the fosite request.
-	oidcStorageVersion = "2"
+	// Version 3 is when we added the Username field to the psession.CustomSessionData.
+	oidcStorageVersion = "3"
 )
 
 var _ openid.OpenIDConnectRequestStorage = &openIDConnectRequestStorage{}

--- a/internal/fositestorage/openidconnect/openidconnect_test.go
+++ b/internal/fositestorage/openidconnect/openidconnect_test.go
@@ -52,7 +52,7 @@ func TestOpenIdConnectStorage(t *testing.T) {
 				},
 			},
 			Data: map[string][]byte{
-				"pinniped-storage-data":    []byte(`{"request":{"id":"abcd-1","requestedAt":"0001-01-01T00:00:00Z","client":{"id":"pinny","redirect_uris":null,"grant_types":null,"response_types":null,"scopes":null,"audience":null,"public":true,"jwks_uri":"where","jwks":null,"token_endpoint_auth_method":"something","request_uris":null,"request_object_signing_alg":"","token_endpoint_auth_signing_alg":""},"scopes":null,"grantedScopes":null,"form":{"key":["val"]},"session":{"fosite":{"Claims":null,"Headers":null,"ExpiresAt":null,"Username":"snorlax","Subject":"panda"},"custom":{"providerUID":"fake-provider-uid","providerName":"fake-provider-name","providerType":"fake-provider-type","warnings":null,"oidc":{"upstreamRefreshToken":"fake-upstream-refresh-token","upstreamAccessToken":"","upstreamSubject":"some-subject","upstreamIssuer":"some-issuer"}}},"requestedAudience":null,"grantedAudience":null},"version":"2"}`),
+				"pinniped-storage-data":    []byte(`{"request":{"id":"abcd-1","requestedAt":"0001-01-01T00:00:00Z","client":{"id":"pinny","redirect_uris":null,"grant_types":null,"response_types":null,"scopes":null,"audience":null,"public":true,"jwks_uri":"where","jwks":null,"token_endpoint_auth_method":"something","request_uris":null,"request_object_signing_alg":"","token_endpoint_auth_signing_alg":""},"scopes":null,"grantedScopes":null,"form":{"key":["val"]},"session":{"fosite":{"Claims":null,"Headers":null,"ExpiresAt":null,"Username":"snorlax","Subject":"panda"},"custom":{"username":"fake-username","providerUID":"fake-provider-uid","providerName":"fake-provider-name","providerType":"fake-provider-type","warnings":null,"oidc":{"upstreamRefreshToken":"fake-upstream-refresh-token","upstreamAccessToken":"","upstreamSubject":"some-subject","upstreamIssuer":"some-issuer"}}},"requestedAudience":null,"grantedAudience":null},"version":"3"}`),
 				"pinniped-storage-version": []byte("1"),
 			},
 			Type: "storage.pinniped.dev/oidc",
@@ -137,7 +137,7 @@ func TestWrongVersion(t *testing.T) {
 
 	_, err = storage.GetOpenIDConnectSession(ctx, "fancy-code.fancy-signature", nil)
 
-	require.EqualError(t, err, "oidc request data has wrong version: oidc session for fancy-signature has version not-the-right-version instead of 2")
+	require.EqualError(t, err, "oidc request data has wrong version: oidc session for fancy-signature has version not-the-right-version instead of 3")
 }
 
 func TestNilSessionRequest(t *testing.T) {
@@ -152,7 +152,7 @@ func TestNilSessionRequest(t *testing.T) {
 			},
 		},
 		Data: map[string][]byte{
-			"pinniped-storage-data":    []byte(`{"nonsense-key": "nonsense-value","version":"2"}`),
+			"pinniped-storage-data":    []byte(`{"nonsense-key": "nonsense-value","version":"3"}`),
 			"pinniped-storage-version": []byte("1"),
 		},
 		Type: "storage.pinniped.dev/oidc",

--- a/internal/fositestorage/pkce/pkce.go
+++ b/internal/fositestorage/pkce/pkce.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package pkce
@@ -28,7 +28,8 @@ const (
 
 	// Version 1 was the initial release of storage.
 	// Version 2 is when we switched to storing psession.PinnipedSession inside the fosite request.
-	pkceStorageVersion = "2"
+	// Version 3 is when we added the Username field to the psession.CustomSessionData.
+	pkceStorageVersion = "3"
 )
 
 var _ pkce.PKCERequestStorage = &pkceStorage{}

--- a/internal/fositestorage/pkce/pkce_test.go
+++ b/internal/fositestorage/pkce/pkce_test.go
@@ -52,7 +52,7 @@ func TestPKCEStorage(t *testing.T) {
 				},
 			},
 			Data: map[string][]byte{
-				"pinniped-storage-data":    []byte(`{"request":{"id":"abcd-1","requestedAt":"0001-01-01T00:00:00Z","client":{"id":"pinny","redirect_uris":null,"grant_types":null,"response_types":null,"scopes":null,"audience":null,"public":true,"jwks_uri":"where","jwks":null,"token_endpoint_auth_method":"something","request_uris":null,"request_object_signing_alg":"","token_endpoint_auth_signing_alg":""},"scopes":null,"grantedScopes":null,"form":{"key":["val"]},"session":{"fosite":{"Claims":null,"Headers":null,"ExpiresAt":null,"Username":"snorlax","Subject":"panda"},"custom":{"providerUID":"fake-provider-uid","providerName":"fake-provider-name","providerType":"fake-provider-type","warnings":null,"oidc":{"upstreamRefreshToken":"fake-upstream-refresh-token","upstreamAccessToken":"","upstreamSubject":"some-subject","upstreamIssuer":"some-issuer"}}},"requestedAudience":null,"grantedAudience":null},"version":"2"}`),
+				"pinniped-storage-data":    []byte(`{"request":{"id":"abcd-1","requestedAt":"0001-01-01T00:00:00Z","client":{"id":"pinny","redirect_uris":null,"grant_types":null,"response_types":null,"scopes":null,"audience":null,"public":true,"jwks_uri":"where","jwks":null,"token_endpoint_auth_method":"something","request_uris":null,"request_object_signing_alg":"","token_endpoint_auth_signing_alg":""},"scopes":null,"grantedScopes":null,"form":{"key":["val"]},"session":{"fosite":{"Claims":null,"Headers":null,"ExpiresAt":null,"Username":"snorlax","Subject":"panda"},"custom":{"username":"fake-username","providerUID":"fake-provider-uid","providerName":"fake-provider-name","providerType":"fake-provider-type","warnings":null,"oidc":{"upstreamRefreshToken":"fake-upstream-refresh-token","upstreamAccessToken":"","upstreamSubject":"some-subject","upstreamIssuer":"some-issuer"}}},"requestedAudience":null,"grantedAudience":null},"version":"3"}`),
 				"pinniped-storage-version": []byte("1"),
 			},
 			Type: "storage.pinniped.dev/pkce",
@@ -140,7 +140,7 @@ func TestWrongVersion(t *testing.T) {
 
 	_, err = storage.GetPKCERequestSession(ctx, "fancy-signature", nil)
 
-	require.EqualError(t, err, "pkce request data has wrong version: pkce session for fancy-signature has version not-the-right-version instead of 2")
+	require.EqualError(t, err, "pkce request data has wrong version: pkce session for fancy-signature has version not-the-right-version instead of 3")
 }
 
 func TestNilSessionRequest(t *testing.T) {
@@ -158,7 +158,7 @@ func TestNilSessionRequest(t *testing.T) {
 			},
 		},
 		Data: map[string][]byte{
-			"pinniped-storage-data":    []byte(`{"nonsense-key": "nonsense-value","version":"2"}`),
+			"pinniped-storage-data":    []byte(`{"nonsense-key": "nonsense-value","version":"3"}`),
 			"pinniped-storage-version": []byte("1"),
 		},
 		Type: "storage.pinniped.dev/pkce",

--- a/internal/fositestorage/refreshtoken/refreshtoken.go
+++ b/internal/fositestorage/refreshtoken/refreshtoken.go
@@ -29,7 +29,8 @@ const (
 
 	// Version 1 was the initial release of storage.
 	// Version 2 is when we switched to storing psession.PinnipedSession inside the fosite request.
-	refreshTokenStorageVersion = "2"
+	// Version 3 is when we added the Username field to the psession.CustomSessionData.
+	refreshTokenStorageVersion = "3"
 )
 
 type RevocationStorage interface {

--- a/internal/fositestorage/refreshtoken/refreshtoken_test.go
+++ b/internal/fositestorage/refreshtoken/refreshtoken_test.go
@@ -52,7 +52,7 @@ func TestRefreshTokenStorage(t *testing.T) {
 				},
 			},
 			Data: map[string][]byte{
-				"pinniped-storage-data":    []byte(`{"request":{"id":"abcd-1","requestedAt":"0001-01-01T00:00:00Z","client":{"id":"pinny","redirect_uris":null,"grant_types":null,"response_types":null,"scopes":null,"audience":null,"public":true,"jwks_uri":"where","jwks":null,"token_endpoint_auth_method":"something","request_uris":null,"request_object_signing_alg":"","token_endpoint_auth_signing_alg":""},"scopes":null,"grantedScopes":null,"form":{"key":["val"]},"session":{"fosite":{"Claims":null,"Headers":null,"ExpiresAt":null,"Username":"snorlax","Subject":"panda"},"custom":{"providerUID":"fake-provider-uid","providerName":"fake-provider-name","providerType":"fake-provider-type","warnings":null,"oidc":{"upstreamRefreshToken":"fake-upstream-refresh-token","upstreamAccessToken":"","upstreamSubject":"some-subject","upstreamIssuer":"some-issuer"}}},"requestedAudience":null,"grantedAudience":null},"version":"2"}`),
+				"pinniped-storage-data":    []byte(`{"request":{"id":"abcd-1","requestedAt":"0001-01-01T00:00:00Z","client":{"id":"pinny","redirect_uris":null,"grant_types":null,"response_types":null,"scopes":null,"audience":null,"public":true,"jwks_uri":"where","jwks":null,"token_endpoint_auth_method":"something","request_uris":null,"request_object_signing_alg":"","token_endpoint_auth_signing_alg":""},"scopes":null,"grantedScopes":null,"form":{"key":["val"]},"session":{"fosite":{"Claims":null,"Headers":null,"ExpiresAt":null,"Username":"snorlax","Subject":"panda"},"custom":{"username":"fake-username","providerUID":"fake-provider-uid","providerName":"fake-provider-name","providerType":"fake-provider-type","warnings":null,"oidc":{"upstreamRefreshToken":"fake-upstream-refresh-token","upstreamAccessToken":"","upstreamSubject":"some-subject","upstreamIssuer":"some-issuer"}}},"requestedAudience":null,"grantedAudience":null},"version":"3"}`),
 				"pinniped-storage-version": []byte("1"),
 			},
 			Type: "storage.pinniped.dev/refresh-token",
@@ -122,7 +122,7 @@ func TestRefreshTokenStorageRevocation(t *testing.T) {
 				},
 			},
 			Data: map[string][]byte{
-				"pinniped-storage-data":    []byte(`{"request":{"id":"abcd-1","requestedAt":"0001-01-01T00:00:00Z","client":{"id":"pinny","redirect_uris":null,"grant_types":null,"response_types":null,"scopes":null,"audience":null,"public":true,"jwks_uri":"where","jwks":null,"token_endpoint_auth_method":"something","request_uris":null,"request_object_signing_alg":"","token_endpoint_auth_signing_alg":""},"scopes":null,"grantedScopes":null,"form":{"key":["val"]},"session":{"fosite":{"Claims":null,"Headers":null,"ExpiresAt":null,"Username":"snorlax","Subject":"panda"},"custom":{"providerUID":"fake-provider-uid","providerName":"fake-provider-name","providerType":"fake-provider-type","warnings":null,"oidc":{"upstreamRefreshToken":"fake-upstream-refresh-token","upstreamAccessToken":"","upstreamSubject":"some-subject","upstreamIssuer":"some-issuer"}}},"requestedAudience":null,"grantedAudience":null},"version":"2"}`),
+				"pinniped-storage-data":    []byte(`{"request":{"id":"abcd-1","requestedAt":"0001-01-01T00:00:00Z","client":{"id":"pinny","redirect_uris":null,"grant_types":null,"response_types":null,"scopes":null,"audience":null,"public":true,"jwks_uri":"where","jwks":null,"token_endpoint_auth_method":"something","request_uris":null,"request_object_signing_alg":"","token_endpoint_auth_signing_alg":""},"scopes":null,"grantedScopes":null,"form":{"key":["val"]},"session":{"fosite":{"Claims":null,"Headers":null,"ExpiresAt":null,"Username":"snorlax","Subject":"panda"},"custom":{"username":"fake-username","providerUID":"fake-provider-uid","providerName":"fake-provider-name","providerType":"fake-provider-type","warnings":null,"oidc":{"upstreamRefreshToken":"fake-upstream-refresh-token","upstreamAccessToken":"","upstreamSubject":"some-subject","upstreamIssuer":"some-issuer"}}},"requestedAudience":null,"grantedAudience":null},"version":"3"}`),
 				"pinniped-storage-version": []byte("1"),
 			},
 			Type: "storage.pinniped.dev/refresh-token",
@@ -177,7 +177,7 @@ func TestRefreshTokenStorageRevokeRefreshTokenMaybeGracePeriod(t *testing.T) {
 				},
 			},
 			Data: map[string][]byte{
-				"pinniped-storage-data":    []byte(`{"request":{"id":"abcd-1","requestedAt":"0001-01-01T00:00:00Z","client":{"id":"pinny","redirect_uris":null,"grant_types":null,"response_types":null,"scopes":null,"audience":null,"public":true,"jwks_uri":"where","jwks":null,"token_endpoint_auth_method":"something","request_uris":null,"request_object_signing_alg":"","token_endpoint_auth_signing_alg":""},"scopes":null,"grantedScopes":null,"form":{"key":["val"]},"session":{"fosite":{"Claims":null,"Headers":null,"ExpiresAt":null,"Username":"snorlax","Subject":"panda"},"custom":{"providerUID":"fake-provider-uid","providerName":"fake-provider-name","providerType":"fake-provider-type","warnings":null,"oidc":{"upstreamRefreshToken":"fake-upstream-refresh-token","upstreamAccessToken":"","upstreamSubject":"some-subject","upstreamIssuer":"some-issuer"}}},"requestedAudience":null,"grantedAudience":null},"version":"2"}`),
+				"pinniped-storage-data":    []byte(`{"request":{"id":"abcd-1","requestedAt":"0001-01-01T00:00:00Z","client":{"id":"pinny","redirect_uris":null,"grant_types":null,"response_types":null,"scopes":null,"audience":null,"public":true,"jwks_uri":"where","jwks":null,"token_endpoint_auth_method":"something","request_uris":null,"request_object_signing_alg":"","token_endpoint_auth_signing_alg":""},"scopes":null,"grantedScopes":null,"form":{"key":["val"]},"session":{"fosite":{"Claims":null,"Headers":null,"ExpiresAt":null,"Username":"snorlax","Subject":"panda"},"custom":{"username":"fake-username","providerUID":"fake-provider-uid","providerName":"fake-provider-name","providerType":"fake-provider-type","warnings":null,"oidc":{"upstreamRefreshToken":"fake-upstream-refresh-token","upstreamAccessToken":"","upstreamSubject":"some-subject","upstreamIssuer":"some-issuer"}}},"requestedAudience":null,"grantedAudience":null},"version":"3"}`),
 				"pinniped-storage-version": []byte("1"),
 			},
 			Type: "storage.pinniped.dev/refresh-token",
@@ -251,7 +251,7 @@ func TestWrongVersion(t *testing.T) {
 
 	_, err = storage.GetRefreshTokenSession(ctx, "fancy-signature", nil)
 
-	require.EqualError(t, err, "refresh token request data has wrong version: refresh token session for fancy-signature has version not-the-right-version instead of 2")
+	require.EqualError(t, err, "refresh token request data has wrong version: refresh token session for fancy-signature has version not-the-right-version instead of 3")
 }
 
 func TestNilSessionRequest(t *testing.T) {
@@ -269,7 +269,7 @@ func TestNilSessionRequest(t *testing.T) {
 			},
 		},
 		Data: map[string][]byte{
-			"pinniped-storage-data":    []byte(`{"nonsense-key": "nonsense-value","version":"2"}`),
+			"pinniped-storage-data":    []byte(`{"nonsense-key": "nonsense-value","version":"3"}`),
 			"pinniped-storage-version": []byte("1"),
 		},
 		Type: "storage.pinniped.dev/refresh-token",
@@ -353,13 +353,13 @@ func TestReadFromSecret(t *testing.T) {
 					},
 				},
 				Data: map[string][]byte{
-					"pinniped-storage-data":    []byte(`{"request":{"id":"abcd-1","session":{"fosite":{"Claims":null,"Headers":null,"ExpiresAt":null,"Username":"snorlax","Subject":"panda"},"custom":{"providerUID":"fake-provider-uid","providerName":"fake-provider-name","providerType":"fake-provider-type","oidc":{"upstreamRefreshToken":"fake-upstream-refresh-token"}}}},"version":"2","active": true}`),
+					"pinniped-storage-data":    []byte(`{"request":{"id":"abcd-1","session":{"fosite":{"Claims":null,"Headers":null,"ExpiresAt":null,"Username":"snorlax","Subject":"panda"},"custom":{"username":"fake-username","providerUID":"fake-provider-uid","providerName":"fake-provider-name","providerType":"fake-provider-type","oidc":{"upstreamRefreshToken":"fake-upstream-refresh-token"}}}},"version":"3","active": true}`),
 					"pinniped-storage-version": []byte("1"),
 				},
 				Type: "storage.pinniped.dev/refresh-token",
 			},
 			wantSession: &Session{
-				Version: "2",
+				Version: "3",
 				Request: &fosite.Request{
 					ID:     "abcd-1",
 					Client: &clientregistry.Client{},
@@ -369,6 +369,7 @@ func TestReadFromSecret(t *testing.T) {
 							Subject:  "panda",
 						},
 						Custom: &psession.CustomSessionData{
+							Username:     "fake-username",
 							ProviderUID:  "fake-provider-uid",
 							ProviderName: "fake-provider-name",
 							ProviderType: "fake-provider-type",
@@ -391,7 +392,7 @@ func TestReadFromSecret(t *testing.T) {
 					},
 				},
 				Data: map[string][]byte{
-					"pinniped-storage-data":    []byte(`{"request":{"id":"abcd-1"},"version":"2","active": true}`),
+					"pinniped-storage-data":    []byte(`{"request":{"id":"abcd-1"},"version":"3","active": true}`),
 					"pinniped-storage-version": []byte("1"),
 				},
 				Type: "storage.pinniped.dev/not-refresh-token",
@@ -414,7 +415,7 @@ func TestReadFromSecret(t *testing.T) {
 				},
 				Type: "storage.pinniped.dev/refresh-token",
 			},
-			wantErr: "refresh token request data has wrong version: refresh token session has version wrong-version-here instead of 2",
+			wantErr: "refresh token request data has wrong version: refresh token session has version wrong-version-here instead of 3",
 		},
 		{
 			name: "missing request",
@@ -427,7 +428,7 @@ func TestReadFromSecret(t *testing.T) {
 					},
 				},
 				Data: map[string][]byte{
-					"pinniped-storage-data":    []byte(`{"version":"2","active": true}`),
+					"pinniped-storage-data":    []byte(`{"version":"3","active": true}`),
 					"pinniped-storage-version": []byte("1"),
 				},
 				Type: "storage.pinniped.dev/refresh-token",

--- a/internal/oidc/auth/auth_handler.go
+++ b/internal/oidc/auth/auth_handler.go
@@ -149,7 +149,8 @@ func handleAuthRequestForLDAPUpstreamCLIFlow(
 	username = authenticateResponse.User.GetName()
 	groups := authenticateResponse.User.GetGroups()
 	customSessionData := downstreamsession.MakeDownstreamLDAPOrADCustomSessionData(ldapUpstream, idpType, authenticateResponse, username)
-	openIDSession := downstreamsession.MakeDownstreamSession(subject, username, groups, authorizeRequester.GetGrantedScopes(), customSessionData)
+	openIDSession := downstreamsession.MakeDownstreamSession(subject, username, groups,
+		authorizeRequester.GetGrantedScopes(), authorizeRequester.GetClient().GetID(), customSessionData)
 	oidc.PerformAuthcodeRedirect(r, w, oauthHelper, authorizeRequester, openIDSession, true)
 
 	return nil
@@ -250,7 +251,8 @@ func handleAuthRequestForOIDCUpstreamPasswordGrant(
 		return nil
 	}
 
-	openIDSession := downstreamsession.MakeDownstreamSession(subject, username, groups, authorizeRequester.GetGrantedScopes(), customSessionData)
+	openIDSession := downstreamsession.MakeDownstreamSession(subject, username, groups,
+		authorizeRequester.GetGrantedScopes(), authorizeRequester.GetClient().GetID(), customSessionData)
 
 	oidc.PerformAuthcodeRedirect(r, w, oauthHelper, authorizeRequester, openIDSession, true)
 

--- a/internal/oidc/auth/auth_handler.go
+++ b/internal/oidc/auth/auth_handler.go
@@ -10,17 +10,15 @@ import (
 	"net/url"
 	"time"
 
-	coreosoidc "github.com/coreos/go-oidc/v3/oidc"
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/handler/openid"
 	"github.com/ory/fosite/token/jwt"
 	"golang.org/x/oauth2"
 
-	supervisoroidc "go.pinniped.dev/generated/latest/apis/supervisor/oidc"
+	oidcapi "go.pinniped.dev/generated/latest/apis/supervisor/oidc"
 	"go.pinniped.dev/internal/httputil/httperr"
 	"go.pinniped.dev/internal/httputil/securityheader"
 	"go.pinniped.dev/internal/oidc"
-	"go.pinniped.dev/internal/oidc/clientregistry"
 	"go.pinniped.dev/internal/oidc/csrftoken"
 	"go.pinniped.dev/internal/oidc/downstreamsession"
 	"go.pinniped.dev/internal/oidc/login"
@@ -56,12 +54,12 @@ func NewHandler(
 			return httperr.Newf(http.StatusMethodNotAllowed, "%s (try GET or POST)", r.Method)
 		}
 
-		// Note that the client might have used supervisoroidc.AuthorizeUpstreamIDPNameParamName and
-		// supervisoroidc.AuthorizeUpstreamIDPTypeParamName query params to request a certain upstream IDP.
+		// Note that the client might have used oidcapi.AuthorizeUpstreamIDPNameParamName and
+		// oidcapi.AuthorizeUpstreamIDPTypeParamName query params to request a certain upstream IDP.
 		// The Pinniped CLI has been sending these params since v0.9.0.
 		// Currently, these are ignored because the Supervisor does not yet support logins when multiple IDPs
 		// are configured. However, these params should be honored in the future when choosing an upstream
-		// here, e.g. by calling supervisoroidc.FindUpstreamIDPByNameAndType() when the params are present.
+		// here, e.g. by calling oidcapi.FindUpstreamIDPByNameAndType() when the params are present.
 		oidcUpstream, ldapUpstream, idpType, err := chooseUpstreamIDP(idpLister)
 		if err != nil {
 			plog.WarningErr("authorize upstream config", err)
@@ -69,8 +67,8 @@ func NewHandler(
 		}
 
 		if idpType == psession.ProviderTypeOIDC {
-			if len(r.Header.Values(supervisoroidc.AuthorizeUsernameHeaderName)) > 0 ||
-				len(r.Header.Values(supervisoroidc.AuthorizePasswordHeaderName)) > 0 {
+			if len(r.Header.Values(oidcapi.AuthorizeUsernameHeaderName)) > 0 ||
+				len(r.Header.Values(oidcapi.AuthorizePasswordHeaderName)) > 0 {
 				// The client set a username header, so they are trying to log in with a username/password.
 				return handleAuthRequestForOIDCUpstreamPasswordGrant(r, w, oauthHelperWithStorage, oidcUpstream)
 			}
@@ -85,8 +83,8 @@ func NewHandler(
 		}
 
 		// We know it's an AD/LDAP upstream.
-		if len(r.Header.Values(supervisoroidc.AuthorizeUsernameHeaderName)) > 0 ||
-			len(r.Header.Values(supervisoroidc.AuthorizePasswordHeaderName)) > 0 {
+		if len(r.Header.Values(oidcapi.AuthorizeUsernameHeaderName)) > 0 ||
+			len(r.Header.Values(oidcapi.AuthorizePasswordHeaderName)) > 0 {
 			// The client set a username header, so they are trying to log in with a username/password.
 			return handleAuthRequestForLDAPUpstreamCLIFlow(r, w,
 				oauthHelperWithStorage,
@@ -150,7 +148,7 @@ func handleAuthRequestForLDAPUpstreamCLIFlow(
 	subject := downstreamsession.DownstreamSubjectFromUpstreamLDAP(ldapUpstream, authenticateResponse)
 	username = authenticateResponse.User.GetName()
 	groups := authenticateResponse.User.GetGroups()
-	customSessionData := downstreamsession.MakeDownstreamLDAPOrADCustomSessionData(ldapUpstream, idpType, authenticateResponse)
+	customSessionData := downstreamsession.MakeDownstreamLDAPOrADCustomSessionData(ldapUpstream, idpType, authenticateResponse, username)
 	openIDSession := downstreamsession.MakeDownstreamSession(subject, username, groups, authorizeRequester.GetGrantedScopes(), customSessionData)
 	oidc.PerformAuthcodeRedirect(r, w, oauthHelper, authorizeRequester, openIDSession, true)
 
@@ -244,7 +242,7 @@ func handleAuthRequestForOIDCUpstreamPasswordGrant(
 		return nil
 	}
 
-	customSessionData, err := downstreamsession.MakeDownstreamOIDCCustomSessionData(oidcUpstream, token)
+	customSessionData, err := downstreamsession.MakeDownstreamOIDCCustomSessionData(oidcUpstream, token, username)
 	if err != nil {
 		oidc.WriteAuthorizeError(w, oauthHelper, authorizeRequester,
 			fosite.ErrAccessDenied.WithHintf("Reason: %s.", err.Error()), true,
@@ -322,7 +320,7 @@ func handleAuthRequestForOIDCUpstreamBrowserFlow(
 }
 
 func requireStaticClientForUsernameAndPasswordHeaders(w http.ResponseWriter, oauthHelper fosite.OAuth2Provider, authorizeRequester fosite.AuthorizeRequester) bool {
-	isStaticClient := authorizeRequester.GetClient().GetID() == clientregistry.PinnipedCLIClientID
+	isStaticClient := authorizeRequester.GetClient().GetID() == oidcapi.ClientIDPinnipedCLI
 	if !isStaticClient {
 		oidc.WriteAuthorizeError(w, oauthHelper, authorizeRequester,
 			fosite.ErrAccessDenied.WithHintf("This client is not allowed to submit username or password headers to this endpoint."), true)
@@ -331,8 +329,8 @@ func requireStaticClientForUsernameAndPasswordHeaders(w http.ResponseWriter, oau
 }
 
 func requireNonEmptyUsernameAndPasswordHeaders(r *http.Request, w http.ResponseWriter, oauthHelper fosite.OAuth2Provider, authorizeRequester fosite.AuthorizeRequester) (string, string, bool) {
-	username := r.Header.Get(supervisoroidc.AuthorizeUsernameHeaderName)
-	password := r.Header.Get(supervisoroidc.AuthorizePasswordHeaderName)
+	username := r.Header.Get(oidcapi.AuthorizeUsernameHeaderName)
+	password := r.Header.Get(oidcapi.AuthorizePasswordHeaderName)
 	if username == "" || password == "" {
 		oidc.WriteAuthorizeError(w, oauthHelper, authorizeRequester,
 			fosite.ErrAccessDenied.WithHintf("Missing or blank username or password."), true)
@@ -348,13 +346,13 @@ func newAuthorizeRequest(r *http.Request, w http.ResponseWriter, oauthHelper fos
 		return nil, false
 	}
 
-	// Automatically grant the openid, offline_access, pinniped:request-audience, and groups scopes, but only if they were requested.
+	// Automatically grant certain scopes, but only if they were requested.
 	// Grant the openid scope (for now) if they asked for it so that `NewAuthorizeResponse` will perform its OIDC validations.
 	// There don't seem to be any validations inside `NewAuthorizeResponse` related to the offline_access scope
 	// at this time, however we will temporarily grant the scope just in case that changes in a future release of fosite.
 	// This is instead of asking the user to approve these scopes. Note that `NewAuthorizeRequest` would have returned
 	// an error if the client requested a scope that they are not allowed to request, so we don't need to worry about that here.
-	downstreamsession.GrantScopesIfRequested(authorizeRequester, []string{coreosoidc.ScopeOpenID, coreosoidc.ScopeOfflineAccess, oidc.RequestAudienceScope, oidc.DownstreamGroupsScope})
+	downstreamsession.AutoApproveScopes(authorizeRequester)
 
 	return authorizeRequester, true
 }
@@ -487,7 +485,7 @@ func handleBrowserFlowAuthRequest(
 	}
 
 	promptParam := r.Form.Get(promptParamName)
-	if promptParam == promptParamNone && oidc.ScopeWasRequested(authorizeRequester, coreosoidc.ScopeOpenID) {
+	if promptParam == promptParamNone && oidc.ScopeWasRequested(authorizeRequester, oidcapi.ScopeOpenID) {
 		oidc.WriteAuthorizeError(w, oauthHelper, authorizeRequester, fosite.ErrLoginRequired, false)
 		return nil, nil // already wrote the error response, don't return error
 	}
@@ -538,8 +536,8 @@ func upstreamStateParam(
 	encoder oidc.Encoder,
 ) (string, error) {
 	stateParamData := oidc.UpstreamStateParamData{
-		// The auth params might have included supervisoroidc.AuthorizeUpstreamIDPNameParamName and
-		// supervisoroidc.AuthorizeUpstreamIDPTypeParamName, but those can be ignored by other handlers
+		// The auth params might have included oidcapi.AuthorizeUpstreamIDPNameParamName and
+		// oidcapi.AuthorizeUpstreamIDPTypeParamName, but those can be ignored by other handlers
 		// that are reading from the encoded upstream state param being built here.
 		// The UpstreamName and UpstreamType struct fields can be used instead.
 		// Remove those params here to avoid potential confusion about which should be used later.
@@ -565,8 +563,8 @@ func removeCustomIDPParams(params url.Values) url.Values {
 		p[k] = v
 	}
 	// Remove the unnecessary params.
-	delete(p, supervisoroidc.AuthorizeUpstreamIDPNameParamName)
-	delete(p, supervisoroidc.AuthorizeUpstreamIDPTypeParamName)
+	delete(p, oidcapi.AuthorizeUpstreamIDPNameParamName)
+	delete(p, oidcapi.AuthorizeUpstreamIDPTypeParamName)
 	return p
 }
 

--- a/internal/oidc/callback/callback_handler.go
+++ b/internal/oidc/callback/callback_handler.go
@@ -79,7 +79,8 @@ func NewHandler(
 			return httperr.Wrap(http.StatusUnprocessableEntity, err.Error(), err)
 		}
 
-		openIDSession := downstreamsession.MakeDownstreamSession(subject, username, groups, authorizeRequester.GetGrantedScopes(), customSessionData)
+		openIDSession := downstreamsession.MakeDownstreamSession(subject, username, groups,
+			authorizeRequester.GetGrantedScopes(), authorizeRequester.GetClient().GetID(), customSessionData)
 
 		authorizeResponder, err := oauthHelper.NewAuthorizeResponse(r.Context(), authorizeRequester, openIDSession)
 		if err != nil {

--- a/internal/oidc/callback/callback_handler.go
+++ b/internal/oidc/callback/callback_handler.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 
-	coreosoidc "github.com/coreos/go-oidc/v3/oidc"
 	"github.com/ory/fosite"
 
 	"go.pinniped.dev/internal/httputil/httperr"
@@ -53,10 +52,10 @@ func NewHandler(
 			return httperr.New(http.StatusBadRequest, "error using state downstream auth params")
 		}
 
-		// Automatically grant the openid, offline_access, pinniped:request-audience, and groups scopes, but only if they were requested.
+		// Automatically grant certain scopes, but only if they were requested.
 		// This is instead of asking the user to approve these scopes. Note that `NewAuthorizeRequest` would have returned
 		// an error if the client requested a scope that they are not allowed to request, so we don't need to worry about that here.
-		downstreamsession.GrantScopesIfRequested(authorizeRequester, []string{coreosoidc.ScopeOpenID, coreosoidc.ScopeOfflineAccess, oidc.RequestAudienceScope, oidc.DownstreamGroupsScope})
+		downstreamsession.AutoApproveScopes(authorizeRequester)
 
 		token, err := upstreamIDPConfig.ExchangeAuthcodeAndValidateTokens(
 			r.Context(),
@@ -75,7 +74,7 @@ func NewHandler(
 			return httperr.Wrap(http.StatusUnprocessableEntity, err.Error(), err)
 		}
 
-		customSessionData, err := downstreamsession.MakeDownstreamOIDCCustomSessionData(upstreamIDPConfig, token)
+		customSessionData, err := downstreamsession.MakeDownstreamOIDCCustomSessionData(upstreamIDPConfig, token, username)
 		if err != nil {
 			return httperr.Wrap(http.StatusUnprocessableEntity, err.Error(), err)
 		}

--- a/internal/oidc/clientregistry/clientregistry_test.go
+++ b/internal/oidc/clientregistry/clientregistry_test.go
@@ -269,7 +269,7 @@ func requireEqualsPinnipedCLI(t *testing.T, c *Client) {
 	require.Equal(t, []string{"http://127.0.0.1/callback"}, c.GetRedirectURIs())
 	require.Equal(t, fosite.Arguments{"authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:token-exchange"}, c.GetGrantTypes())
 	require.Equal(t, fosite.Arguments{"code"}, c.GetResponseTypes())
-	require.Equal(t, fosite.Arguments{oidc.ScopeOpenID, oidc.ScopeOfflineAccess, "profile", "email", "pinniped:request-audience", "groups"}, c.GetScopes())
+	require.Equal(t, fosite.Arguments{oidc.ScopeOpenID, oidc.ScopeOfflineAccess, "profile", "email", "pinniped:request-audience", "username", "groups"}, c.GetScopes())
 	require.True(t, c.IsPublic())
 	require.Nil(t, c.GetAudience())
 	require.Nil(t, c.GetRequestURIs())
@@ -302,6 +302,7 @@ func requireEqualsPinnipedCLI(t *testing.T, c *Client) {
 			"profile",
 			"email",
 			"pinniped:request-audience",
+			"username",
 			"groups"
 		  ],
 		  "audience": null,

--- a/internal/oidc/discovery/discovery_handler.go
+++ b/internal/oidc/discovery/discovery_handler.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 
 	"go.pinniped.dev/generated/latest/apis/supervisor/idpdiscovery/v1alpha1"
+	oidcapi "go.pinniped.dev/generated/latest/apis/supervisor/oidc"
 	"go.pinniped.dev/internal/oidc"
 )
 
@@ -68,8 +69,8 @@ func NewHandler(issuerURL string) http.Handler {
 		IDTokenSigningAlgValuesSupported:  []string{"ES256"},
 		TokenEndpointAuthMethodsSupported: []string{"client_secret_basic"},
 		CodeChallengeMethodsSupported:     []string{"S256"},
-		ScopesSupported:                   []string{"openid", "offline"},
-		ClaimsSupported:                   []string{"groups"},
+		ScopesSupported:                   []string{oidcapi.ScopeOpenID, oidcapi.ScopeOfflineAccess, oidcapi.ScopeRequestAudience, oidcapi.ScopeUsername, oidcapi.ScopeGroups},
+		ClaimsSupported:                   []string{oidcapi.IDTokenClaimUsername, oidcapi.IDTokenClaimGroups},
 	}
 
 	var b bytes.Buffer

--- a/internal/oidc/discovery/discovery_handler_test.go
+++ b/internal/oidc/discovery/discovery_handler_test.go
@@ -45,9 +45,9 @@ func TestDiscovery(t *testing.T) {
 				"subject_types_supported": ["public"],
 				"id_token_signing_alg_values_supported": ["ES256"],
 				"token_endpoint_auth_methods_supported": ["client_secret_basic"],
-				"scopes_supported": ["openid", "offline"],
+				"scopes_supported": ["openid", "offline_access", "pinniped:request-audience", "username", "groups"],
 				"code_challenge_methods_supported": ["S256"],
-				"claims_supported": ["groups"],
+				"claims_supported": ["username", "groups"],
 				"discovery.supervisor.pinniped.dev/v1alpha1": {
 					"pinniped_identity_providers_endpoint": "https://some-issuer.com/some/path/v1alpha1/pinniped_identity_providers"
 				}

--- a/internal/oidc/downstreamsession/downstream_session.go
+++ b/internal/oidc/downstreamsession/downstream_session.go
@@ -41,7 +41,14 @@ const (
 )
 
 // MakeDownstreamSession creates a downstream OIDC session.
-func MakeDownstreamSession(subject string, username string, groups []string, grantedScopes []string, custom *psession.CustomSessionData) *psession.PinnipedSession {
+func MakeDownstreamSession(
+	subject string,
+	username string,
+	groups []string,
+	grantedScopes []string,
+	clientID string,
+	custom *psession.CustomSessionData,
+) *psession.PinnipedSession {
 	now := time.Now().UTC()
 	openIDSession := &psession.PinnipedSession{
 		Fosite: &openid.DefaultSession{
@@ -56,13 +63,17 @@ func MakeDownstreamSession(subject string, username string, groups []string, gra
 	if groups == nil {
 		groups = []string{}
 	}
-	openIDSession.IDTokenClaims().Extra = map[string]interface{}{}
+
+	extras := map[string]interface{}{}
+	extras[oidcapi.IDTokenClaimAuthorizedParty] = clientID
 	if slices.Contains(grantedScopes, oidcapi.ScopeUsername) {
-		openIDSession.IDTokenClaims().Extra[oidcapi.IDTokenClaimUsername] = username
+		extras[oidcapi.IDTokenClaimUsername] = username
 	}
 	if slices.Contains(grantedScopes, oidcapi.ScopeGroups) {
-		openIDSession.IDTokenClaims().Extra[oidcapi.IDTokenClaimGroups] = groups
+		extras[oidcapi.IDTokenClaimGroups] = groups
 	}
+	openIDSession.IDTokenClaims().Extra = extras
+
 	return openIDSession
 }
 

--- a/internal/oidc/downstreamsession/downstream_session.go
+++ b/internal/oidc/downstreamsession/downstream_session.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/strings/slices"
 
+	oidcapi "go.pinniped.dev/generated/latest/apis/supervisor/oidc"
 	"go.pinniped.dev/internal/authenticators"
 	"go.pinniped.dev/internal/constable"
 	"go.pinniped.dev/internal/oidc"
@@ -27,7 +28,7 @@ import (
 
 const (
 	// The name of the email claim from https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
-	emailClaimName = "email"
+	emailClaimName = oidcapi.ScopeEmail
 
 	// The name of the email_verified claim from https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
 	emailVerifiedClaimName = "email_verified"
@@ -55,11 +56,12 @@ func MakeDownstreamSession(subject string, username string, groups []string, gra
 	if groups == nil {
 		groups = []string{}
 	}
-	openIDSession.IDTokenClaims().Extra = map[string]interface{}{
-		oidc.DownstreamUsernameClaim: username,
+	openIDSession.IDTokenClaims().Extra = map[string]interface{}{}
+	if slices.Contains(grantedScopes, oidcapi.ScopeUsername) {
+		openIDSession.IDTokenClaims().Extra[oidcapi.IDTokenClaimUsername] = username
 	}
-	if slices.Contains(grantedScopes, oidc.DownstreamGroupsScope) {
-		openIDSession.IDTokenClaims().Extra[oidc.DownstreamGroupsClaim] = groups
+	if slices.Contains(grantedScopes, oidcapi.ScopeGroups) {
+		openIDSession.IDTokenClaims().Extra[oidcapi.IDTokenClaimGroups] = groups
 	}
 	return openIDSession
 }
@@ -68,8 +70,10 @@ func MakeDownstreamLDAPOrADCustomSessionData(
 	ldapUpstream provider.UpstreamLDAPIdentityProviderI,
 	idpType psession.ProviderType,
 	authenticateResponse *authenticators.Response,
+	username string,
 ) *psession.CustomSessionData {
 	customSessionData := &psession.CustomSessionData{
+		Username:     username,
 		ProviderUID:  ldapUpstream.GetResourceUID(),
 		ProviderName: ldapUpstream.GetName(),
 		ProviderType: idpType,
@@ -92,17 +96,22 @@ func MakeDownstreamLDAPOrADCustomSessionData(
 	return customSessionData
 }
 
-func MakeDownstreamOIDCCustomSessionData(oidcUpstream provider.UpstreamOIDCIdentityProviderI, token *oidctypes.Token) (*psession.CustomSessionData, error) {
-	upstreamSubject, err := ExtractStringClaimValue(oidc.IDTokenSubjectClaim, oidcUpstream.GetName(), token.IDToken.Claims)
+func MakeDownstreamOIDCCustomSessionData(
+	oidcUpstream provider.UpstreamOIDCIdentityProviderI,
+	token *oidctypes.Token,
+	username string,
+) (*psession.CustomSessionData, error) {
+	upstreamSubject, err := ExtractStringClaimValue(oidcapi.IDTokenClaimSubject, oidcUpstream.GetName(), token.IDToken.Claims)
 	if err != nil {
 		return nil, err
 	}
-	upstreamIssuer, err := ExtractStringClaimValue(oidc.IDTokenIssuerClaim, oidcUpstream.GetName(), token.IDToken.Claims)
+	upstreamIssuer, err := ExtractStringClaimValue(oidcapi.IDTokenClaimIssuer, oidcUpstream.GetName(), token.IDToken.Claims)
 	if err != nil {
 		return nil, err
 	}
 
 	customSessionData := &psession.CustomSessionData{
+		Username:     username,
 		ProviderUID:  oidcUpstream.GetResourceUID(),
 		ProviderName: oidcUpstream.GetName(),
 		ProviderType: psession.ProviderTypeOIDC,
@@ -148,10 +157,29 @@ func MakeDownstreamOIDCCustomSessionData(oidcUpstream provider.UpstreamOIDCIdent
 	return customSessionData, nil
 }
 
-// GrantScopesIfRequested auto-grants the scopes for which we do not require end-user approval, if they were requested.
-func GrantScopesIfRequested(authorizeRequester fosite.AuthorizeRequester, scopes []string) {
-	for _, scope := range scopes {
+// AutoApproveScopes auto-grants the scopes which we support and for which we do not require end-user approval,
+// if they were requested. This should only be called after it has been validated that the client is allowed to request
+// the scopes that it requested (which is a check performed by fosite).
+func AutoApproveScopes(authorizeRequester fosite.AuthorizeRequester) {
+	for _, scope := range []string{
+		oidcapi.ScopeOpenID,
+		oidcapi.ScopeOfflineAccess,
+		oidcapi.ScopeRequestAudience,
+		oidcapi.ScopeUsername,
+		oidcapi.ScopeGroups,
+	} {
 		oidc.GrantScopeIfRequested(authorizeRequester, scope)
+	}
+
+	// For backwards-compatibility with old pinniped CLI binaries which never request the username and groups scopes
+	// (because those scopes did not exist yet when those CLIs were released), grant/approve the username and groups
+	// scopes even if the CLI did not request them. Basically, pretend that the CLI requested them and auto-approve
+	// them. Newer versions of the CLI binaries will request these scopes, so after enough time has passed that
+	// we can assume the old versions of the CLI are no longer in use in the wild, then we can remove this code and
+	// just let the above logic handle all clients.
+	if authorizeRequester.GetClient().GetID() == oidcapi.ClientIDPinnipedCLI {
+		authorizeRequester.GrantScope(oidcapi.ScopeUsername)
+		authorizeRequester.GrantScope(oidcapi.ScopeGroups)
 	}
 }
 
@@ -179,11 +207,11 @@ func getSubjectAndUsernameFromUpstreamIDToken(
 ) (string, string, error) {
 	// The spec says the "sub" claim is only unique per issuer,
 	// so we will prepend the issuer string to make it globally unique.
-	upstreamIssuer, err := ExtractStringClaimValue(oidc.IDTokenIssuerClaim, upstreamIDPConfig.GetName(), idTokenClaims)
+	upstreamIssuer, err := ExtractStringClaimValue(oidcapi.IDTokenClaimIssuer, upstreamIDPConfig.GetName(), idTokenClaims)
 	if err != nil {
 		return "", "", err
 	}
-	upstreamSubject, err := ExtractStringClaimValue(oidc.IDTokenSubjectClaim, upstreamIDPConfig.GetName(), idTokenClaims)
+	upstreamSubject, err := ExtractStringClaimValue(oidcapi.IDTokenClaimSubject, upstreamIDPConfig.GetName(), idTokenClaims)
 	if err != nil {
 		return "", "", err
 	}
@@ -266,13 +294,13 @@ func DownstreamSubjectFromUpstreamLDAP(ldapUpstream provider.UpstreamLDAPIdentit
 
 func DownstreamLDAPSubject(uid string, ldapURL url.URL) string {
 	q := ldapURL.Query()
-	q.Set(oidc.IDTokenSubjectClaim, uid)
+	q.Set(oidcapi.IDTokenClaimSubject, uid)
 	ldapURL.RawQuery = q.Encode()
 	return ldapURL.String()
 }
 
 func downstreamSubjectFromUpstreamOIDC(upstreamIssuerAsString string, upstreamSubject string) string {
-	return fmt.Sprintf("%s?%s=%s", upstreamIssuerAsString, oidc.IDTokenSubjectClaim, url.QueryEscape(upstreamSubject))
+	return fmt.Sprintf("%s?%s=%s", upstreamIssuerAsString, oidcapi.IDTokenClaimSubject, url.QueryEscape(upstreamSubject))
 }
 
 // GetGroupsFromUpstreamIDToken returns mapped group names coerced into a slice of strings.

--- a/internal/oidc/login/post_login_handler.go
+++ b/internal/oidc/login/post_login_handler.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/url"
 
-	coreosoidc "github.com/coreos/go-oidc/v3/oidc"
 	"github.com/ory/fosite"
 
 	"go.pinniped.dev/internal/httputil/httperr"
@@ -46,10 +45,10 @@ func NewPostHandler(issuerURL string, upstreamIDPs oidc.UpstreamIdentityProvider
 			return httperr.New(http.StatusBadRequest, "error using state downstream auth params")
 		}
 
-		// Automatically grant the openid, offline_access, pinniped:request-audience and groups scopes, but only if they were requested.
+		// Automatically grant certain scopes, but only if they were requested.
 		// This is instead of asking the user to approve these scopes. Note that `NewAuthorizeRequest` would have returned
 		// an error if the client requested a scope that they are not allowed to request, so we don't need to worry about that here.
-		downstreamsession.GrantScopesIfRequested(authorizeRequester, []string{coreosoidc.ScopeOpenID, coreosoidc.ScopeOfflineAccess, oidc.RequestAudienceScope, oidc.DownstreamGroupsScope})
+		downstreamsession.AutoApproveScopes(authorizeRequester)
 
 		// Get the username and password form params from the POST body.
 		username := r.PostFormValue(usernameParamName)
@@ -83,7 +82,7 @@ func NewPostHandler(issuerURL string, upstreamIDPs oidc.UpstreamIdentityProvider
 		subject := downstreamsession.DownstreamSubjectFromUpstreamLDAP(ldapUpstream, authenticateResponse)
 		username = authenticateResponse.User.GetName()
 		groups := authenticateResponse.User.GetGroups()
-		customSessionData := downstreamsession.MakeDownstreamLDAPOrADCustomSessionData(ldapUpstream, idpType, authenticateResponse)
+		customSessionData := downstreamsession.MakeDownstreamLDAPOrADCustomSessionData(ldapUpstream, idpType, authenticateResponse, username)
 		openIDSession := downstreamsession.MakeDownstreamSession(subject, username, groups, authorizeRequester.GetGrantedScopes(), customSessionData)
 		oidc.PerformAuthcodeRedirect(r, w, oauthHelper, authorizeRequester, openIDSession, false)
 

--- a/internal/oidc/login/post_login_handler.go
+++ b/internal/oidc/login/post_login_handler.go
@@ -83,7 +83,8 @@ func NewPostHandler(issuerURL string, upstreamIDPs oidc.UpstreamIdentityProvider
 		username = authenticateResponse.User.GetName()
 		groups := authenticateResponse.User.GetGroups()
 		customSessionData := downstreamsession.MakeDownstreamLDAPOrADCustomSessionData(ldapUpstream, idpType, authenticateResponse, username)
-		openIDSession := downstreamsession.MakeDownstreamSession(subject, username, groups, authorizeRequester.GetGrantedScopes(), customSessionData)
+		openIDSession := downstreamsession.MakeDownstreamSession(subject, username, groups,
+			authorizeRequester.GetGrantedScopes(), authorizeRequester.GetClient().GetID(), customSessionData)
 		oidc.PerformAuthcodeRedirect(r, w, oauthHelper, authorizeRequester, openIDSession, false)
 
 		return nil

--- a/internal/oidc/provider/manager/manager_test.go
+++ b/internal/oidc/provider/manager/manager_test.go
@@ -171,7 +171,7 @@ func TestManager(t *testing.T) {
 			r.NoError(err)
 			actualLocationQueryParams := parsedLocation.Query()
 			r.Contains(actualLocationQueryParams, "code")
-			r.Equal("openid", actualLocationQueryParams.Get("scope"))
+			r.Equal("openid username groups", actualLocationQueryParams.Get("scope"))
 			r.Equal("some-state-value-with-enough-bytes-to-exceed-min-allowed", actualLocationQueryParams.Get("state"))
 
 			// Make sure that we wired up the callback endpoint to use kube storage for fosite sessions.
@@ -343,7 +343,7 @@ func TestManager(t *testing.T) {
 
 			authRequestParams := "?" + url.Values{
 				"response_type":         []string{"code"},
-				"scope":                 []string{"openid profile email"},
+				"scope":                 []string{"openid profile email username groups"},
 				"client_id":             []string{downstreamClientID},
 				"state":                 []string{"some-state-value-with-enough-bytes-to-exceed-min-allowed"},
 				"nonce":                 []string{"some-nonce-value-with-enough-bytes-to-exceed-min-allowed"},

--- a/internal/oidc/token/token_handler_test.go
+++ b/internal/oidc/token/token_handler_test.go
@@ -36,6 +36,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apiserver/pkg/warning"
 	"k8s.io/client-go/kubernetes/fake"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
@@ -52,6 +53,7 @@ import (
 	"go.pinniped.dev/internal/httputil/httperr"
 	"go.pinniped.dev/internal/oidc"
 	"go.pinniped.dev/internal/oidc/jwks"
+	"go.pinniped.dev/internal/oidc/oidcclientvalidator"
 	"go.pinniped.dev/internal/oidc/provider"
 	"go.pinniped.dev/internal/oidcclientsecretstorage"
 	"go.pinniped.dev/internal/psession"
@@ -236,7 +238,7 @@ var (
 	happyAuthRequest = &http.Request{
 		Form: url.Values{
 			"response_type":         {"code"},
-			"scope":                 {"openid profile email groups"},
+			"scope":                 {"openid profile email username groups"},
 			"client_id":             {pinnipedCLIClientID},
 			"state":                 {"some-state-value-with-enough-bytes-to-exceed-min-allowed"},
 			"nonce":                 {goodNonce},
@@ -277,10 +279,12 @@ type tokenEndpointResponseExpectedValues struct {
 	wantClientID                      string
 	wantRequestedScopes               []string
 	wantGrantedScopes                 []string
+	wantUsername                      string
 	wantGroups                        []string
 	wantUpstreamRefreshCall           *expectedUpstreamRefresh
 	wantUpstreamOIDCValidateTokenCall *expectedUpstreamValidateTokens
 	wantCustomSessionDataStored       *psession.CustomSessionData
+	wantWarnings                      []RecordedWarning
 }
 
 type authcodeExchangeInputs struct {
@@ -303,6 +307,7 @@ func addFullyCapableDynamicClientAndSecretToKubeResources(t *testing.T, supervis
 		dynamicClientUID,
 		goodRedirectURI,
 		[]string{testutil.HashedPassword1AtGoMinCost, testutil.HashedPassword2AtGoMinCost},
+		oidcclientvalidator.Validate,
 	)
 	require.NoError(t, supervisorClient.Tracker().Add(oidcClient))
 	require.NoError(t, kubeClient.Tracker().Add(secret))
@@ -327,13 +332,14 @@ func TestTokenEndpointAuthcodeExchange(t *testing.T) {
 		{
 			name: "request is valid and tokens are issued",
 			authcodeExchange: authcodeExchangeInputs{
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid profile email groups") },
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid profile email username groups") },
 				want: tokenEndpointResponseExpectedValues{
 					wantStatus:            http.StatusOK,
 					wantClientID:          pinnipedCLIClientID,
 					wantSuccessBodyFields: []string{"id_token", "access_token", "token_type", "scope", "expires_in"}, // no refresh token
-					wantRequestedScopes:   []string{"openid", "profile", "email", "groups"},
-					wantGrantedScopes:     []string{"openid", "groups"},
+					wantRequestedScopes:   []string{"openid", "profile", "email", "username", "groups"},
+					wantGrantedScopes:     []string{"openid", "username", "groups"},
+					wantUsername:          goodUsername,
 					wantGroups:            goodGroups,
 				},
 			},
@@ -344,15 +350,16 @@ func TestTokenEndpointAuthcodeExchange(t *testing.T) {
 			authcodeExchange: authcodeExchangeInputs{
 				modifyAuthRequest: func(r *http.Request) {
 					addDynamicClientIDToFormPostBody(r)
-					r.Form.Set("scope", "openid pinniped:request-audience groups")
+					r.Form.Set("scope", "openid pinniped:request-audience username groups")
 				},
 				modifyTokenRequest: modifyAuthcodeTokenRequestWithDynamicClientAuth,
 				want: tokenEndpointResponseExpectedValues{
 					wantStatus:            http.StatusOK,
 					wantClientID:          dynamicClientID,
 					wantSuccessBodyFields: []string{"id_token", "access_token", "token_type", "scope", "expires_in"}, // no refresh token
-					wantRequestedScopes:   []string{"openid", "pinniped:request-audience", "groups"},
-					wantGrantedScopes:     []string{"openid", "pinniped:request-audience", "groups"},
+					wantRequestedScopes:   []string{"openid", "pinniped:request-audience", "username", "groups"},
+					wantGrantedScopes:     []string{"openid", "pinniped:request-audience", "username", "groups"},
+					wantUsername:          goodUsername,
 					wantGroups:            goodGroups,
 				},
 			},
@@ -366,8 +373,9 @@ func TestTokenEndpointAuthcodeExchange(t *testing.T) {
 					wantClientID:          pinnipedCLIClientID,
 					wantSuccessBodyFields: []string{"access_token", "token_type", "scope", "expires_in"}, // no id or refresh tokens
 					wantRequestedScopes:   []string{"profile", "email"},
-					wantGrantedScopes:     []string{},
-					wantGroups:            nil,
+					wantGrantedScopes:     []string{"username", "groups"}, // username and groups were not requested, but granted anyway for backwards compatibility
+					wantUsername:          goodUsername,
+					wantGroups:            goodGroups,
 				},
 			},
 		},
@@ -377,21 +385,22 @@ func TestTokenEndpointAuthcodeExchange(t *testing.T) {
 			authcodeExchange: authcodeExchangeInputs{
 				modifyAuthRequest: func(r *http.Request) {
 					addDynamicClientIDToFormPostBody(r)
-					r.Form.Set("scope", "pinniped:request-audience groups")
+					r.Form.Set("scope", "pinniped:request-audience username groups")
 				},
 				modifyTokenRequest: modifyAuthcodeTokenRequestWithDynamicClientAuth,
 				want: tokenEndpointResponseExpectedValues{
 					wantStatus:            http.StatusOK,
 					wantClientID:          dynamicClientID,
 					wantSuccessBodyFields: []string{"access_token", "token_type", "scope", "expires_in"}, // no id or refresh tokens
-					wantRequestedScopes:   []string{"pinniped:request-audience", "groups"},
-					wantGrantedScopes:     []string{"pinniped:request-audience", "groups"},
-					wantGroups:            nil,
+					wantRequestedScopes:   []string{"pinniped:request-audience", "username", "groups"},
+					wantGrantedScopes:     []string{"pinniped:request-audience", "username", "groups"},
+					wantUsername:          goodUsername,
+					wantGroups:            goodGroups,
 				},
 			},
 		},
 		{
-			name: "offline_access and openid scopes were requested and granted from authorize endpoint (no groups)",
+			name: "offline_access and openid scopes were requested and granted from authorize endpoint (no username or groups requested)",
 			authcodeExchange: authcodeExchangeInputs{
 				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access") },
 				want: tokenEndpointResponseExpectedValues{
@@ -399,27 +408,49 @@ func TestTokenEndpointAuthcodeExchange(t *testing.T) {
 					wantClientID:          pinnipedCLIClientID,
 					wantSuccessBodyFields: []string{"id_token", "access_token", "token_type", "scope", "expires_in", "refresh_token"}, // all possible tokens
 					wantRequestedScopes:   []string{"openid", "offline_access"},
-					wantGrantedScopes:     []string{"openid", "offline_access"},
-					wantGroups:            nil,
+					wantGrantedScopes:     []string{"openid", "offline_access", "username", "groups"}, // username and groups were not requested, but granted anyway for backwards compatibility
+					wantUsername:          goodUsername,
+					wantGroups:            goodGroups,
 				},
 			},
 		},
 		{
-			name:          "offline_access and openid scopes were requested and granted from authorize endpoint for dynamic client (no groups)",
+			name:          "openid, offline_access, and username scopes (no groups) were requested and granted from authorize endpoint for dynamic client",
 			kubeResources: addFullyCapableDynamicClientAndSecretToKubeResources,
 			authcodeExchange: authcodeExchangeInputs{
 				modifyAuthRequest: func(r *http.Request) {
 					addDynamicClientIDToFormPostBody(r)
-					r.Form.Set("scope", "openid offline_access")
+					r.Form.Set("scope", "openid offline_access username")
 				},
 				modifyTokenRequest: modifyAuthcodeTokenRequestWithDynamicClientAuth,
 				want: tokenEndpointResponseExpectedValues{
 					wantStatus:            http.StatusOK,
 					wantClientID:          dynamicClientID,
 					wantSuccessBodyFields: []string{"id_token", "access_token", "token_type", "scope", "expires_in", "refresh_token"}, // all possible tokens
-					wantRequestedScopes:   []string{"openid", "offline_access"},
-					wantGrantedScopes:     []string{"openid", "offline_access"},
+					wantRequestedScopes:   []string{"openid", "offline_access", "username"},
+					wantGrantedScopes:     []string{"openid", "offline_access", "username"},
+					wantUsername:          goodUsername,
 					wantGroups:            nil,
+				},
+			},
+		},
+		{
+			name:          "openid, offline_access, and groups scopes (no username) were requested and granted from authorize endpoint for dynamic client",
+			kubeResources: addFullyCapableDynamicClientAndSecretToKubeResources,
+			authcodeExchange: authcodeExchangeInputs{
+				modifyAuthRequest: func(r *http.Request) {
+					addDynamicClientIDToFormPostBody(r)
+					r.Form.Set("scope", "openid offline_access groups")
+				},
+				modifyTokenRequest: modifyAuthcodeTokenRequestWithDynamicClientAuth,
+				want: tokenEndpointResponseExpectedValues{
+					wantStatus:            http.StatusOK,
+					wantClientID:          dynamicClientID,
+					wantSuccessBodyFields: []string{"id_token", "access_token", "token_type", "scope", "expires_in", "refresh_token"}, // all possible tokens
+					wantRequestedScopes:   []string{"openid", "offline_access", "groups"},
+					wantGrantedScopes:     []string{"openid", "offline_access", "groups"},
+					wantUsername:          "",
+					wantGroups:            goodGroups,
 				},
 			},
 		},
@@ -432,13 +463,14 @@ func TestTokenEndpointAuthcodeExchange(t *testing.T) {
 					wantClientID:          pinnipedCLIClientID,
 					wantSuccessBodyFields: []string{"access_token", "token_type", "scope", "expires_in", "refresh_token"}, // no id token
 					wantRequestedScopes:   []string{"offline_access"},
-					wantGrantedScopes:     []string{"offline_access"},
-					wantGroups:            nil,
+					wantGrantedScopes:     []string{"offline_access", "username", "groups"}, // username and groups were not requested, but granted anyway for backwards compatibility
+					wantUsername:          goodUsername,
+					wantGroups:            goodGroups,
 				},
 			},
 		},
 		{
-			name:          "offline_access (without openid scope) was requested and granted from authorize endpoint for dynamic client",
+			name:          "offline_access (without openid, username, groups scopes) was requested and granted from authorize endpoint for dynamic client",
 			kubeResources: addFullyCapableDynamicClientAndSecretToKubeResources,
 			authcodeExchange: authcodeExchangeInputs{
 				modifyAuthRequest: func(r *http.Request) {
@@ -452,20 +484,22 @@ func TestTokenEndpointAuthcodeExchange(t *testing.T) {
 					wantSuccessBodyFields: []string{"access_token", "token_type", "scope", "expires_in", "refresh_token"}, // no id token
 					wantRequestedScopes:   []string{"offline_access"},
 					wantGrantedScopes:     []string{"offline_access"},
+					wantUsername:          "",
 					wantGroups:            nil,
 				},
 			},
 		},
 		{
-			name: "groups scope is requested",
+			name: "username and groups scopes are requested",
 			authcodeExchange: authcodeExchangeInputs{
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid profile email groups") },
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid profile email username groups") },
 				want: tokenEndpointResponseExpectedValues{
 					wantStatus:            http.StatusOK,
 					wantClientID:          pinnipedCLIClientID,
 					wantSuccessBodyFields: []string{"id_token", "access_token", "token_type", "scope", "expires_in"}, // no refresh token
-					wantRequestedScopes:   []string{"openid", "profile", "email", "groups"},
-					wantGrantedScopes:     []string{"openid", "groups"},
+					wantRequestedScopes:   []string{"openid", "profile", "email", "username", "groups"},
+					wantGrantedScopes:     []string{"openid", "username", "groups"},
+					wantUsername:          goodUsername,
 					wantGroups:            goodGroups,
 				},
 			},
@@ -783,13 +817,14 @@ func TestTokenEndpointWhenAuthcodeIsUsedTwice(t *testing.T) {
 		{
 			name: "authcode exchange succeeds once and then fails when the same authcode is used again",
 			authcodeExchange: authcodeExchangeInputs{
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access profile email groups") },
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access profile email username groups") },
 				want: tokenEndpointResponseExpectedValues{
 					wantStatus:            http.StatusOK,
 					wantClientID:          pinnipedCLIClientID,
 					wantSuccessBodyFields: []string{"id_token", "refresh_token", "access_token", "token_type", "expires_in", "scope"},
-					wantRequestedScopes:   []string{"openid", "offline_access", "profile", "email", "groups"},
-					wantGrantedScopes:     []string{"openid", "offline_access", "groups"},
+					wantRequestedScopes:   []string{"openid", "offline_access", "profile", "email", "username", "groups"},
+					wantGrantedScopes:     []string{"openid", "offline_access", "username", "groups"},
+					wantUsername:          goodUsername,
 					wantGroups:            goodGroups,
 				},
 			},
@@ -832,9 +867,10 @@ func TestTokenEndpointWhenAuthcodeIsUsedTwice(t *testing.T) {
 			// Note that customSessionData is only relevant to refresh grant, so we leave it as nil for this
 			// authcode exchange test, even though in practice it would actually be in the session.
 			requireValidOIDCStorage(t, parsedResponseBody, authCode, oauthStore,
-				test.authcodeExchange.want.wantClientID, test.authcodeExchange.want.wantRequestedScopes,
-				test.authcodeExchange.want.wantGrantedScopes, test.authcodeExchange.want.wantGroups, nil,
-				approxRequestTime)
+				test.authcodeExchange.want.wantClientID,
+				test.authcodeExchange.want.wantRequestedScopes, test.authcodeExchange.want.wantGrantedScopes,
+				test.authcodeExchange.want.wantUsername, test.authcodeExchange.want.wantGroups,
+				nil, approxRequestTime)
 
 			// Check that the access token and refresh token storage were both deleted, and the number of other storage objects did not change.
 			testutil.RequireNumberOfSecretsMatchingLabelSelector(t, secrets, labels.Set{crud.SecretLabelKey: authorizationcode.TypeLabelValue}, 1)
@@ -853,8 +889,9 @@ func TestTokenEndpointTokenExchange(t *testing.T) { // tests for grant_type "urn
 		wantStatus:            http.StatusOK,
 		wantClientID:          pinnipedCLIClientID,
 		wantSuccessBodyFields: []string{"id_token", "access_token", "token_type", "expires_in", "scope"},
-		wantRequestedScopes:   []string{"openid", "pinniped:request-audience", "groups"},
-		wantGrantedScopes:     []string{"openid", "pinniped:request-audience", "groups"},
+		wantRequestedScopes:   []string{"openid", "pinniped:request-audience", "username", "groups"},
+		wantGrantedScopes:     []string{"openid", "pinniped:request-audience", "username", "groups"},
+		wantUsername:          goodUsername,
 		wantGroups:            goodGroups,
 	}
 
@@ -862,14 +899,15 @@ func TestTokenEndpointTokenExchange(t *testing.T) { // tests for grant_type "urn
 		wantStatus:            http.StatusOK,
 		wantClientID:          dynamicClientID,
 		wantSuccessBodyFields: []string{"id_token", "access_token", "token_type", "expires_in", "scope"},
-		wantRequestedScopes:   []string{"openid", "pinniped:request-audience", "groups"},
-		wantGrantedScopes:     []string{"openid", "pinniped:request-audience", "groups"},
+		wantRequestedScopes:   []string{"openid", "pinniped:request-audience", "username", "groups"},
+		wantGrantedScopes:     []string{"openid", "pinniped:request-audience", "username", "groups"},
+		wantUsername:          goodUsername,
 		wantGroups:            goodGroups,
 	}
 
 	doValidAuthCodeExchange := authcodeExchangeInputs{
 		modifyAuthRequest: func(authRequest *http.Request) {
-			authRequest.Form.Set("scope", "openid pinniped:request-audience groups")
+			authRequest.Form.Set("scope", "openid pinniped:request-audience username groups")
 		},
 		want: successfulAuthCodeExchange,
 	}
@@ -877,7 +915,7 @@ func TestTokenEndpointTokenExchange(t *testing.T) { // tests for grant_type "urn
 	doValidAuthCodeExchangeUsingDynamicClient := authcodeExchangeInputs{
 		modifyAuthRequest: func(authRequest *http.Request) {
 			addDynamicClientIDToFormPostBody(authRequest)
-			authRequest.Form.Set("scope", "openid pinniped:request-audience groups")
+			authRequest.Form.Set("scope", "openid pinniped:request-audience username groups")
 		},
 		modifyTokenRequest: modifyAuthcodeTokenRequestWithDynamicClientAuth,
 		want:               successfulAuthCodeExchangeUsingDynamicClient,
@@ -903,9 +941,56 @@ func TestTokenEndpointTokenExchange(t *testing.T) { // tests for grant_type "urn
 			wantStatus:        http.StatusOK,
 		},
 		{
+			name: "happy path without requesting username and groups scopes",
+			authcodeExchange: authcodeExchangeInputs{
+				modifyAuthRequest: func(authRequest *http.Request) {
+					authRequest.Form.Set("scope", "openid pinniped:request-audience")
+				},
+				want: tokenEndpointResponseExpectedValues{
+					wantStatus:            http.StatusOK,
+					wantClientID:          pinnipedCLIClientID,
+					wantSuccessBodyFields: []string{"access_token", "token_type", "expires_in", "scope", "id_token"},
+					wantRequestedScopes:   []string{"openid", "pinniped:request-audience"},
+					wantGrantedScopes:     []string{"openid", "pinniped:request-audience", "username", "groups"}, // username and groups were not requested, but granted anyway for backwards compatibility
+					wantUsername:          goodUsername,
+					wantGroups:            goodGroups,
+				},
+			},
+			requestedAudience: "some-workload-cluster",
+			wantStatus:        http.StatusOK,
+		},
+		{
 			name:             "happy path with dynamic client",
 			kubeResources:    addFullyCapableDynamicClientAndSecretToKubeResources,
 			authcodeExchange: doValidAuthCodeExchangeUsingDynamicClient,
+			modifyRequestParams: func(t *testing.T, params url.Values) {
+				params.Del("client_id") // client auth for dynamic clients must be in basic auth header
+			},
+			modifyRequestHeaders: func(r *http.Request) {
+				r.SetBasicAuth(dynamicClientID, testutil.PlaintextPassword1)
+			},
+			requestedAudience: "some-workload-cluster",
+			wantStatus:        http.StatusOK,
+		},
+		{
+			name:          "happy path with dynamic client without requesting groups, so gets no groups in ID tokens",
+			kubeResources: addFullyCapableDynamicClientAndSecretToKubeResources,
+			authcodeExchange: authcodeExchangeInputs{
+				modifyAuthRequest: func(authRequest *http.Request) {
+					addDynamicClientIDToFormPostBody(authRequest)
+					authRequest.Form.Set("scope", "openid pinniped:request-audience username") // don't request groups scope
+				},
+				modifyTokenRequest: modifyAuthcodeTokenRequestWithDynamicClientAuth,
+				want: tokenEndpointResponseExpectedValues{
+					wantStatus:            http.StatusOK,
+					wantClientID:          dynamicClientID,
+					wantSuccessBodyFields: []string{"id_token", "access_token", "token_type", "expires_in", "scope"},
+					wantRequestedScopes:   []string{"openid", "pinniped:request-audience", "username"}, // don't want groups scope
+					wantGrantedScopes:     []string{"openid", "pinniped:request-audience", "username"}, // don't want groups scope
+					wantUsername:          goodUsername,
+					wantGroups:            nil,
+				},
+			},
 			modifyRequestParams: func(t *testing.T, params url.Values) {
 				params.Del("client_id") // client auth for dynamic clients must be in basic auth header
 			},
@@ -934,15 +1019,16 @@ func TestTokenEndpointTokenExchange(t *testing.T) { // tests for grant_type "urn
 			authcodeExchange: authcodeExchangeInputs{
 				modifyAuthRequest: func(authRequest *http.Request) {
 					addDynamicClientIDToFormPostBody(authRequest)
-					authRequest.Form.Set("scope", "openid groups") // don't request pinniped:request-audience scope
+					authRequest.Form.Set("scope", "openid username groups") // don't request pinniped:request-audience scope
 				},
 				modifyTokenRequest: modifyAuthcodeTokenRequestWithDynamicClientAuth,
 				want: tokenEndpointResponseExpectedValues{
 					wantStatus:            http.StatusOK,
 					wantClientID:          dynamicClientID,
 					wantSuccessBodyFields: []string{"id_token", "access_token", "token_type", "expires_in", "scope"},
-					wantRequestedScopes:   []string{"openid", "groups"}, // don't want pinniped:request-audience scope
-					wantGrantedScopes:     []string{"openid", "groups"}, // don't want pinniped:request-audience scope
+					wantRequestedScopes:   []string{"openid", "username", "groups"}, // don't want pinniped:request-audience scope
+					wantGrantedScopes:     []string{"openid", "username", "groups"}, // don't want pinniped:request-audience scope
+					wantUsername:          goodUsername,
 					wantGroups:            goodGroups,
 				},
 			},
@@ -962,15 +1048,16 @@ func TestTokenEndpointTokenExchange(t *testing.T) { // tests for grant_type "urn
 			authcodeExchange: authcodeExchangeInputs{
 				modifyAuthRequest: func(authRequest *http.Request) {
 					addDynamicClientIDToFormPostBody(authRequest)
-					authRequest.Form.Set("scope", "openid groups") // don't request pinniped:request-audience scope
+					authRequest.Form.Set("scope", "openid username groups") // don't request pinniped:request-audience scope
 				},
 				modifyTokenRequest: modifyAuthcodeTokenRequestWithDynamicClientAuth,
 				want: tokenEndpointResponseExpectedValues{
 					wantStatus:            http.StatusOK,
 					wantClientID:          dynamicClientID,
 					wantSuccessBodyFields: []string{"id_token", "access_token", "token_type", "expires_in", "scope"},
-					wantRequestedScopes:   []string{"openid", "groups"}, // don't want pinniped:request-audience scope
-					wantGrantedScopes:     []string{"openid", "groups"}, // don't want pinniped:request-audience scope
+					wantRequestedScopes:   []string{"openid", "username", "groups"}, // don't want pinniped:request-audience scope
+					wantGrantedScopes:     []string{"openid", "username", "groups"}, // don't want pinniped:request-audience scope
+					wantUsername:          goodUsername,
 					wantGroups:            goodGroups,
 				},
 			},
@@ -990,16 +1077,17 @@ func TestTokenEndpointTokenExchange(t *testing.T) { // tests for grant_type "urn
 			authcodeExchange: authcodeExchangeInputs{
 				modifyAuthRequest: func(authRequest *http.Request) {
 					addDynamicClientIDToFormPostBody(authRequest)
-					authRequest.Form.Set("scope", "pinniped:request-audience groups") // don't request openid scope
+					authRequest.Form.Set("scope", "pinniped:request-audience username groups") // don't request openid scope
 				},
 				modifyTokenRequest: modifyAuthcodeTokenRequestWithDynamicClientAuth,
 				want: tokenEndpointResponseExpectedValues{
 					wantStatus:            http.StatusOK,
 					wantClientID:          dynamicClientID,
 					wantSuccessBodyFields: []string{"access_token", "token_type", "expires_in", "scope"}, // no id token
-					wantRequestedScopes:   []string{"pinniped:request-audience", "groups"},               // don't want openid scope
-					wantGrantedScopes:     []string{"pinniped:request-audience", "groups"},               // don't want openid scope
-					wantGroups:            nil,
+					wantRequestedScopes:   []string{"pinniped:request-audience", "username", "groups"},   // don't want openid scope
+					wantGrantedScopes:     []string{"pinniped:request-audience", "username", "groups"},   // don't want openid scope
+					wantUsername:          goodUsername,
+					wantGroups:            goodGroups,
 				},
 			},
 			modifyRequestParams: func(t *testing.T, params url.Values) {
@@ -1011,6 +1099,35 @@ func TestTokenEndpointTokenExchange(t *testing.T) { // tests for grant_type "urn
 			requestedAudience:        "some-workload-cluster",
 			wantStatus:               http.StatusForbidden,
 			wantResponseBodyContains: `The resource owner or authorization server denied the request. missing the 'openid' scope`,
+		},
+		{
+			name:          "dynamic client did not ask for the username scope in the original authorization request, so the session during token exchange has no username associated with it",
+			kubeResources: addFullyCapableDynamicClientAndSecretToKubeResources,
+			authcodeExchange: authcodeExchangeInputs{
+				modifyAuthRequest: func(authRequest *http.Request) {
+					addDynamicClientIDToFormPostBody(authRequest)
+					authRequest.Form.Set("scope", "openid pinniped:request-audience groups") // don't request username scope
+				},
+				modifyTokenRequest: modifyAuthcodeTokenRequestWithDynamicClientAuth,
+				want: tokenEndpointResponseExpectedValues{
+					wantStatus:            http.StatusOK,
+					wantClientID:          dynamicClientID,
+					wantSuccessBodyFields: []string{"id_token", "access_token", "token_type", "expires_in", "scope"},
+					wantRequestedScopes:   []string{"openid", "pinniped:request-audience", "groups"}, // no username scope
+					wantGrantedScopes:     []string{"openid", "pinniped:request-audience", "groups"}, // no username scope
+					wantUsername:          "",
+					wantGroups:            goodGroups,
+				},
+			},
+			modifyRequestParams: func(t *testing.T, params url.Values) {
+				params.Del("client_id") // client auth for dynamic clients must be in basic auth header
+			},
+			modifyRequestHeaders: func(r *http.Request) {
+				r.SetBasicAuth(dynamicClientID, testutil.PlaintextPassword1)
+			},
+			requestedAudience:        "some-workload-cluster",
+			wantStatus:               http.StatusForbidden,
+			wantResponseBodyContains: `The resource owner or authorization server denied the request. No username found in session. Ensure that the 'username' scope was requested and granted at the authorization endpoint.`,
 		},
 		{
 			name:                     "missing audience",
@@ -1160,14 +1277,15 @@ func TestTokenEndpointTokenExchange(t *testing.T) { // tests for grant_type "urn
 			name: "access token missing pinniped:request-audience scope",
 			authcodeExchange: authcodeExchangeInputs{
 				modifyAuthRequest: func(authRequest *http.Request) {
-					authRequest.Form.Set("scope", "openid groups")
+					authRequest.Form.Set("scope", "openid username groups")
 				},
 				want: tokenEndpointResponseExpectedValues{
 					wantStatus:            http.StatusOK,
 					wantClientID:          pinnipedCLIClientID,
 					wantSuccessBodyFields: []string{"id_token", "access_token", "token_type", "expires_in", "scope"},
-					wantRequestedScopes:   []string{"openid", "groups"},
-					wantGrantedScopes:     []string{"openid", "groups"},
+					wantRequestedScopes:   []string{"openid", "username", "groups"},
+					wantGrantedScopes:     []string{"openid", "username", "groups"},
+					wantUsername:          goodUsername,
 					wantGroups:            goodGroups,
 				},
 			},
@@ -1179,15 +1297,16 @@ func TestTokenEndpointTokenExchange(t *testing.T) { // tests for grant_type "urn
 			name: "access token missing openid scope",
 			authcodeExchange: authcodeExchangeInputs{
 				modifyAuthRequest: func(authRequest *http.Request) {
-					authRequest.Form.Set("scope", "pinniped:request-audience groups")
+					authRequest.Form.Set("scope", "pinniped:request-audience username groups")
 				},
 				want: tokenEndpointResponseExpectedValues{
 					wantStatus:            http.StatusOK,
 					wantClientID:          pinnipedCLIClientID,
 					wantSuccessBodyFields: []string{"access_token", "token_type", "expires_in", "scope"},
-					wantRequestedScopes:   []string{"pinniped:request-audience", "groups"},
-					wantGrantedScopes:     []string{"pinniped:request-audience", "groups"},
-					wantGroups:            nil,
+					wantRequestedScopes:   []string{"pinniped:request-audience", "username", "groups"},
+					wantGrantedScopes:     []string{"pinniped:request-audience", "username", "groups"},
+					wantUsername:          goodUsername,
+					wantGroups:            goodGroups,
 				},
 			},
 			requestedAudience:        "some-workload-cluster",
@@ -1195,28 +1314,10 @@ func TestTokenEndpointTokenExchange(t *testing.T) { // tests for grant_type "urn
 			wantResponseBodyContains: `missing the 'openid' scope`,
 		},
 		{
-			name: "access token missing groups scope",
-			authcodeExchange: authcodeExchangeInputs{
-				modifyAuthRequest: func(authRequest *http.Request) {
-					authRequest.Form.Set("scope", "openid pinniped:request-audience")
-				},
-				want: tokenEndpointResponseExpectedValues{
-					wantStatus:            http.StatusOK,
-					wantClientID:          pinnipedCLIClientID,
-					wantSuccessBodyFields: []string{"access_token", "token_type", "expires_in", "scope", "id_token"},
-					wantRequestedScopes:   []string{"openid", "pinniped:request-audience"},
-					wantGrantedScopes:     []string{"openid", "pinniped:request-audience"},
-					wantGroups:            nil,
-				},
-			},
-			requestedAudience: "some-workload-cluster",
-			wantStatus:        http.StatusOK,
-		},
-		{
 			name: "token minting failure",
 			authcodeExchange: authcodeExchangeInputs{
 				modifyAuthRequest: func(authRequest *http.Request) {
-					authRequest.Form.Set("scope", "openid pinniped:request-audience groups")
+					authRequest.Form.Set("scope", "openid pinniped:request-audience username groups")
 				},
 				// Fail to fetch a JWK signing key after the authcode exchange has happened.
 				makeOathHelper: makeOauthHelperWithJWTKeyThatWorksOnlyOnce,
@@ -1313,7 +1414,11 @@ func TestTokenEndpointTokenExchange(t *testing.T) { // tests for grant_type "urn
 			require.Contains(t, tokenClaims["aud"], test.requestedAudience)
 			require.Equal(t, goodSubject, tokenClaims["sub"])
 			require.Equal(t, goodIssuer, tokenClaims["iss"])
-			require.Equal(t, goodUsername, tokenClaims["username"])
+			if test.authcodeExchange.want.wantUsername != "" {
+				require.Equal(t, test.authcodeExchange.want.wantUsername, tokenClaims["username"])
+			} else {
+				require.Nil(t, tokenClaims["username"])
+			}
 			if test.authcodeExchange.want.wantGroups != nil {
 				require.Equal(t, toSliceOfInterface(test.authcodeExchange.want.wantGroups), tokenClaims["groups"])
 			} else {
@@ -1381,6 +1486,7 @@ func TestRefreshGrant(t *testing.T) {
 
 	initialUpstreamOIDCRefreshTokenCustomSessionData := func() *psession.CustomSessionData {
 		return &psession.CustomSessionData{
+			Username:     goodUsername,
 			ProviderName: oidcUpstreamName,
 			ProviderUID:  oidcUpstreamResourceUID,
 			ProviderType: oidcUpstreamType,
@@ -1394,6 +1500,7 @@ func TestRefreshGrant(t *testing.T) {
 
 	initialUpstreamOIDCAccessTokenCustomSessionData := func() *psession.CustomSessionData {
 		return &psession.CustomSessionData{
+			Username:     goodUsername,
 			ProviderName: oidcUpstreamName,
 			ProviderUID:  oidcUpstreamResourceUID,
 			ProviderType: oidcUpstreamType,
@@ -1463,9 +1570,10 @@ func TestRefreshGrant(t *testing.T) {
 			wantStatus:                  http.StatusOK,
 			wantClientID:                pinnipedCLIClientID,
 			wantSuccessBodyFields:       []string{"id_token", "refresh_token", "access_token", "token_type", "expires_in", "scope"},
-			wantRequestedScopes:         []string{"openid", "offline_access", "groups"},
-			wantGrantedScopes:           []string{"openid", "offline_access", "groups"},
+			wantRequestedScopes:         []string{"openid", "offline_access", "username", "groups"},
+			wantGrantedScopes:           []string{"openid", "offline_access", "username", "groups"},
 			wantCustomSessionDataStored: wantCustomSessionDataStored,
+			wantUsername:                goodUsername,
 			wantGroups:                  goodGroups,
 		}
 		return want
@@ -1526,6 +1634,7 @@ func TestRefreshGrant(t *testing.T) {
 	}
 
 	happyActiveDirectoryCustomSessionData := &psession.CustomSessionData{
+		Username:     goodUsername,
 		ProviderUID:  activeDirectoryUpstreamResourceUID,
 		ProviderName: activeDirectoryUpstreamName,
 		ProviderType: activeDirectoryUpstreamType,
@@ -1533,7 +1642,9 @@ func TestRefreshGrant(t *testing.T) {
 			UserDN: activeDirectoryUpstreamDN,
 		},
 	}
+
 	happyLDAPCustomSessionData := &psession.CustomSessionData{
+		Username:     goodUsername,
 		ProviderUID:  ldapUpstreamResourceUID,
 		ProviderName: ldapUpstreamName,
 		ProviderType: ldapUpstreamType,
@@ -1541,6 +1652,21 @@ func TestRefreshGrant(t *testing.T) {
 			UserDN: ldapUpstreamDN,
 		},
 	}
+
+	happyAuthcodeExchangeInputsForOIDCUpstream := authcodeExchangeInputs{
+		customSessionData: initialUpstreamOIDCRefreshTokenCustomSessionData(),
+		modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access username groups") },
+		want:              happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(initialUpstreamOIDCRefreshTokenCustomSessionData()),
+	}
+
+	happyAuthcodeExchangeInputsForLDAPUpstream := authcodeExchangeInputs{
+		modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access username groups") },
+		customSessionData: happyLDAPCustomSessionData,
+		want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
+			happyLDAPCustomSessionData,
+		),
+	}
+
 	tests := []struct {
 		name                      string
 		idps                      *oidctestutil.UpstreamIDPListerBuilder
@@ -1559,11 +1685,7 @@ func TestRefreshGrant(t *testing.T) {
 						},
 					},
 				}).WithRefreshedTokens(refreshedUpstreamTokensWithIDAndRefreshTokens()).Build()),
-			authcodeExchange: authcodeExchangeInputs{
-				customSessionData: initialUpstreamOIDCRefreshTokenCustomSessionData(),
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				want:              happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(initialUpstreamOIDCRefreshTokenCustomSessionData()),
-			},
+			authcodeExchange: happyAuthcodeExchangeInputsForOIDCUpstream,
 			refreshRequest: refreshRequestInputs{
 				want: happyRefreshTokenResponseForOpenIDAndOfflineAccess(
 					upstreamOIDCCustomSessionDataWithNewRefreshToken(oidcUpstreamRefreshedRefreshToken),
@@ -1586,7 +1708,7 @@ func TestRefreshGrant(t *testing.T) {
 				customSessionData: initialUpstreamOIDCRefreshTokenCustomSessionData(),
 				modifyAuthRequest: func(r *http.Request) {
 					addDynamicClientIDToFormPostBody(r)
-					r.Form.Set("scope", "openid offline_access groups")
+					r.Form.Set("scope", "openid offline_access username groups")
 				},
 				modifyTokenRequest: modifyAuthcodeTokenRequestWithDynamicClientAuth,
 				want:               withWantDynamicClientID(happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(initialUpstreamOIDCRefreshTokenCustomSessionData())),
@@ -1597,6 +1719,53 @@ func TestRefreshGrant(t *testing.T) {
 					upstreamOIDCCustomSessionDataWithNewRefreshToken(oidcUpstreamRefreshedRefreshToken),
 					refreshedUpstreamTokensWithIDAndRefreshTokens(),
 				)),
+			},
+		},
+		{
+			name: "happy path refresh grant with upstream username claim but without downstream username scope granted, using dynamic client",
+			idps: oidctestutil.NewUpstreamIDPListerBuilder().WithOIDC(
+				upstreamOIDCIdentityProviderBuilder().WithUsernameClaim("username-claim").WithValidatedAndMergedWithUserInfoTokens(&oidctypes.Token{
+					IDToken: &oidctypes.IDToken{
+						Claims: map[string]interface{}{
+							"some-claim":     "some-value",
+							"sub":            goodUpstreamSubject,
+							"username-claim": goodUsername,
+						},
+					},
+				}).WithRefreshedTokens(refreshedUpstreamTokensWithIDAndRefreshTokens()).Build()),
+			kubeResources: addFullyCapableDynamicClientAndSecretToKubeResources,
+			authcodeExchange: authcodeExchangeInputs{
+				customSessionData: initialUpstreamOIDCRefreshTokenCustomSessionData(),
+				modifyAuthRequest: func(r *http.Request) {
+					addDynamicClientIDToFormPostBody(r)
+					r.Form.Set("scope", "openid offline_access groups")
+				},
+				modifyTokenRequest: modifyAuthcodeTokenRequestWithDynamicClientAuth,
+				want: withWantDynamicClientID(tokenEndpointResponseExpectedValues{
+					wantStatus:                  http.StatusOK,
+					wantClientID:                dynamicClientID,
+					wantSuccessBodyFields:       []string{"id_token", "refresh_token", "access_token", "token_type", "expires_in", "scope"},
+					wantRequestedScopes:         []string{"openid", "offline_access", "groups"},
+					wantGrantedScopes:           []string{"openid", "offline_access", "groups"},
+					wantCustomSessionDataStored: initialUpstreamOIDCRefreshTokenCustomSessionData(),
+					wantUsername:                "",
+					wantGroups:                  goodGroups,
+				}),
+			},
+			refreshRequest: refreshRequestInputs{
+				modifyTokenRequest: modifyRefreshTokenRequestWithDynamicClientAuth,
+				want: withWantDynamicClientID(tokenEndpointResponseExpectedValues{
+					wantStatus:                        http.StatusOK,
+					wantClientID:                      dynamicClientID,
+					wantSuccessBodyFields:             []string{"id_token", "refresh_token", "access_token", "token_type", "expires_in", "scope"},
+					wantRequestedScopes:               []string{"openid", "offline_access", "groups"},
+					wantGrantedScopes:                 []string{"openid", "offline_access", "groups"},
+					wantCustomSessionDataStored:       upstreamOIDCCustomSessionDataWithNewRefreshToken(oidcUpstreamRefreshedRefreshToken),
+					wantUsername:                      "",
+					wantGroups:                        goodGroups,
+					wantUpstreamRefreshCall:           happyOIDCUpstreamRefreshCall(),
+					wantUpstreamOIDCValidateTokenCall: happyUpstreamValidateTokenCall(refreshedUpstreamTokensWithIDAndRefreshTokens(), true),
+				}),
 			},
 		},
 		{
@@ -1611,11 +1780,7 @@ func TestRefreshGrant(t *testing.T) {
 						},
 					},
 				}).WithRefreshedTokens(refreshedUpstreamTokensWithIDAndRefreshTokens()).Build()),
-			authcodeExchange: authcodeExchangeInputs{
-				customSessionData: initialUpstreamOIDCRefreshTokenCustomSessionData(),
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				want:              happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(initialUpstreamOIDCRefreshTokenCustomSessionData()),
-			},
+			authcodeExchange: happyAuthcodeExchangeInputsForOIDCUpstream,
 			refreshRequest: refreshRequestInputs{
 				want: happyRefreshTokenResponseForOpenIDAndOfflineAccess(
 					upstreamOIDCCustomSessionDataWithNewRefreshToken(oidcUpstreamRefreshedRefreshToken),
@@ -1641,7 +1806,7 @@ func TestRefreshGrant(t *testing.T) {
 					}).WithRefreshedTokens(refreshedUpstreamTokensWithIDAndRefreshTokens()).Build()),
 			authcodeExchange: authcodeExchangeInputs{
 				customSessionData: initialUpstreamOIDCAccessTokenCustomSessionData(),
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access username groups") },
 				want:              happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(initialUpstreamOIDCAccessTokenCustomSessionData()),
 			},
 			refreshRequest: refreshRequestInputs{
@@ -1649,8 +1814,9 @@ func TestRefreshGrant(t *testing.T) {
 					wantStatus:            http.StatusOK,
 					wantClientID:          pinnipedCLIClientID,
 					wantSuccessBodyFields: []string{"refresh_token", "id_token", "access_token", "token_type", "expires_in", "scope"},
-					wantRequestedScopes:   []string{"openid", "offline_access", "groups"},
-					wantGrantedScopes:     []string{"openid", "offline_access", "groups"},
+					wantRequestedScopes:   []string{"openid", "offline_access", "username", "groups"},
+					wantGrantedScopes:     []string{"openid", "offline_access", "username", "groups"},
+					wantUsername:          goodUsername,
 					wantGroups:            goodGroups,
 					wantUpstreamOIDCValidateTokenCall: &expectedUpstreamValidateTokens{
 						oidcUpstreamName,
@@ -1682,8 +1848,10 @@ func TestRefreshGrant(t *testing.T) {
 					wantClientID:                pinnipedCLIClientID,
 					wantSuccessBodyFields:       []string{"refresh_token", "access_token", "token_type", "expires_in", "scope"},
 					wantRequestedScopes:         []string{"offline_access"},
-					wantGrantedScopes:           []string{"offline_access"},
+					wantGrantedScopes:           []string{"offline_access", "username", "groups"}, // username and groups were not requested, but granted anyway for backwards compatibility
 					wantCustomSessionDataStored: initialUpstreamOIDCRefreshTokenCustomSessionData(),
+					wantUsername:                goodUsername,
+					wantGroups:                  goodGroups,
 				},
 			},
 			refreshRequest: refreshRequestInputs{
@@ -1692,10 +1860,12 @@ func TestRefreshGrant(t *testing.T) {
 					wantClientID:                      pinnipedCLIClientID,
 					wantSuccessBodyFields:             []string{"refresh_token", "access_token", "token_type", "expires_in", "scope"},
 					wantRequestedScopes:               []string{"offline_access"},
-					wantGrantedScopes:                 []string{"offline_access"},
+					wantGrantedScopes:                 []string{"offline_access", "username", "groups"},
 					wantUpstreamRefreshCall:           happyOIDCUpstreamRefreshCall(),
 					wantUpstreamOIDCValidateTokenCall: happyUpstreamValidateTokenCall(refreshedUpstreamTokensWithRefreshTokenWithoutIDToken(), false),
 					wantCustomSessionDataStored:       upstreamOIDCCustomSessionDataWithNewRefreshToken(oidcUpstreamRefreshedRefreshToken),
+					wantUsername:                      goodUsername,
+					wantGroups:                        goodGroups,
 				},
 			},
 		},
@@ -1707,18 +1877,15 @@ func TestRefreshGrant(t *testing.T) {
 						Claims: map[string]interface{}{},
 					},
 				}).WithRefreshedTokens(refreshedUpstreamTokensWithRefreshTokenWithoutIDToken()).Build()),
-			authcodeExchange: authcodeExchangeInputs{
-				customSessionData: initialUpstreamOIDCRefreshTokenCustomSessionData(),
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				want:              happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(initialUpstreamOIDCRefreshTokenCustomSessionData()),
-			},
+			authcodeExchange: happyAuthcodeExchangeInputsForOIDCUpstream,
 			refreshRequest: refreshRequestInputs{
 				want: tokenEndpointResponseExpectedValues{
 					wantStatus:                        http.StatusOK,
 					wantClientID:                      pinnipedCLIClientID,
 					wantSuccessBodyFields:             []string{"refresh_token", "access_token", "id_token", "token_type", "expires_in", "scope"},
-					wantRequestedScopes:               []string{"openid", "offline_access", "groups"},
-					wantGrantedScopes:                 []string{"openid", "offline_access", "groups"},
+					wantRequestedScopes:               []string{"openid", "offline_access", "username", "groups"},
+					wantGrantedScopes:                 []string{"openid", "offline_access", "username", "groups"},
+					wantUsername:                      goodUsername,
 					wantGroups:                        goodGroups,
 					wantUpstreamRefreshCall:           happyOIDCUpstreamRefreshCall(),
 					wantUpstreamOIDCValidateTokenCall: happyUpstreamValidateTokenCall(refreshedUpstreamTokensWithRefreshTokenWithoutIDToken(), false),
@@ -1737,22 +1904,61 @@ func TestRefreshGrant(t *testing.T) {
 						},
 					},
 				}).WithRefreshedTokens(refreshedUpstreamTokensWithIDAndRefreshTokens()).Build()),
-			authcodeExchange: authcodeExchangeInputs{
-				customSessionData: initialUpstreamOIDCRefreshTokenCustomSessionData(),
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				want:              happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(initialUpstreamOIDCRefreshTokenCustomSessionData()),
-			},
+			authcodeExchange: happyAuthcodeExchangeInputsForOIDCUpstream,
 			refreshRequest: refreshRequestInputs{
 				want: tokenEndpointResponseExpectedValues{
 					wantStatus:                        http.StatusOK,
 					wantClientID:                      pinnipedCLIClientID,
 					wantSuccessBodyFields:             []string{"refresh_token", "access_token", "id_token", "token_type", "expires_in", "scope"},
-					wantRequestedScopes:               []string{"openid", "offline_access", "groups"},
-					wantGrantedScopes:                 []string{"openid", "offline_access", "groups"},
+					wantRequestedScopes:               []string{"openid", "offline_access", "username", "groups"},
+					wantGrantedScopes:                 []string{"openid", "offline_access", "username", "groups"},
+					wantUsername:                      goodUsername,
 					wantGroups:                        []string{"new-group1", "new-group2", "new-group3"},
 					wantUpstreamRefreshCall:           happyOIDCUpstreamRefreshCall(),
 					wantUpstreamOIDCValidateTokenCall: happyUpstreamValidateTokenCall(refreshedUpstreamTokensWithIDAndRefreshTokens(), true),
 					wantCustomSessionDataStored:       upstreamOIDCCustomSessionDataWithNewRefreshToken(oidcUpstreamRefreshedRefreshToken),
+					wantWarnings: []RecordedWarning{
+						{Text: `User "some-username" has been added to the following groups: ["new-group1" "new-group2" "new-group3"]`},
+						{Text: `User "some-username" has been removed from the following groups: ["group1" "groups2"]`},
+					},
+				},
+			},
+		},
+		{
+			name: "happy path refresh grant when the upstream refresh returns new group memberships (as strings) from the merged ID token and userinfo results, it updates groups, using dynamic client - updates groups without outputting warnings",
+			idps: oidctestutil.NewUpstreamIDPListerBuilder().WithOIDC(
+				upstreamOIDCIdentityProviderBuilder().WithGroupsClaim("my-groups-claim").WithValidatedAndMergedWithUserInfoTokens(&oidctypes.Token{
+					IDToken: &oidctypes.IDToken{
+						Claims: map[string]interface{}{
+							"sub":             goodUpstreamSubject,
+							"my-groups-claim": []string{"new-group1", "new-group2", "new-group3"}, // refreshed claims includes updated groups
+						},
+					},
+				}).WithRefreshedTokens(refreshedUpstreamTokensWithIDAndRefreshTokens()).Build()),
+			kubeResources: addFullyCapableDynamicClientAndSecretToKubeResources,
+			authcodeExchange: authcodeExchangeInputs{
+				customSessionData: initialUpstreamOIDCRefreshTokenCustomSessionData(),
+				modifyAuthRequest: func(r *http.Request) {
+					addDynamicClientIDToFormPostBody(r)
+					r.Form.Set("scope", "openid offline_access username groups")
+				},
+				modifyTokenRequest: modifyAuthcodeTokenRequestWithDynamicClientAuth,
+				want:               withWantDynamicClientID(happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(initialUpstreamOIDCRefreshTokenCustomSessionData())),
+			},
+			refreshRequest: refreshRequestInputs{
+				modifyTokenRequest: modifyRefreshTokenRequestWithDynamicClientAuth,
+				want: tokenEndpointResponseExpectedValues{
+					wantStatus:                        http.StatusOK,
+					wantClientID:                      dynamicClientID,
+					wantSuccessBodyFields:             []string{"refresh_token", "access_token", "id_token", "token_type", "expires_in", "scope"},
+					wantRequestedScopes:               []string{"openid", "offline_access", "username", "groups"},
+					wantGrantedScopes:                 []string{"openid", "offline_access", "username", "groups"},
+					wantUsername:                      goodUsername,
+					wantGroups:                        []string{"new-group1", "new-group2", "new-group3"},
+					wantUpstreamRefreshCall:           happyOIDCUpstreamRefreshCall(),
+					wantUpstreamOIDCValidateTokenCall: happyUpstreamValidateTokenCall(refreshedUpstreamTokensWithIDAndRefreshTokens(), true),
+					wantCustomSessionDataStored:       upstreamOIDCCustomSessionDataWithNewRefreshToken(oidcUpstreamRefreshedRefreshToken),
+					wantWarnings:                      nil, // dynamic clients should not get these warnings which are intended for the pinniped-cli client
 				},
 			},
 		},
@@ -1767,22 +1973,23 @@ func TestRefreshGrant(t *testing.T) {
 						},
 					},
 				}).WithRefreshedTokens(refreshedUpstreamTokensWithIDAndRefreshTokens()).Build()),
-			authcodeExchange: authcodeExchangeInputs{
-				customSessionData: initialUpstreamOIDCRefreshTokenCustomSessionData(),
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				want:              happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(initialUpstreamOIDCRefreshTokenCustomSessionData()),
-			},
+			authcodeExchange: happyAuthcodeExchangeInputsForOIDCUpstream,
 			refreshRequest: refreshRequestInputs{
 				want: tokenEndpointResponseExpectedValues{
 					wantStatus:                        http.StatusOK,
 					wantClientID:                      pinnipedCLIClientID,
 					wantSuccessBodyFields:             []string{"refresh_token", "access_token", "id_token", "token_type", "expires_in", "scope"},
-					wantRequestedScopes:               []string{"openid", "offline_access", "groups"},
-					wantGrantedScopes:                 []string{"openid", "offline_access", "groups"},
+					wantRequestedScopes:               []string{"openid", "offline_access", "username", "groups"},
+					wantGrantedScopes:                 []string{"openid", "offline_access", "username", "groups"},
+					wantUsername:                      goodUsername,
 					wantGroups:                        []string{"new-group1", "new-group2", "new-group3"},
 					wantUpstreamRefreshCall:           happyOIDCUpstreamRefreshCall(),
 					wantUpstreamOIDCValidateTokenCall: happyUpstreamValidateTokenCall(refreshedUpstreamTokensWithIDAndRefreshTokens(), true),
 					wantCustomSessionDataStored:       upstreamOIDCCustomSessionDataWithNewRefreshToken(oidcUpstreamRefreshedRefreshToken),
+					wantWarnings: []RecordedWarning{
+						{Text: `User "some-username" has been added to the following groups: ["new-group1" "new-group2" "new-group3"]`},
+						{Text: `User "some-username" has been removed from the following groups: ["group1" "groups2"]`},
+					},
 				},
 			},
 		},
@@ -1797,22 +2004,22 @@ func TestRefreshGrant(t *testing.T) {
 						},
 					},
 				}).WithRefreshedTokens(refreshedUpstreamTokensWithIDAndRefreshTokens()).Build()),
-			authcodeExchange: authcodeExchangeInputs{
-				customSessionData: initialUpstreamOIDCRefreshTokenCustomSessionData(),
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				want:              happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(initialUpstreamOIDCRefreshTokenCustomSessionData()),
-			},
+			authcodeExchange: happyAuthcodeExchangeInputsForOIDCUpstream,
 			refreshRequest: refreshRequestInputs{
 				want: tokenEndpointResponseExpectedValues{
 					wantStatus:                        http.StatusOK,
 					wantClientID:                      pinnipedCLIClientID,
 					wantSuccessBodyFields:             []string{"refresh_token", "access_token", "id_token", "token_type", "expires_in", "scope"},
-					wantRequestedScopes:               []string{"openid", "offline_access", "groups"},
-					wantGrantedScopes:                 []string{"openid", "offline_access", "groups"},
+					wantRequestedScopes:               []string{"openid", "offline_access", "username", "groups"},
+					wantGrantedScopes:                 []string{"openid", "offline_access", "username", "groups"},
+					wantUsername:                      goodUsername,
 					wantGroups:                        []string{}, // the user no longer belongs to any groups
 					wantUpstreamRefreshCall:           happyOIDCUpstreamRefreshCall(),
 					wantUpstreamOIDCValidateTokenCall: happyUpstreamValidateTokenCall(refreshedUpstreamTokensWithIDAndRefreshTokens(), true),
 					wantCustomSessionDataStored:       upstreamOIDCCustomSessionDataWithNewRefreshToken(oidcUpstreamRefreshedRefreshToken),
+					wantWarnings: []RecordedWarning{
+						{Text: `User "some-username" has been removed from the following groups: ["group1" "groups2"]`},
+					},
 				},
 			},
 		},
@@ -1827,18 +2034,15 @@ func TestRefreshGrant(t *testing.T) {
 						},
 					},
 				}).WithRefreshedTokens(refreshedUpstreamTokensWithIDAndRefreshTokens()).Build()),
-			authcodeExchange: authcodeExchangeInputs{
-				customSessionData: initialUpstreamOIDCRefreshTokenCustomSessionData(),
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				want:              happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(initialUpstreamOIDCRefreshTokenCustomSessionData()),
-			},
+			authcodeExchange: happyAuthcodeExchangeInputsForOIDCUpstream,
 			refreshRequest: refreshRequestInputs{
 				want: tokenEndpointResponseExpectedValues{
 					wantStatus:                        http.StatusOK,
 					wantClientID:                      pinnipedCLIClientID,
 					wantSuccessBodyFields:             []string{"refresh_token", "access_token", "id_token", "token_type", "expires_in", "scope"},
-					wantRequestedScopes:               []string{"openid", "offline_access", "groups"},
-					wantGrantedScopes:                 []string{"openid", "offline_access", "groups"},
+					wantRequestedScopes:               []string{"openid", "offline_access", "username", "groups"},
+					wantGrantedScopes:                 []string{"openid", "offline_access", "username", "groups"},
+					wantUsername:                      goodUsername,
 					wantGroups:                        goodGroups, // the same groups as from the initial login
 					wantUpstreamRefreshCall:           happyOIDCUpstreamRefreshCall(),
 					wantUpstreamOIDCValidateTokenCall: happyUpstreamValidateTokenCall(refreshedUpstreamTokensWithIDAndRefreshTokens(), true),
@@ -1854,23 +2058,56 @@ func TestRefreshGrant(t *testing.T) {
 				URL:                  ldapUpstreamURL,
 				PerformRefreshGroups: []string{"new-group1", "new-group2", "new-group3"},
 			}),
-			authcodeExchange: authcodeExchangeInputs{
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				customSessionData: happyLDAPCustomSessionData,
-				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
-					happyLDAPCustomSessionData,
-				),
-			},
+			authcodeExchange: happyAuthcodeExchangeInputsForLDAPUpstream,
 			refreshRequest: refreshRequestInputs{
 				want: tokenEndpointResponseExpectedValues{
 					wantStatus:                  http.StatusOK,
 					wantClientID:                pinnipedCLIClientID,
 					wantSuccessBodyFields:       []string{"refresh_token", "access_token", "id_token", "token_type", "expires_in", "scope"},
-					wantRequestedScopes:         []string{"openid", "offline_access", "groups"},
-					wantGrantedScopes:           []string{"openid", "offline_access", "groups"},
+					wantRequestedScopes:         []string{"openid", "offline_access", "username", "groups"},
+					wantGrantedScopes:           []string{"openid", "offline_access", "username", "groups"},
+					wantUsername:                goodUsername,
 					wantGroups:                  []string{"new-group1", "new-group2", "new-group3"},
 					wantUpstreamRefreshCall:     happyLDAPUpstreamRefreshCall(),
 					wantCustomSessionDataStored: happyLDAPCustomSessionData,
+					wantWarnings: []RecordedWarning{
+						{Text: `User "some-username" has been added to the following groups: ["new-group1" "new-group2" "new-group3"]`},
+						{Text: `User "some-username" has been removed from the following groups: ["group1" "groups2"]`},
+					},
+				},
+			},
+		},
+		{
+			name: "happy path refresh grant when the upstream refresh returns new group memberships from LDAP, it updates groups, using dynamic client - updates groups without outputting warnings",
+			idps: oidctestutil.NewUpstreamIDPListerBuilder().WithLDAP(&oidctestutil.TestUpstreamLDAPIdentityProvider{
+				Name:                 ldapUpstreamName,
+				ResourceUID:          ldapUpstreamResourceUID,
+				URL:                  ldapUpstreamURL,
+				PerformRefreshGroups: []string{"new-group1", "new-group2", "new-group3"},
+			}),
+			kubeResources: addFullyCapableDynamicClientAndSecretToKubeResources,
+			authcodeExchange: authcodeExchangeInputs{
+				customSessionData: happyLDAPCustomSessionData,
+				modifyAuthRequest: func(r *http.Request) {
+					addDynamicClientIDToFormPostBody(r)
+					r.Form.Set("scope", "openid offline_access username groups")
+				},
+				modifyTokenRequest: modifyAuthcodeTokenRequestWithDynamicClientAuth,
+				want:               withWantDynamicClientID(happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(happyLDAPCustomSessionData)),
+			},
+			refreshRequest: refreshRequestInputs{
+				modifyTokenRequest: modifyRefreshTokenRequestWithDynamicClientAuth,
+				want: tokenEndpointResponseExpectedValues{
+					wantStatus:                  http.StatusOK,
+					wantClientID:                dynamicClientID,
+					wantSuccessBodyFields:       []string{"refresh_token", "access_token", "id_token", "token_type", "expires_in", "scope"},
+					wantRequestedScopes:         []string{"openid", "offline_access", "username", "groups"},
+					wantGrantedScopes:           []string{"openid", "offline_access", "username", "groups"},
+					wantUsername:                goodUsername,
+					wantGroups:                  []string{"new-group1", "new-group2", "new-group3"},
+					wantUpstreamRefreshCall:     happyLDAPUpstreamRefreshCall(),
+					wantCustomSessionDataStored: happyLDAPCustomSessionData,
+					wantWarnings:                nil, // dynamic clients should not get these warnings which are intended for the pinniped-cli client
 				},
 			},
 		},
@@ -1882,33 +2119,31 @@ func TestRefreshGrant(t *testing.T) {
 				URL:                  ldapUpstreamURL,
 				PerformRefreshGroups: []string{},
 			}),
-			authcodeExchange: authcodeExchangeInputs{
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				customSessionData: happyLDAPCustomSessionData,
-				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
-					happyLDAPCustomSessionData,
-				),
-			},
+			authcodeExchange: happyAuthcodeExchangeInputsForLDAPUpstream,
 			refreshRequest: refreshRequestInputs{
 				want: tokenEndpointResponseExpectedValues{
 					wantStatus:                  http.StatusOK,
 					wantClientID:                pinnipedCLIClientID,
 					wantSuccessBodyFields:       []string{"refresh_token", "access_token", "id_token", "token_type", "expires_in", "scope"},
-					wantRequestedScopes:         []string{"openid", "offline_access", "groups"},
-					wantGrantedScopes:           []string{"openid", "offline_access", "groups"},
+					wantRequestedScopes:         []string{"openid", "offline_access", "username", "groups"},
+					wantGrantedScopes:           []string{"openid", "offline_access", "username", "groups"},
+					wantUsername:                goodUsername,
 					wantGroups:                  []string{},
 					wantUpstreamRefreshCall:     happyLDAPUpstreamRefreshCall(),
 					wantCustomSessionDataStored: happyLDAPCustomSessionData,
+					wantWarnings: []RecordedWarning{
+						{Text: `User "some-username" has been removed from the following groups: ["group1" "groups2"]`},
+					},
 				},
 			},
 		},
 		{
-			name: "ldap refresh grant when the upstream refresh when groups scope not requested on original request or refresh",
+			name: "ldap refresh grant when the upstream refresh when username and groups scopes are not requested on original request or refresh",
 			idps: oidctestutil.NewUpstreamIDPListerBuilder().WithLDAP(&oidctestutil.TestUpstreamLDAPIdentityProvider{
 				Name:                 ldapUpstreamName,
 				ResourceUID:          ldapUpstreamResourceUID,
 				URL:                  ldapUpstreamURL,
-				PerformRefreshGroups: []string{},
+				PerformRefreshGroups: []string{"new-group1", "new-group2", "new-group3"},
 			}),
 			authcodeExchange: authcodeExchangeInputs{
 				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access") },
@@ -1918,9 +2153,10 @@ func TestRefreshGrant(t *testing.T) {
 					wantClientID:                pinnipedCLIClientID,
 					wantSuccessBodyFields:       []string{"id_token", "refresh_token", "access_token", "token_type", "expires_in", "scope"},
 					wantRequestedScopes:         []string{"openid", "offline_access"},
-					wantGrantedScopes:           []string{"openid", "offline_access"},
+					wantGrantedScopes:           []string{"openid", "offline_access", "username", "groups"}, // username and groups were not requested, but granted anyway for backwards compatibility
 					wantCustomSessionDataStored: happyLDAPCustomSessionData,
-					wantGroups:                  nil,
+					wantUsername:                goodUsername,
+					wantGroups:                  goodGroups,
 				},
 			},
 			refreshRequest: refreshRequestInputs{
@@ -1932,15 +2168,20 @@ func TestRefreshGrant(t *testing.T) {
 					wantClientID:                pinnipedCLIClientID,
 					wantSuccessBodyFields:       []string{"refresh_token", "access_token", "id_token", "token_type", "expires_in", "scope"},
 					wantRequestedScopes:         []string{"openid", "offline_access"},
-					wantGrantedScopes:           []string{"openid", "offline_access"},
-					wantGroups:                  nil,
+					wantGrantedScopes:           []string{"openid", "offline_access", "username", "groups"}, // username and groups were not requested, but granted anyway for backwards compatibility
+					wantUsername:                goodUsername,
+					wantGroups:                  []string{"new-group1", "new-group2", "new-group3"},
 					wantUpstreamRefreshCall:     happyLDAPUpstreamRefreshCall(),
 					wantCustomSessionDataStored: happyLDAPCustomSessionData,
+					wantWarnings: []RecordedWarning{
+						{Text: `User "some-username" has been added to the following groups: ["new-group1" "new-group2" "new-group3"]`},
+						{Text: `User "some-username" has been removed from the following groups: ["group1" "groups2"]`},
+					},
 				},
 			},
 		},
 		{
-			name: "oidc refresh grant when the upstream refresh when groups scope not requested on original request or refresh",
+			name: "oidc refresh grant when the upstream refresh when username and groups scopes are not requested on original request or refresh",
 			idps: oidctestutil.NewUpstreamIDPListerBuilder().WithOIDC(
 				upstreamOIDCIdentityProviderBuilder().WithGroupsClaim("my-groups-claim").WithValidatedAndMergedWithUserInfoTokens(&oidctypes.Token{
 					IDToken: &oidctypes.IDToken{
@@ -1958,9 +2199,10 @@ func TestRefreshGrant(t *testing.T) {
 					wantClientID:                pinnipedCLIClientID,
 					wantSuccessBodyFields:       []string{"id_token", "refresh_token", "access_token", "token_type", "expires_in", "scope"},
 					wantRequestedScopes:         []string{"openid", "offline_access"},
-					wantGrantedScopes:           []string{"openid", "offline_access"},
+					wantGrantedScopes:           []string{"openid", "offline_access", "username", "groups"}, // username and groups were not requested, but granted anyway for backwards compatibility
 					wantCustomSessionDataStored: initialUpstreamOIDCRefreshTokenCustomSessionData(),
-					wantGroups:                  nil,
+					wantUsername:                goodUsername,
+					wantGroups:                  goodGroups,
 				},
 			},
 			refreshRequest: refreshRequestInputs{
@@ -1972,11 +2214,16 @@ func TestRefreshGrant(t *testing.T) {
 					wantClientID:                      pinnipedCLIClientID,
 					wantSuccessBodyFields:             []string{"refresh_token", "access_token", "id_token", "token_type", "expires_in", "scope"},
 					wantRequestedScopes:               []string{"openid", "offline_access"},
-					wantGrantedScopes:                 []string{"openid", "offline_access"},
-					wantGroups:                        nil,
+					wantGrantedScopes:                 []string{"openid", "offline_access", "username", "groups"}, // username and groups were not requested, but granted anyway for backwards compatibility
+					wantUsername:                      goodUsername,
+					wantGroups:                        []string{"new-group1", "new-group2", "new-group3"},
 					wantUpstreamRefreshCall:           happyOIDCUpstreamRefreshCall(),
 					wantUpstreamOIDCValidateTokenCall: happyUpstreamValidateTokenCall(refreshedUpstreamTokensWithIDAndRefreshTokens(), true),
 					wantCustomSessionDataStored:       upstreamOIDCCustomSessionDataWithNewRefreshToken(oidcUpstreamRefreshedRefreshToken),
+					wantWarnings: []RecordedWarning{
+						{Text: `User "some-username" has been added to the following groups: ["new-group1" "new-group2" "new-group3"]`},
+						{Text: `User "some-username" has been removed from the following groups: ["group1" "groups2"]`},
+					},
 				},
 			},
 		},
@@ -1995,7 +2242,7 @@ func TestRefreshGrant(t *testing.T) {
 			authcodeExchange: authcodeExchangeInputs{
 				modifyAuthRequest: func(r *http.Request) {
 					addDynamicClientIDToFormPostBody(r)
-					r.Form.Set("scope", "openid offline_access")
+					r.Form.Set("scope", "openid offline_access username")
 				},
 				modifyTokenRequest: modifyAuthcodeTokenRequestWithDynamicClientAuth,
 				customSessionData:  initialUpstreamOIDCRefreshTokenCustomSessionData(),
@@ -2003,23 +2250,25 @@ func TestRefreshGrant(t *testing.T) {
 					wantStatus:                  http.StatusOK,
 					wantClientID:                dynamicClientID,
 					wantSuccessBodyFields:       []string{"id_token", "refresh_token", "access_token", "token_type", "expires_in", "scope"},
-					wantRequestedScopes:         []string{"openid", "offline_access"},
-					wantGrantedScopes:           []string{"openid", "offline_access"},
+					wantRequestedScopes:         []string{"openid", "offline_access", "username"},
+					wantGrantedScopes:           []string{"openid", "offline_access", "username"},
 					wantCustomSessionDataStored: initialUpstreamOIDCRefreshTokenCustomSessionData(),
+					wantUsername:                goodUsername,
 					wantGroups:                  nil,
 				},
 			},
 			refreshRequest: refreshRequestInputs{
 				modifyTokenRequest: func(r *http.Request, refreshToken string, accessToken string) {
-					r.Body = happyRefreshRequestBody(refreshToken).WithClientID("").WithScope("openid offline_access").ReadCloser()
+					r.Body = happyRefreshRequestBody(refreshToken).WithClientID("").WithScope("openid offline_access username").ReadCloser()
 					r.SetBasicAuth(dynamicClientID, testutil.PlaintextPassword1) // Use basic auth header instead.
 				},
 				want: tokenEndpointResponseExpectedValues{
 					wantStatus:                        http.StatusOK,
 					wantClientID:                      dynamicClientID,
 					wantSuccessBodyFields:             []string{"refresh_token", "access_token", "id_token", "token_type", "expires_in", "scope"},
-					wantRequestedScopes:               []string{"openid", "offline_access"},
-					wantGrantedScopes:                 []string{"openid", "offline_access"},
+					wantRequestedScopes:               []string{"openid", "offline_access", "username"},
+					wantGrantedScopes:                 []string{"openid", "offline_access", "username"},
+					wantUsername:                      goodUsername,
 					wantGroups:                        nil,
 					wantUpstreamRefreshCall:           happyOIDCUpstreamRefreshCall(),
 					wantUpstreamOIDCValidateTokenCall: happyUpstreamValidateTokenCall(refreshedUpstreamTokensWithIDAndRefreshTokens(), true),
@@ -2038,15 +2287,16 @@ func TestRefreshGrant(t *testing.T) {
 				PerformRefreshGroups: []string{"new-group1", "new-group2", "new-group3"},
 			}),
 			authcodeExchange: authcodeExchangeInputs{
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access username groups") },
 				customSessionData: happyLDAPCustomSessionData,
 				want: tokenEndpointResponseExpectedValues{
 					wantStatus:                  http.StatusOK,
 					wantClientID:                pinnipedCLIClientID,
 					wantSuccessBodyFields:       []string{"id_token", "refresh_token", "access_token", "token_type", "expires_in", "scope"},
-					wantRequestedScopes:         []string{"openid", "offline_access", "groups"},
-					wantGrantedScopes:           []string{"openid", "offline_access", "groups"},
+					wantRequestedScopes:         []string{"openid", "offline_access", "username", "groups"},
+					wantGrantedScopes:           []string{"openid", "offline_access", "username", "groups"},
 					wantCustomSessionDataStored: happyLDAPCustomSessionData,
+					wantUsername:                goodUsername,
 					wantGroups:                  goodGroups,
 				},
 			},
@@ -2058,11 +2308,16 @@ func TestRefreshGrant(t *testing.T) {
 					wantStatus:                  http.StatusOK,
 					wantClientID:                pinnipedCLIClientID,
 					wantSuccessBodyFields:       []string{"refresh_token", "access_token", "id_token", "token_type", "expires_in", "scope"},
-					wantRequestedScopes:         []string{"openid", "offline_access", "groups"},
-					wantGrantedScopes:           []string{"openid", "offline_access", "groups"},
+					wantRequestedScopes:         []string{"openid", "offline_access", "username", "groups"},
+					wantGrantedScopes:           []string{"openid", "offline_access", "username", "groups"},
+					wantUsername:                goodUsername,
 					wantGroups:                  []string{"new-group1", "new-group2", "new-group3"}, // groups are updated even though the scope was not included
 					wantUpstreamRefreshCall:     happyLDAPUpstreamRefreshCall(),
 					wantCustomSessionDataStored: happyLDAPCustomSessionData,
+					wantWarnings: []RecordedWarning{
+						{Text: `User "some-username" has been added to the following groups: ["new-group1" "new-group2" "new-group3"]`},
+						{Text: `User "some-username" has been removed from the following groups: ["group1" "groups2"]`},
+					},
 				},
 			},
 		},
@@ -2077,11 +2332,7 @@ func TestRefreshGrant(t *testing.T) {
 						},
 					},
 				}).WithRefreshedTokens(refreshedUpstreamTokensWithIDAndRefreshTokens()).Build()),
-			authcodeExchange: authcodeExchangeInputs{
-				customSessionData: initialUpstreamOIDCRefreshTokenCustomSessionData(),
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				want:              happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(initialUpstreamOIDCRefreshTokenCustomSessionData()),
-			},
+			authcodeExchange: happyAuthcodeExchangeInputsForOIDCUpstream,
 			refreshRequest: refreshRequestInputs{
 				want: tokenEndpointResponseExpectedValues{
 					wantStatus:                        http.StatusUnauthorized,
@@ -2101,11 +2352,7 @@ func TestRefreshGrant(t *testing.T) {
 						},
 					},
 				}).WithRefreshedTokens(refreshedUpstreamTokensWithIDTokenWithoutRefreshToken()).Build()),
-			authcodeExchange: authcodeExchangeInputs{
-				customSessionData: initialUpstreamOIDCRefreshTokenCustomSessionData(),
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				want:              happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(initialUpstreamOIDCRefreshTokenCustomSessionData()),
-			},
+			authcodeExchange: happyAuthcodeExchangeInputsForOIDCUpstream,
 			refreshRequest: refreshRequestInputs{
 				want: happyRefreshTokenResponseForOpenIDAndOfflineAccess(
 					initialUpstreamOIDCRefreshTokenCustomSessionData(), // still has the initial refresh token stored
@@ -2123,11 +2370,7 @@ func TestRefreshGrant(t *testing.T) {
 						},
 					},
 				}).WithRefreshedTokens(refreshedUpstreamTokensWithIDAndRefreshTokens()).Build()),
-			authcodeExchange: authcodeExchangeInputs{
-				customSessionData: initialUpstreamOIDCRefreshTokenCustomSessionData(),
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				want:              happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(initialUpstreamOIDCRefreshTokenCustomSessionData()),
-			},
+			authcodeExchange: happyAuthcodeExchangeInputsForOIDCUpstream,
 			refreshRequest: refreshRequestInputs{
 				modifyTokenRequest: func(r *http.Request, refreshToken string, accessToken string) {
 					r.Body = happyRefreshRequestBody(refreshToken).WithScope("openid some-other-scope-not-from-auth-request").ReadCloser()
@@ -2150,13 +2393,16 @@ func TestRefreshGrant(t *testing.T) {
 				}).WithRefreshedTokens(refreshedUpstreamTokensWithIDAndRefreshTokens()).Build()),
 			authcodeExchange: authcodeExchangeInputs{
 				customSessionData: initialUpstreamOIDCRefreshTokenCustomSessionData(),
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access pinniped:request-audience groups") },
+				modifyAuthRequest: func(r *http.Request) {
+					r.Form.Set("scope", "openid offline_access pinniped:request-audience username groups")
+				},
 				want: tokenEndpointResponseExpectedValues{
 					wantStatus:                  http.StatusOK,
 					wantClientID:                pinnipedCLIClientID,
 					wantSuccessBodyFields:       []string{"id_token", "refresh_token", "access_token", "token_type", "expires_in", "scope"},
-					wantRequestedScopes:         []string{"openid", "offline_access", "pinniped:request-audience", "groups"},
-					wantGrantedScopes:           []string{"openid", "offline_access", "pinniped:request-audience", "groups"},
+					wantRequestedScopes:         []string{"openid", "offline_access", "pinniped:request-audience", "username", "groups"},
+					wantGrantedScopes:           []string{"openid", "offline_access", "pinniped:request-audience", "username", "groups"},
+					wantUsername:                goodUsername,
 					wantGroups:                  goodGroups,
 					wantCustomSessionDataStored: initialUpstreamOIDCRefreshTokenCustomSessionData(),
 				},
@@ -2169,8 +2415,9 @@ func TestRefreshGrant(t *testing.T) {
 					wantStatus:                        http.StatusOK,
 					wantClientID:                      pinnipedCLIClientID,
 					wantSuccessBodyFields:             []string{"id_token", "refresh_token", "access_token", "token_type", "expires_in", "scope"},
-					wantRequestedScopes:               []string{"openid", "offline_access", "pinniped:request-audience", "groups"},
-					wantGrantedScopes:                 []string{"openid", "offline_access", "pinniped:request-audience", "groups"},
+					wantRequestedScopes:               []string{"openid", "offline_access", "pinniped:request-audience", "username", "groups"},
+					wantGrantedScopes:                 []string{"openid", "offline_access", "pinniped:request-audience", "username", "groups"},
+					wantUsername:                      goodUsername,
 					wantGroups:                        goodGroups,
 					wantUpstreamRefreshCall:           happyOIDCUpstreamRefreshCall(),
 					wantUpstreamOIDCValidateTokenCall: happyUpstreamValidateTokenCall(refreshedUpstreamTokensWithIDAndRefreshTokens(), true),
@@ -2188,11 +2435,7 @@ func TestRefreshGrant(t *testing.T) {
 						},
 					},
 				}).WithRefreshedTokens(refreshedUpstreamTokensWithIDAndRefreshTokens()).Build()),
-			authcodeExchange: authcodeExchangeInputs{
-				customSessionData: initialUpstreamOIDCRefreshTokenCustomSessionData(),
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				want:              happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(initialUpstreamOIDCRefreshTokenCustomSessionData()),
-			},
+			authcodeExchange: happyAuthcodeExchangeInputsForOIDCUpstream,
 			refreshRequest: refreshRequestInputs{
 				modifyTokenRequest: func(r *http.Request, refreshToken string, accessToken string) {
 					r.Body = happyRefreshRequestBody(refreshToken).WithScope("").ReadCloser()
@@ -2208,14 +2451,16 @@ func TestRefreshGrant(t *testing.T) {
 			idps: oidctestutil.NewUpstreamIDPListerBuilder().WithOIDC(upstreamOIDCIdentityProviderBuilder().Build()),
 			authcodeExchange: authcodeExchangeInputs{
 				customSessionData: initialUpstreamOIDCRefreshTokenCustomSessionData(),
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "offline_access") },
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "offline_access username groups") },
 				want: tokenEndpointResponseExpectedValues{
 					wantStatus:                  http.StatusOK,
 					wantClientID:                pinnipedCLIClientID,
 					wantSuccessBodyFields:       []string{"refresh_token", "access_token", "token_type", "expires_in", "scope"},
-					wantRequestedScopes:         []string{"offline_access"},
-					wantGrantedScopes:           []string{"offline_access"},
+					wantRequestedScopes:         []string{"offline_access", "username", "groups"},
+					wantGrantedScopes:           []string{"offline_access", "username", "groups"},
 					wantCustomSessionDataStored: initialUpstreamOIDCRefreshTokenCustomSessionData(),
+					wantUsername:                goodUsername,
+					wantGroups:                  goodGroups,
 				},
 			},
 			refreshRequest: refreshRequestInputs{
@@ -2233,14 +2478,16 @@ func TestRefreshGrant(t *testing.T) {
 			idps: oidctestutil.NewUpstreamIDPListerBuilder().WithOIDC(upstreamOIDCIdentityProviderBuilder().Build()),
 			authcodeExchange: authcodeExchangeInputs{
 				customSessionData: initialUpstreamOIDCRefreshTokenCustomSessionData(),
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "offline_access") },
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "offline_access username groups") },
 				want: tokenEndpointResponseExpectedValues{
 					wantStatus:                  http.StatusOK,
 					wantClientID:                pinnipedCLIClientID,
 					wantSuccessBodyFields:       []string{"refresh_token", "access_token", "token_type", "expires_in", "scope"},
-					wantRequestedScopes:         []string{"offline_access"},
-					wantGrantedScopes:           []string{"offline_access"},
+					wantRequestedScopes:         []string{"offline_access", "username", "groups"},
+					wantGrantedScopes:           []string{"offline_access", "username", "groups"},
 					wantCustomSessionDataStored: initialUpstreamOIDCRefreshTokenCustomSessionData(),
+					wantUsername:                goodUsername,
+					wantGroups:                  goodGroups,
 				},
 			},
 			refreshRequest: refreshRequestInputs{
@@ -2258,14 +2505,16 @@ func TestRefreshGrant(t *testing.T) {
 			idps: oidctestutil.NewUpstreamIDPListerBuilder().WithOIDC(upstreamOIDCIdentityProviderBuilder().Build()),
 			authcodeExchange: authcodeExchangeInputs{
 				customSessionData: initialUpstreamOIDCRefreshTokenCustomSessionData(),
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "offline_access") },
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "offline_access username groups") },
 				want: tokenEndpointResponseExpectedValues{
 					wantStatus:                  http.StatusOK,
 					wantClientID:                pinnipedCLIClientID,
 					wantSuccessBodyFields:       []string{"refresh_token", "access_token", "token_type", "expires_in", "scope"},
-					wantRequestedScopes:         []string{"offline_access"},
-					wantGrantedScopes:           []string{"offline_access"},
+					wantRequestedScopes:         []string{"offline_access", "username", "groups"},
+					wantGrantedScopes:           []string{"offline_access", "username", "groups"},
 					wantCustomSessionDataStored: initialUpstreamOIDCRefreshTokenCustomSessionData(),
+					wantUsername:                goodUsername,
+					wantGroups:                  goodGroups,
 				},
 			},
 			refreshRequest: refreshRequestInputs{
@@ -2288,15 +2537,8 @@ func TestRefreshGrant(t *testing.T) {
 						},
 					},
 				}).WithRefreshedTokens(refreshedUpstreamTokensWithIDAndRefreshTokens()).Build()),
-			kubeResources: addFullyCapableDynamicClientAndSecretToKubeResources,
-			authcodeExchange: authcodeExchangeInputs{
-				// Make the auth request and authcode exchange request using the pinniped-cli client.
-				customSessionData: initialUpstreamOIDCRefreshTokenCustomSessionData(),
-				modifyAuthRequest: func(r *http.Request) {
-					r.Form.Set("scope", "openid offline_access groups")
-				},
-				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(initialUpstreamOIDCRefreshTokenCustomSessionData()),
-			},
+			kubeResources:    addFullyCapableDynamicClientAndSecretToKubeResources,
+			authcodeExchange: happyAuthcodeExchangeInputsForOIDCUpstream, // Make the auth request and authcode exchange request using the pinniped-cli client.
 			refreshRequest: refreshRequestInputs{
 				// Make the refresh request with the dynamic client.
 				modifyTokenRequest: modifyRefreshTokenRequestWithDynamicClientAuth,
@@ -2321,7 +2563,7 @@ func TestRefreshGrant(t *testing.T) {
 				customSessionData: initialUpstreamOIDCRefreshTokenCustomSessionData(),
 				modifyAuthRequest: func(r *http.Request) {
 					addDynamicClientIDToFormPostBody(r)
-					r.Form.Set("scope", "openid offline_access groups")
+					r.Form.Set("scope", "openid offline_access username groups")
 				},
 				modifyTokenRequest: modifyAuthcodeTokenRequestWithDynamicClientAuth,
 				want:               withWantDynamicClientID(happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(initialUpstreamOIDCRefreshTokenCustomSessionData())),
@@ -2352,7 +2594,7 @@ func TestRefreshGrant(t *testing.T) {
 				customSessionData: initialUpstreamOIDCRefreshTokenCustomSessionData(),
 				modifyAuthRequest: func(r *http.Request) {
 					addDynamicClientIDToFormPostBody(r)
-					r.Form.Set("scope", "openid offline_access groups")
+					r.Form.Set("scope", "openid offline_access username groups")
 				},
 				modifyTokenRequest: modifyAuthcodeTokenRequestWithDynamicClientAuth,
 				want:               withWantDynamicClientID(happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(initialUpstreamOIDCRefreshTokenCustomSessionData())),
@@ -2373,7 +2615,7 @@ func TestRefreshGrant(t *testing.T) {
 			idps: oidctestutil.NewUpstreamIDPListerBuilder().WithOIDC(upstreamOIDCIdentityProviderBuilder().Build()),
 			authcodeExchange: authcodeExchangeInputs{
 				customSessionData: nil, // this should not happen in practice
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access username groups") },
 				want:              happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(nil),
 			},
 			refreshRequest: refreshRequestInputs{
@@ -2393,7 +2635,7 @@ func TestRefreshGrant(t *testing.T) {
 					ProviderType: oidcUpstreamType,
 					OIDC:         &psession.OIDCSessionData{UpstreamRefreshToken: oidcUpstreamInitialRefreshToken},
 				},
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access username groups") },
 				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
 					&psession.CustomSessionData{ // want the initial customSessionData to be unmodified
 						ProviderName: "", // this should not happen in practice
@@ -2420,7 +2662,7 @@ func TestRefreshGrant(t *testing.T) {
 					ProviderType: oidcUpstreamType,
 					OIDC:         &psession.OIDCSessionData{UpstreamRefreshToken: oidcUpstreamInitialRefreshToken},
 				},
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access username groups") },
 				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
 					&psession.CustomSessionData{ // want the initial customSessionData to be unmodified
 						ProviderName: oidcUpstreamName,
@@ -2447,7 +2689,7 @@ func TestRefreshGrant(t *testing.T) {
 					ProviderType: "", // this should not happen in practice
 					OIDC:         &psession.OIDCSessionData{UpstreamRefreshToken: oidcUpstreamInitialRefreshToken},
 				},
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access username groups") },
 				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
 					&psession.CustomSessionData{ // want the initial customSessionData to be unmodified
 						ProviderName: oidcUpstreamName,
@@ -2474,7 +2716,7 @@ func TestRefreshGrant(t *testing.T) {
 					ProviderType: "not-an-allowed-provider-type", // this should not happen in practice
 					OIDC:         &psession.OIDCSessionData{UpstreamRefreshToken: oidcUpstreamInitialRefreshToken},
 				},
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access username groups") },
 				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
 					&psession.CustomSessionData{ // want the initial customSessionData to be unmodified
 						ProviderName: oidcUpstreamName,
@@ -2501,7 +2743,7 @@ func TestRefreshGrant(t *testing.T) {
 					ProviderType: oidcUpstreamType,
 					OIDC:         nil, // this should not happen in practice
 				},
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access username groups") },
 				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
 					&psession.CustomSessionData{ // want the initial customSessionData to be unmodified
 						ProviderName: oidcUpstreamName,
@@ -2531,7 +2773,7 @@ func TestRefreshGrant(t *testing.T) {
 						UpstreamAccessToken:  "",
 					},
 				},
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access username groups") },
 				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
 					&psession.CustomSessionData{ // want the initial customSessionData to be unmodified
 						ProviderName: oidcUpstreamName,
@@ -2561,7 +2803,7 @@ func TestRefreshGrant(t *testing.T) {
 					ProviderType: oidcUpstreamType,
 					OIDC:         &psession.OIDCSessionData{UpstreamRefreshToken: oidcUpstreamInitialRefreshToken},
 				},
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access username groups") },
 				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
 					&psession.CustomSessionData{ // want the initial customSessionData to be unmodified
 						ProviderName: "this-name-will-not-be-found", // this could happen if the OIDCIdentityProvider was deleted since original login
@@ -2593,7 +2835,7 @@ func TestRefreshGrant(t *testing.T) {
 					ProviderType: oidcUpstreamType,
 					OIDC:         &psession.OIDCSessionData{UpstreamRefreshToken: oidcUpstreamInitialRefreshToken},
 				},
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access username groups") },
 				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
 					&psession.CustomSessionData{ // want the initial customSessionData to be unmodified
 						ProviderName: oidcUpstreamName,
@@ -2619,11 +2861,7 @@ func TestRefreshGrant(t *testing.T) {
 			name: "when the upstream refresh fails during the refresh request",
 			idps: oidctestutil.NewUpstreamIDPListerBuilder().WithOIDC(upstreamOIDCIdentityProviderBuilder().
 				WithPerformRefreshError(errors.New("some upstream refresh error")).Build()),
-			authcodeExchange: authcodeExchangeInputs{
-				customSessionData: initialUpstreamOIDCRefreshTokenCustomSessionData(),
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				want:              happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(initialUpstreamOIDCRefreshTokenCustomSessionData()),
-			},
+			authcodeExchange: happyAuthcodeExchangeInputsForOIDCUpstream,
 			refreshRequest: refreshRequestInputs{
 				want: tokenEndpointResponseExpectedValues{
 					wantUpstreamRefreshCall: happyOIDCUpstreamRefreshCall(),
@@ -2644,11 +2882,7 @@ func TestRefreshGrant(t *testing.T) {
 				// This is the current format of the errors returned by the production code version of ValidateTokenAndMergeWithUserInfo, see ValidateTokenAndMergeWithUserInfo in upstreamoidc.go
 				WithValidateTokenAndMergeWithUserInfoError(httperr.Wrap(http.StatusBadRequest, "some validate error", errors.New("some validate cause"))).
 				Build()),
-			authcodeExchange: authcodeExchangeInputs{
-				customSessionData: initialUpstreamOIDCRefreshTokenCustomSessionData(),
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				want:              happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(initialUpstreamOIDCRefreshTokenCustomSessionData()),
-			},
+			authcodeExchange: happyAuthcodeExchangeInputsForOIDCUpstream,
 			refreshRequest: refreshRequestInputs{
 				want: tokenEndpointResponseExpectedValues{
 					wantUpstreamRefreshCall:           happyOIDCUpstreamRefreshCall(),
@@ -2676,11 +2910,7 @@ func TestRefreshGrant(t *testing.T) {
 					},
 				}).
 				Build()),
-			authcodeExchange: authcodeExchangeInputs{
-				customSessionData: initialUpstreamOIDCRefreshTokenCustomSessionData(),
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				want:              happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(initialUpstreamOIDCRefreshTokenCustomSessionData()),
-			},
+			authcodeExchange: happyAuthcodeExchangeInputsForOIDCUpstream,
 			refreshRequest: refreshRequestInputs{
 				want: tokenEndpointResponseExpectedValues{
 					wantUpstreamRefreshCall:           happyOIDCUpstreamRefreshCall(),
@@ -2705,11 +2935,7 @@ func TestRefreshGrant(t *testing.T) {
 						},
 					},
 				}).WithRefreshedTokens(refreshedUpstreamTokensWithIDAndRefreshTokens()).Build()),
-			authcodeExchange: authcodeExchangeInputs{
-				customSessionData: initialUpstreamOIDCRefreshTokenCustomSessionData(),
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				want:              happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(initialUpstreamOIDCRefreshTokenCustomSessionData()),
-			},
+			authcodeExchange: happyAuthcodeExchangeInputsForOIDCUpstream,
 			refreshRequest: refreshRequestInputs{
 				want: tokenEndpointResponseExpectedValues{
 					wantUpstreamRefreshCall:           happyOIDCUpstreamRefreshCall(),
@@ -2736,11 +2962,7 @@ func TestRefreshGrant(t *testing.T) {
 						},
 					},
 				}).WithRefreshedTokens(refreshedUpstreamTokensWithIDAndRefreshTokens()).Build()),
-			authcodeExchange: authcodeExchangeInputs{
-				customSessionData: initialUpstreamOIDCRefreshTokenCustomSessionData(),
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				want:              happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(initialUpstreamOIDCRefreshTokenCustomSessionData()),
-			},
+			authcodeExchange: happyAuthcodeExchangeInputsForOIDCUpstream,
 			refreshRequest: refreshRequestInputs{
 				want: tokenEndpointResponseExpectedValues{
 					wantUpstreamRefreshCall:           happyOIDCUpstreamRefreshCall(),
@@ -2767,11 +2989,7 @@ func TestRefreshGrant(t *testing.T) {
 						},
 					},
 				}).WithRefreshedTokens(refreshedUpstreamTokensWithIDAndRefreshTokens()).Build()),
-			authcodeExchange: authcodeExchangeInputs{
-				customSessionData: initialUpstreamOIDCRefreshTokenCustomSessionData(),
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				want:              happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(initialUpstreamOIDCRefreshTokenCustomSessionData()),
-			},
+			authcodeExchange: happyAuthcodeExchangeInputsForOIDCUpstream,
 			refreshRequest: refreshRequestInputs{
 				want: tokenEndpointResponseExpectedValues{
 					wantUpstreamRefreshCall:           happyOIDCUpstreamRefreshCall(),
@@ -2794,17 +3012,76 @@ func TestRefreshGrant(t *testing.T) {
 				URL:                  ldapUpstreamURL,
 				PerformRefreshGroups: goodGroups,
 			}),
-			authcodeExchange: authcodeExchangeInputs{
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				customSessionData: happyLDAPCustomSessionData,
-				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
-					happyLDAPCustomSessionData,
-				),
-			},
+			authcodeExchange: happyAuthcodeExchangeInputsForLDAPUpstream,
 			refreshRequest: refreshRequestInputs{
 				want: happyRefreshTokenResponseForLDAP(
 					happyLDAPCustomSessionData,
 				),
+			},
+		},
+		{
+			name: "upstream ldap refresh happy path using dynamic client",
+			idps: oidctestutil.NewUpstreamIDPListerBuilder().WithLDAP(&oidctestutil.TestUpstreamLDAPIdentityProvider{
+				Name:                 ldapUpstreamName,
+				ResourceUID:          ldapUpstreamResourceUID,
+				URL:                  ldapUpstreamURL,
+				PerformRefreshGroups: goodGroups,
+			}),
+			kubeResources: addFullyCapableDynamicClientAndSecretToKubeResources,
+			authcodeExchange: authcodeExchangeInputs{
+				modifyAuthRequest: func(r *http.Request) {
+					addDynamicClientIDToFormPostBody(r)
+					r.Form.Set("scope", "openid offline_access username groups")
+				},
+				modifyTokenRequest: modifyAuthcodeTokenRequestWithDynamicClientAuth,
+				customSessionData:  happyLDAPCustomSessionData,
+				want:               withWantDynamicClientID(happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(happyLDAPCustomSessionData)),
+			},
+			refreshRequest: refreshRequestInputs{
+				modifyTokenRequest: modifyRefreshTokenRequestWithDynamicClientAuth,
+				want:               withWantDynamicClientID(happyRefreshTokenResponseForLDAP(happyLDAPCustomSessionData)),
+			},
+		},
+		{
+			name: "upstream ldap refresh happy path without downstream username scope granted, using dynamic client",
+			idps: oidctestutil.NewUpstreamIDPListerBuilder().WithLDAP(&oidctestutil.TestUpstreamLDAPIdentityProvider{
+				Name:                 ldapUpstreamName,
+				ResourceUID:          ldapUpstreamResourceUID,
+				URL:                  ldapUpstreamURL,
+				PerformRefreshGroups: goodGroups,
+			}),
+			kubeResources: addFullyCapableDynamicClientAndSecretToKubeResources,
+			authcodeExchange: authcodeExchangeInputs{
+				modifyAuthRequest: func(r *http.Request) {
+					addDynamicClientIDToFormPostBody(r)
+					r.Form.Set("scope", "openid offline_access groups")
+				},
+				modifyTokenRequest: modifyAuthcodeTokenRequestWithDynamicClientAuth,
+				customSessionData:  happyLDAPCustomSessionData,
+				want: withWantDynamicClientID(tokenEndpointResponseExpectedValues{
+					wantStatus:                  http.StatusOK,
+					wantClientID:                dynamicClientID,
+					wantSuccessBodyFields:       []string{"id_token", "refresh_token", "access_token", "token_type", "expires_in", "scope"},
+					wantRequestedScopes:         []string{"openid", "offline_access", "groups"},
+					wantGrantedScopes:           []string{"openid", "offline_access", "groups"},
+					wantCustomSessionDataStored: happyLDAPCustomSessionData,
+					wantUsername:                "",
+					wantGroups:                  goodGroups,
+				}),
+			},
+			refreshRequest: refreshRequestInputs{
+				modifyTokenRequest: modifyRefreshTokenRequestWithDynamicClientAuth,
+				want: withWantDynamicClientID(tokenEndpointResponseExpectedValues{
+					wantStatus:                  http.StatusOK,
+					wantClientID:                dynamicClientID,
+					wantSuccessBodyFields:       []string{"id_token", "refresh_token", "access_token", "token_type", "expires_in", "scope"},
+					wantRequestedScopes:         []string{"openid", "offline_access", "groups"},
+					wantGrantedScopes:           []string{"openid", "offline_access", "groups"},
+					wantCustomSessionDataStored: happyLDAPCustomSessionData,
+					wantUsername:                "",
+					wantGroups:                  goodGroups,
+					wantUpstreamRefreshCall:     happyLDAPUpstreamRefreshCall(),
+				}),
 			},
 		},
 		{
@@ -2816,7 +3093,7 @@ func TestRefreshGrant(t *testing.T) {
 				PerformRefreshGroups: goodGroups,
 			}),
 			authcodeExchange: authcodeExchangeInputs{
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access username groups") },
 				customSessionData: happyActiveDirectoryCustomSessionData,
 				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
 					happyActiveDirectoryCustomSessionData,
@@ -2836,7 +3113,7 @@ func TestRefreshGrant(t *testing.T) {
 				URL:         ldapUpstreamURL,
 			}),
 			authcodeExchange: authcodeExchangeInputs{
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access username groups") },
 				customSessionData: &psession.CustomSessionData{
 					ProviderUID:  ldapUpstreamResourceUID,
 					ProviderName: ldapUpstreamName,
@@ -2872,7 +3149,7 @@ func TestRefreshGrant(t *testing.T) {
 				URL:         ldapUpstreamURL,
 			}),
 			authcodeExchange: authcodeExchangeInputs{
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access username groups") },
 				customSessionData: &psession.CustomSessionData{
 					ProviderUID:     activeDirectoryUpstreamResourceUID,
 					ProviderName:    activeDirectoryUpstreamName,
@@ -2908,7 +3185,7 @@ func TestRefreshGrant(t *testing.T) {
 				URL:         ldapUpstreamURL,
 			}),
 			authcodeExchange: authcodeExchangeInputs{
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access username groups") },
 				customSessionData: &psession.CustomSessionData{
 					ProviderUID:  ldapUpstreamResourceUID,
 					ProviderName: ldapUpstreamName,
@@ -2948,7 +3225,7 @@ func TestRefreshGrant(t *testing.T) {
 				URL:         ldapUpstreamURL,
 			}),
 			authcodeExchange: authcodeExchangeInputs{
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access username groups") },
 				customSessionData: &psession.CustomSessionData{
 					ProviderUID:  ldapUpstreamResourceUID,
 					ProviderName: ldapUpstreamName,
@@ -2988,13 +3265,7 @@ func TestRefreshGrant(t *testing.T) {
 				URL:               ldapUpstreamURL,
 				PerformRefreshErr: errors.New("Some error performing upstream refresh"),
 			}),
-			authcodeExchange: authcodeExchangeInputs{
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				customSessionData: happyLDAPCustomSessionData,
-				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
-					happyLDAPCustomSessionData,
-				),
-			},
+			authcodeExchange: happyAuthcodeExchangeInputsForLDAPUpstream,
 			refreshRequest: refreshRequestInputs{
 				want: tokenEndpointResponseExpectedValues{
 					wantUpstreamRefreshCall: happyLDAPUpstreamRefreshCall(),
@@ -3017,7 +3288,7 @@ func TestRefreshGrant(t *testing.T) {
 				PerformRefreshErr: errors.New("Some error performing upstream refresh"),
 			}),
 			authcodeExchange: authcodeExchangeInputs{
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access username groups") },
 				customSessionData: happyActiveDirectoryCustomSessionData,
 				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
 					happyActiveDirectoryCustomSessionData,
@@ -3037,15 +3308,9 @@ func TestRefreshGrant(t *testing.T) {
 			},
 		},
 		{
-			name: "upstream ldap idp not found",
-			idps: oidctestutil.NewUpstreamIDPListerBuilder(),
-			authcodeExchange: authcodeExchangeInputs{
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				customSessionData: happyLDAPCustomSessionData,
-				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
-					happyLDAPCustomSessionData,
-				),
-			},
+			name:             "upstream ldap idp not found",
+			idps:             oidctestutil.NewUpstreamIDPListerBuilder(),
+			authcodeExchange: happyAuthcodeExchangeInputsForLDAPUpstream,
 			refreshRequest: refreshRequestInputs{
 				want: tokenEndpointResponseExpectedValues{
 					wantStatus: http.StatusUnauthorized,
@@ -3062,7 +3327,7 @@ func TestRefreshGrant(t *testing.T) {
 			name: "upstream active directory idp not found",
 			idps: oidctestutil.NewUpstreamIDPListerBuilder(),
 			authcodeExchange: authcodeExchangeInputs{
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access username groups") },
 				customSessionData: happyActiveDirectoryCustomSessionData,
 				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
 					happyActiveDirectoryCustomSessionData,
@@ -3087,13 +3352,7 @@ func TestRefreshGrant(t *testing.T) {
 				ResourceUID: ldapUpstreamResourceUID,
 				URL:         ldapUpstreamURL,
 			}),
-			authcodeExchange: authcodeExchangeInputs{
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				customSessionData: happyLDAPCustomSessionData,
-				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
-					happyLDAPCustomSessionData,
-				),
-			},
+			authcodeExchange: happyAuthcodeExchangeInputsForLDAPUpstream,
 			modifyRefreshTokenStorage: func(t *testing.T, oauthStore *oidc.KubeStorage, refreshToken string) {
 				refreshTokenSignature := getFositeDataSignature(t, refreshToken)
 				firstRequester, err := oauthStore.GetRefreshTokenSession(context.Background(), refreshTokenSignature, nil)
@@ -3118,16 +3377,15 @@ func TestRefreshGrant(t *testing.T) {
 			},
 		},
 		{
-			name: "username not found in extra field",
+			name: "groups not found in extra field when the groups scope was granted",
 			idps: oidctestutil.NewUpstreamIDPListerBuilder().WithLDAP(&oidctestutil.TestUpstreamLDAPIdentityProvider{
 				Name:        ldapUpstreamName,
 				ResourceUID: ldapUpstreamResourceUID,
 				URL:         ldapUpstreamURL,
 			}),
 			authcodeExchange: authcodeExchangeInputs{
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access username groups") },
 				customSessionData: happyLDAPCustomSessionData,
-				//fositeSessionData: &openid.DefaultSession{},
 				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
 					happyLDAPCustomSessionData,
 				),
@@ -3137,11 +3395,7 @@ func TestRefreshGrant(t *testing.T) {
 				firstRequester, err := oauthStore.GetRefreshTokenSession(context.Background(), refreshTokenSignature, nil)
 				require.NoError(t, err)
 				session := firstRequester.GetSession().(*psession.PinnipedSession)
-				session.Fosite = &openid.DefaultSession{
-					Claims: &jwt.IDTokenClaims{
-						Extra: map[string]interface{}{},
-					},
-				}
+				delete(session.Fosite.Claims.Extra, "groups")
 				err = oauthStore.DeleteRefreshTokenSession(context.Background(), refreshTokenSignature)
 				require.NoError(t, err)
 				err = oauthStore.CreateRefreshTokenSession(context.Background(), refreshTokenSignature, firstRequester)
@@ -3160,16 +3414,15 @@ func TestRefreshGrant(t *testing.T) {
 			},
 		},
 		{
-			name: "username in extra is not a string",
+			name: "username in custom session is empty string during refresh",
 			idps: oidctestutil.NewUpstreamIDPListerBuilder().WithLDAP(&oidctestutil.TestUpstreamLDAPIdentityProvider{
 				Name:        ldapUpstreamName,
 				ResourceUID: ldapUpstreamResourceUID,
 				URL:         ldapUpstreamURL,
 			}),
 			authcodeExchange: authcodeExchangeInputs{
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access username groups") },
 				customSessionData: happyLDAPCustomSessionData,
-				//fositeSessionData: &openid.DefaultSession{},
 				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
 					happyLDAPCustomSessionData,
 				),
@@ -3179,53 +3432,7 @@ func TestRefreshGrant(t *testing.T) {
 				firstRequester, err := oauthStore.GetRefreshTokenSession(context.Background(), refreshTokenSignature, nil)
 				require.NoError(t, err)
 				session := firstRequester.GetSession().(*psession.PinnipedSession)
-				session.Fosite = &openid.DefaultSession{
-					Claims: &jwt.IDTokenClaims{
-						Extra: map[string]interface{}{"username": 123},
-					},
-				}
-				err = oauthStore.DeleteRefreshTokenSession(context.Background(), refreshTokenSignature)
-				require.NoError(t, err)
-				err = oauthStore.CreateRefreshTokenSession(context.Background(), refreshTokenSignature, firstRequester)
-				require.NoError(t, err)
-			},
-			refreshRequest: refreshRequestInputs{
-				want: tokenEndpointResponseExpectedValues{
-					wantStatus: http.StatusInternalServerError,
-					wantErrorResponseBody: here.Doc(`
-						{
-							"error":             "error",
-							"error_description": "There was an internal server error. Required upstream data not found in session."
-						}
-					`),
-				},
-			},
-		},
-		{
-			name: "username in extra is an empty string",
-			idps: oidctestutil.NewUpstreamIDPListerBuilder().WithLDAP(&oidctestutil.TestUpstreamLDAPIdentityProvider{
-				Name:        ldapUpstreamName,
-				ResourceUID: ldapUpstreamResourceUID,
-				URL:         ldapUpstreamURL,
-			}),
-			authcodeExchange: authcodeExchangeInputs{
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				customSessionData: happyLDAPCustomSessionData,
-				//fositeSessionData: &openid.DefaultSession{},
-				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
-					happyLDAPCustomSessionData,
-				),
-			},
-			modifyRefreshTokenStorage: func(t *testing.T, oauthStore *oidc.KubeStorage, refreshToken string) {
-				refreshTokenSignature := getFositeDataSignature(t, refreshToken)
-				firstRequester, err := oauthStore.GetRefreshTokenSession(context.Background(), refreshTokenSignature, nil)
-				require.NoError(t, err)
-				session := firstRequester.GetSession().(*psession.PinnipedSession)
-				session.Fosite = &openid.DefaultSession{
-					Claims: &jwt.IDTokenClaims{
-						Extra: map[string]interface{}{"username": ""},
-					},
-				}
+				session.Custom.Username = ""
 				err = oauthStore.DeleteRefreshTokenSession(context.Background(), refreshTokenSignature)
 				require.NoError(t, err)
 				err = oauthStore.CreateRefreshTokenSession(context.Background(), refreshTokenSignature, firstRequester)
@@ -3250,13 +3457,7 @@ func TestRefreshGrant(t *testing.T) {
 				ResourceUID: "the-wrong-uid",
 				URL:         ldapUpstreamURL,
 			}),
-			authcodeExchange: authcodeExchangeInputs{
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				customSessionData: happyLDAPCustomSessionData,
-				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
-					happyLDAPCustomSessionData,
-				),
-			},
+			authcodeExchange: happyAuthcodeExchangeInputsForLDAPUpstream,
 			refreshRequest: refreshRequestInputs{
 				want: tokenEndpointResponseExpectedValues{
 					wantStatus: http.StatusUnauthorized,
@@ -3277,7 +3478,7 @@ func TestRefreshGrant(t *testing.T) {
 				URL:         ldapUpstreamURL,
 			}),
 			authcodeExchange: authcodeExchangeInputs{
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
+				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access username groups") },
 				customSessionData: happyActiveDirectoryCustomSessionData,
 				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
 					happyActiveDirectoryCustomSessionData,
@@ -3296,141 +3497,13 @@ func TestRefreshGrant(t *testing.T) {
 			},
 		},
 		{
-			name: "upstream ldap idp not found",
-			idps: oidctestutil.NewUpstreamIDPListerBuilder(),
-			authcodeExchange: authcodeExchangeInputs{
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				customSessionData: happyLDAPCustomSessionData,
-				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
-					happyLDAPCustomSessionData,
-				),
-			},
-			refreshRequest: refreshRequestInputs{
-				want: tokenEndpointResponseExpectedValues{
-					wantStatus: http.StatusUnauthorized,
-					wantErrorResponseBody: here.Doc(`
-						{
-							"error":             "error",
-							"error_description": "Error during upstream refresh. Provider from upstream session data was not found."
-						}
-					`),
-				},
-			},
-		},
-		{
-			name: "upstream active directory idp not found",
-			idps: oidctestutil.NewUpstreamIDPListerBuilder(),
-			authcodeExchange: authcodeExchangeInputs{
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				customSessionData: happyActiveDirectoryCustomSessionData,
-				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
-					happyActiveDirectoryCustomSessionData,
-				),
-			},
-			refreshRequest: refreshRequestInputs{
-				want: tokenEndpointResponseExpectedValues{
-					wantStatus: http.StatusUnauthorized,
-					wantErrorResponseBody: here.Doc(`
-						{
-							"error":             "error",
-							"error_description": "Error during upstream refresh. Provider from upstream session data was not found."
-						}
-					`),
-				},
-			},
-		},
-		{
-			name: "fosite session is empty",
-			idps: oidctestutil.NewUpstreamIDPListerBuilder().WithLDAP(&oidctestutil.TestUpstreamLDAPIdentityProvider{
-				Name:        ldapUpstreamName,
-				ResourceUID: ldapUpstreamResourceUID,
-				URL:         ldapUpstreamURL,
-			}),
-			authcodeExchange: authcodeExchangeInputs{
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				customSessionData: happyLDAPCustomSessionData,
-				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
-					happyLDAPCustomSessionData,
-				),
-			},
-			modifyRefreshTokenStorage: func(t *testing.T, oauthStore *oidc.KubeStorage, refreshToken string) {
-				refreshTokenSignature := getFositeDataSignature(t, refreshToken)
-				firstRequester, err := oauthStore.GetRefreshTokenSession(context.Background(), refreshTokenSignature, nil)
-				require.NoError(t, err)
-				session := firstRequester.GetSession().(*psession.PinnipedSession)
-				session.Fosite = &openid.DefaultSession{}
-				err = oauthStore.DeleteRefreshTokenSession(context.Background(), refreshTokenSignature)
-				require.NoError(t, err)
-				err = oauthStore.CreateRefreshTokenSession(context.Background(), refreshTokenSignature, firstRequester)
-				require.NoError(t, err)
-			},
-			refreshRequest: refreshRequestInputs{
-				want: tokenEndpointResponseExpectedValues{
-					wantStatus: http.StatusInternalServerError,
-					wantErrorResponseBody: here.Doc(`
-						{
-							"error":             "error",
-							"error_description": "There was an internal server error. Required upstream data not found in session."
-						}
-					`),
-				},
-			},
-		},
-		{
-			name: "username not found in extra field",
-			idps: oidctestutil.NewUpstreamIDPListerBuilder().WithLDAP(&oidctestutil.TestUpstreamLDAPIdentityProvider{
-				Name:        ldapUpstreamName,
-				ResourceUID: ldapUpstreamResourceUID,
-				URL:         ldapUpstreamURL,
-			}),
-			authcodeExchange: authcodeExchangeInputs{
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				customSessionData: happyLDAPCustomSessionData,
-				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
-					happyLDAPCustomSessionData,
-				),
-			},
-			modifyRefreshTokenStorage: func(t *testing.T, oauthStore *oidc.KubeStorage, refreshToken string) {
-				refreshTokenSignature := getFositeDataSignature(t, refreshToken)
-				firstRequester, err := oauthStore.GetRefreshTokenSession(context.Background(), refreshTokenSignature, nil)
-				require.NoError(t, err)
-				session := firstRequester.GetSession().(*psession.PinnipedSession)
-				session.Fosite = &openid.DefaultSession{
-					Claims: &jwt.IDTokenClaims{
-						Extra: map[string]interface{}{},
-					},
-				}
-				err = oauthStore.DeleteRefreshTokenSession(context.Background(), refreshTokenSignature)
-				require.NoError(t, err)
-				err = oauthStore.CreateRefreshTokenSession(context.Background(), refreshTokenSignature, firstRequester)
-				require.NoError(t, err)
-			},
-			refreshRequest: refreshRequestInputs{
-				want: tokenEndpointResponseExpectedValues{
-					wantStatus: http.StatusInternalServerError,
-					wantErrorResponseBody: here.Doc(`
-						{
-							"error":             "error",
-							"error_description": "There was an internal server error. Required upstream data not found in session."
-						}
-					`),
-				},
-			},
-		},
-		{
 			name: "auth time is the zero value", // time.Times can never be nil, but it is possible that it would be the zero value which would mean something's wrong
 			idps: oidctestutil.NewUpstreamIDPListerBuilder().WithLDAP(&oidctestutil.TestUpstreamLDAPIdentityProvider{
 				Name:        ldapUpstreamName,
 				ResourceUID: ldapUpstreamResourceUID,
 				URL:         ldapUpstreamURL,
 			}),
-			authcodeExchange: authcodeExchangeInputs{
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				customSessionData: happyLDAPCustomSessionData,
-				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
-					happyLDAPCustomSessionData,
-				),
-			},
+			authcodeExchange: happyAuthcodeExchangeInputsForLDAPUpstream,
 			modifyRefreshTokenStorage: func(t *testing.T, oauthStore *oidc.KubeStorage, refreshToken string) {
 				refreshTokenSignature := getFositeDataSignature(t, refreshToken)
 				firstRequester, err := oauthStore.GetRefreshTokenSession(context.Background(), refreshTokenSignature, nil)
@@ -3451,58 +3524,6 @@ func TestRefreshGrant(t *testing.T) {
 						{
 							"error":             "error",
 							"error_description": "There was an internal server error. Required upstream data not found in session."
-						}
-					`),
-				},
-			},
-		},
-		{
-			name: "when the ldap provider in the session storage is found but has the wrong resource UID during the refresh request",
-			idps: oidctestutil.NewUpstreamIDPListerBuilder().WithLDAP(&oidctestutil.TestUpstreamLDAPIdentityProvider{
-				Name:        ldapUpstreamName,
-				ResourceUID: "the-wrong-uid",
-				URL:         ldapUpstreamURL,
-			}),
-			authcodeExchange: authcodeExchangeInputs{
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				customSessionData: happyLDAPCustomSessionData,
-				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
-					happyLDAPCustomSessionData,
-				),
-			},
-			refreshRequest: refreshRequestInputs{
-				want: tokenEndpointResponseExpectedValues{
-					wantStatus: http.StatusUnauthorized,
-					wantErrorResponseBody: here.Doc(`
-						{
-							"error":             "error",
-							"error_description": "Error during upstream refresh. Provider from upstream session data has changed its resource UID since authentication."
-						}
-					`),
-				},
-			},
-		},
-		{
-			name: "when the active directory provider in the session storage is found but has the wrong resource UID during the refresh request",
-			idps: oidctestutil.NewUpstreamIDPListerBuilder().WithActiveDirectory(&oidctestutil.TestUpstreamLDAPIdentityProvider{
-				Name:        activeDirectoryUpstreamName,
-				ResourceUID: "the-wrong-uid",
-				URL:         ldapUpstreamURL,
-			}),
-			authcodeExchange: authcodeExchangeInputs{
-				modifyAuthRequest: func(r *http.Request) { r.Form.Set("scope", "openid offline_access groups") },
-				customSessionData: happyActiveDirectoryCustomSessionData,
-				want: happyAuthcodeExchangeTokenResponseForOpenIDAndOfflineAccess(
-					happyActiveDirectoryCustomSessionData,
-				),
-			},
-			refreshRequest: refreshRequestInputs{
-				want: tokenEndpointResponseExpectedValues{
-					wantStatus: http.StatusUnauthorized,
-					wantErrorResponseBody: here.Doc(`
-						{
-							"error":             "error",
-							"error_description": "Error during upstream refresh. Provider from upstream session data has changed its resource UID since authentication."
 						}
 					`),
 				},
@@ -3540,7 +3561,9 @@ func TestRefreshGrant(t *testing.T) {
 			if test.modifyRefreshTokenStorage != nil {
 				test.modifyRefreshTokenStorage(t, oauthStore, firstRefreshToken)
 			}
-			reqContext := context.WithValue(context.Background(), struct{ name string }{name: "test"}, "request-context")
+
+			reqContextWarningRecorder := &TestWarningRecorder{}
+			reqContext := warning.WithWarningRecorder(context.WithValue(context.Background(), struct{ name string }{name: "test"}, "request-context"), reqContextWarningRecorder)
 			req := httptest.NewRequest("POST", "/path/shouldn't/matter",
 				happyRefreshRequestBody(firstRefreshToken).ReadCloser()).WithContext(reqContext)
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -3577,6 +3600,13 @@ func TestRefreshGrant(t *testing.T) {
 				test.idps.RequireExactlyZeroCallsToValidateToken(t)
 			}
 
+			// Test that the expected warnings were set on the request context.
+			if test.refreshRequest.want.wantWarnings != nil {
+				require.Equal(t, test.refreshRequest.want.wantWarnings, reqContextWarningRecorder.Warnings)
+			} else {
+				require.Len(t, reqContextWarningRecorder.Warnings, 0, "wanted no warnings on the request context, but found some")
+			}
+
 			// The bug in fosite that prevents at_hash from appearing in the initial ID token does not impact the refreshed ID token
 			wantAtHashClaimInIDToken := true
 			// Refreshed ID tokens do not include the nonce from the original auth request
@@ -3584,6 +3614,7 @@ func TestRefreshGrant(t *testing.T) {
 
 			requireTokenEndpointBehavior(t,
 				test.refreshRequest.want,
+				test.authcodeExchange.want.wantUsername, // the old username from the initial login
 				test.authcodeExchange.want.wantGroups,   // the old groups from the initial login
 				test.authcodeExchange.customSessionData, // the old custom session data from the initial login
 				wantAtHashClaimInIDToken,
@@ -3726,6 +3757,7 @@ func exchangeAuthcodeForTokens(
 
 	requireTokenEndpointBehavior(t,
 		test.want,
+		test.want.wantUsername, // the old username from the initial login
 		test.want.wantGroups,   // the old groups from the initial login
 		test.customSessionData, // the old custom session data from the initial login
 		wantAtHashClaimInIDToken,
@@ -3744,6 +3776,7 @@ func exchangeAuthcodeForTokens(
 func requireTokenEndpointBehavior(
 	t *testing.T,
 	test tokenEndpointResponseExpectedValues,
+	oldUsername string,
 	oldGroups []string,
 	oldCustomSessionData *psession.CustomSessionData,
 	wantAtHashClaimInIDToken bool,
@@ -3769,10 +3802,10 @@ func requireTokenEndpointBehavior(
 		wantRefreshToken := contains(test.wantSuccessBodyFields, "refresh_token")
 
 		requireInvalidAuthCodeStorage(t, authCode, oauthStore, secrets, requestTime)
-		requireValidAccessTokenStorage(t, parsedResponseBody, oauthStore, test.wantClientID, test.wantRequestedScopes, test.wantGrantedScopes, test.wantGroups, test.wantCustomSessionDataStored, secrets, requestTime)
+		requireValidAccessTokenStorage(t, parsedResponseBody, oauthStore, test.wantClientID, test.wantRequestedScopes, test.wantGrantedScopes, test.wantUsername, test.wantGroups, test.wantCustomSessionDataStored, secrets, requestTime)
 		requireInvalidPKCEStorage(t, authCode, oauthStore)
-		// Performing a refresh does not update the OIDC storage, so after a refresh it should still have the old custom session data and old groups from the initial login.
-		requireValidOIDCStorage(t, parsedResponseBody, authCode, oauthStore, test.wantClientID, test.wantRequestedScopes, test.wantGrantedScopes, oldGroups, oldCustomSessionData, requestTime)
+		// Performing a refresh does not update the OIDC storage, so after a refresh it should still have the old custom session data and old username and groups from the initial login.
+		requireValidOIDCStorage(t, parsedResponseBody, authCode, oauthStore, test.wantClientID, test.wantRequestedScopes, test.wantGrantedScopes, oldUsername, oldGroups, oldCustomSessionData, requestTime)
 
 		expectedNumberOfRefreshTokenSessionsStored := 0
 		if wantRefreshToken {
@@ -3781,10 +3814,10 @@ func requireTokenEndpointBehavior(
 		expectedNumberOfIDSessionsStored := 0
 		if wantIDToken {
 			expectedNumberOfIDSessionsStored = 1
-			requireValidIDToken(t, parsedResponseBody, jwtSigningKey, test.wantClientID, wantAtHashClaimInIDToken, wantNonceValueInIDToken, test.wantGroups, parsedResponseBody["access_token"].(string), requestTime)
+			requireValidIDToken(t, parsedResponseBody, jwtSigningKey, test.wantClientID, wantAtHashClaimInIDToken, wantNonceValueInIDToken, test.wantUsername, test.wantGroups, parsedResponseBody["access_token"].(string), requestTime)
 		}
 		if wantRefreshToken {
-			requireValidRefreshTokenStorage(t, parsedResponseBody, oauthStore, test.wantClientID, test.wantRequestedScopes, test.wantGrantedScopes, test.wantGroups, test.wantCustomSessionDataStored, secrets, requestTime)
+			requireValidRefreshTokenStorage(t, parsedResponseBody, oauthStore, test.wantClientID, test.wantRequestedScopes, test.wantGrantedScopes, test.wantUsername, test.wantGroups, test.wantCustomSessionDataStored, secrets, requestTime)
 		}
 
 		testutil.RequireNumberOfSecretsMatchingLabelSelector(t, secrets, labels.Set{crud.SecretLabelKey: authorizationcode.TypeLabelValue}, 1)
@@ -3963,12 +3996,10 @@ func simulateAuthEndpointHavingAlreadyRun(
 				Subject:     goodSubject,
 				RequestedAt: goodRequestedAtTime,
 				AuthTime:    goodAuthTime,
-				Extra: map[string]interface{}{
-					oidc.DownstreamUsernameClaim: goodUsername,
-				},
+				Extra:       map[string]interface{}{},
 			},
-			Subject:  "", // not used, note that callback_handler.go does not set this
-			Username: "", // not used, note that callback_handler.go does not set this
+			Subject:  "", // not used, note that the authorization and callback endpoints do not set this
+			Username: "", // not used, note that the authorization and callback endpoints do not set this
 		},
 		Custom: initialCustomSessionData,
 	}
@@ -3983,10 +4014,19 @@ func simulateAuthEndpointHavingAlreadyRun(
 	if strings.Contains(authRequest.Form.Get("scope"), "pinniped:request-audience") {
 		authRequester.GrantScope("pinniped:request-audience")
 	}
-	if strings.Contains(authRequest.Form.Get("scope"), "groups") {
-		authRequester.GrantScope("groups")
-		session.Fosite.Claims.Extra[oidc.DownstreamGroupsClaim] = goodGroups
+
+	// The authorization endpoint makes a special exception for the pinniped-cli client for backwards compatibility
+	// and grants the username and groups scopes to that client even if it did not ask for them. Simulate that
+	// behavior here too.
+	if strings.Contains(authRequest.Form.Get("scope"), "username") || authRequest.Form.Get("client_id") == pinnipedCLIClientID {
+		authRequester.GrantScope("username")
+		session.Fosite.Claims.Extra["username"] = goodUsername
 	}
+	if strings.Contains(authRequest.Form.Get("scope"), "groups") || authRequest.Form.Get("client_id") == pinnipedCLIClientID {
+		authRequester.GrantScope("groups")
+		session.Fosite.Claims.Extra["groups"] = goodGroups
+	}
+
 	authResponder, err := oauthHelper.NewAuthorizeResponse(ctx, authRequester, session)
 	require.NoError(t, err)
 	return authResponder
@@ -4032,6 +4072,7 @@ func requireValidRefreshTokenStorage(
 	wantClientID string,
 	wantRequestedScopes []string,
 	wantGrantedScopes []string,
+	wantUsername string,
 	wantGroups []string,
 	wantCustomSessionData *psession.CustomSessionData,
 	secrets v1.SecretInterface,
@@ -4060,6 +4101,7 @@ func requireValidRefreshTokenStorage(
 		wantRequestedScopes,
 		wantGrantedScopes,
 		true,
+		wantUsername,
 		wantGroups,
 		wantCustomSessionData,
 		requestTime,
@@ -4075,6 +4117,7 @@ func requireValidAccessTokenStorage(
 	wantClientID string,
 	wantRequestedScopes []string,
 	wantGrantedScopes []string,
+	wantUsername string,
 	wantGroups []string,
 	wantCustomSessionData *psession.CustomSessionData,
 	secrets v1.SecretInterface,
@@ -4122,6 +4165,7 @@ func requireValidAccessTokenStorage(
 		wantRequestedScopes,
 		wantGrantedScopes,
 		true,
+		wantUsername,
 		wantGroups,
 		wantCustomSessionData,
 		requestTime,
@@ -4167,6 +4211,7 @@ func requireValidOIDCStorage(
 	wantClientID string,
 	wantRequestedScopes []string,
 	wantGrantedScopes []string,
+	wantUsername string,
 	wantGroups []string,
 	wantCustomSessionData *psession.CustomSessionData,
 	requestTime time.Time,
@@ -4193,6 +4238,7 @@ func requireValidOIDCStorage(
 			wantRequestedScopes,
 			wantGrantedScopes,
 			false,
+			wantUsername,
 			wantGroups,
 			wantCustomSessionData,
 			requestTime,
@@ -4211,6 +4257,7 @@ func requireValidStoredRequest(
 	wantRequestedScopes []string,
 	wantGrantedScopes []string,
 	wantAccessTokenExpiresAt bool,
+	wantUsername string,
 	wantGroups []string,
 	wantCustomSessionData *psession.CustomSessionData,
 	requestTime time.Time,
@@ -4231,49 +4278,45 @@ func requireValidStoredRequest(
 	session, ok := request.GetSession().(*psession.PinnipedSession)
 	require.Truef(t, ok, "could not cast %T to %T", request.GetSession(), &psession.PinnipedSession{})
 
-	// Assert that the session claims are what we think they should be, but only if we are doing OIDC.
-	if contains(wantGrantedScopes, "openid") {
-		claims := session.Fosite.Claims
-		require.Empty(t, claims.JTI) // When claims.JTI is empty, Fosite will generate a UUID for this field.
-		require.Equal(t, goodSubject, claims.Subject)
+	// Assert that the session claims are what we think they should be.
+	claims := session.Fosite.Claims
+	require.Empty(t, claims.JTI) // When claims.JTI is empty, Fosite will generate a UUID for this field.
+	require.Equal(t, goodSubject, claims.Subject)
 
-		// Our custom claims from the authorize endpoint should still be set.
-		expectedExtra := map[string]interface{}{
-			"username": goodUsername,
-		}
-		if wantGroups != nil {
-			expectedExtra["groups"] = toSliceOfInterface(wantGroups)
-		}
-		require.Equal(t, expectedExtra, claims.Extra)
-
-		// We are in charge of setting these fields. For the purpose of testing, we ensure that the
-		// sentinel test value is set correctly.
-		require.Equal(t, goodRequestedAtTime, claims.RequestedAt)
-		require.Equal(t, goodAuthTime, claims.AuthTime)
-
-		// These fields will all be given good defaults by fosite at runtime and we only need to use them
-		// if we want to override the default behaviors. We currently don't need to override these defaults,
-		// so they do not end up being stored. Fosite sets its defaults at runtime in openid.DefaultStrategy's
-		// GenerateIDToken() method.
-		require.Empty(t, claims.Issuer)
-		require.Empty(t, claims.Audience)
-		require.Empty(t, claims.Nonce)
-		require.Zero(t, claims.ExpiresAt)
-		require.Zero(t, claims.IssuedAt)
-
-		// Fosite unconditionally overwrites claims.AccessTokenHash at runtime in openid.OpenIDConnectExplicitHandler's
-		// PopulateTokenEndpointResponse() method, just before it calls the same GenerateIDToken() mentioned above,
-		// so it does not end up saved in storage.
-		require.Empty(t, claims.AccessTokenHash)
-
-		// At this time, we don't use any of these optional (per the OIDC spec) fields.
-		require.Empty(t, claims.AuthenticationContextClassReference)
-		require.Empty(t, claims.AuthenticationMethodsReferences)
-		require.Empty(t, claims.CodeHash)
-	} else if wantGroups != nil {
-		t.Fatal("test did not want the openid scope to be granted, but also wanted groups, " +
-			"which is a combination that doesn't make sense since you need an ID token to get groups")
+	// Our custom claims from the authorize endpoint should still be set.
+	expectedExtra := map[string]interface{}{}
+	if wantUsername != "" {
+		expectedExtra["username"] = wantUsername
 	}
+	if wantGroups != nil {
+		expectedExtra["groups"] = toSliceOfInterface(wantGroups)
+	}
+	require.Equal(t, expectedExtra, claims.Extra)
+
+	// We are in charge of setting these fields. For the purpose of testing, we ensure that the
+	// sentinel test value is set correctly.
+	require.Equal(t, goodRequestedAtTime, claims.RequestedAt)
+	require.Equal(t, goodAuthTime, claims.AuthTime)
+
+	// These fields will all be given good defaults by fosite at runtime and we only need to use them
+	// if we want to override the default behaviors. We currently don't need to override these defaults,
+	// so they do not end up being stored. Fosite sets its defaults at runtime in openid.DefaultStrategy's
+	// GenerateIDToken() method.
+	require.Empty(t, claims.Issuer)
+	require.Empty(t, claims.Audience)
+	require.Empty(t, claims.Nonce)
+	require.Zero(t, claims.ExpiresAt)
+	require.Zero(t, claims.IssuedAt)
+
+	// Fosite unconditionally overwrites claims.AccessTokenHash at runtime in openid.OpenIDConnectExplicitHandler's
+	// PopulateTokenEndpointResponse() method, just before it calls the same GenerateIDToken() mentioned above,
+	// so it does not end up saved in storage.
+	require.Empty(t, claims.AccessTokenHash)
+
+	// At this time, we don't use any of these optional (per the OIDC spec) fields.
+	require.Empty(t, claims.AuthenticationContextClassReference)
+	require.Empty(t, claims.AuthenticationMethodsReferences)
+	require.Empty(t, claims.CodeHash)
 
 	// Assert that the session headers are what we think they should be.
 	headers := session.Fosite.Headers
@@ -4336,6 +4379,7 @@ func requireValidIDToken(
 	wantClientID string,
 	wantAtHashClaimInIDToken bool,
 	wantNonceValueInIDToken bool,
+	wantUsernameInIDToken string,
 	wantGroupsInIDToken []string,
 	actualAccessToken string,
 	requestTime time.Time,
@@ -4368,12 +4412,15 @@ func requireValidIDToken(
 	// Note that there is a bug in fosite which prevents the `at_hash` claim from appearing in this ID token
 	// during the initial authcode exchange, but does not prevent `at_hash` from appearing in the refreshed ID token.
 	// We can add a workaround for this later.
-	idTokenFields := []string{"sub", "aud", "iss", "jti", "auth_time", "exp", "iat", "rat", "username"}
+	idTokenFields := []string{"sub", "aud", "iss", "jti", "auth_time", "exp", "iat", "rat"}
 	if wantAtHashClaimInIDToken {
 		idTokenFields = append(idTokenFields, "at_hash")
 	}
 	if wantNonceValueInIDToken {
 		idTokenFields = append(idTokenFields, "nonce")
+	}
+	if wantUsernameInIDToken != "" {
+		idTokenFields = append(idTokenFields, "username")
 	}
 	if wantGroupsInIDToken != nil {
 		idTokenFields = append(idTokenFields, "groups")
@@ -4388,7 +4435,7 @@ func requireValidIDToken(
 	err := token.Claims(&claims)
 	require.NoError(t, err)
 	require.Equal(t, goodSubject, claims.Subject)
-	require.Equal(t, goodUsername, claims.Username)
+	require.Equal(t, wantUsernameInIDToken, claims.Username)
 	require.Equal(t, wantGroupsInIDToken, claims.Groups)
 	require.Len(t, claims.Audience, 1)
 	require.Equal(t, wantClientID, claims.Audience[0])
@@ -4498,4 +4545,25 @@ func TestDiffSortedGroups(t *testing.T) {
 			require.Equal(t, test.wantRemoved, removed)
 		})
 	}
+}
+
+type RecordedWarning struct {
+	Agent string
+	Text  string
+}
+
+type TestWarningRecorder struct {
+	Warnings []RecordedWarning
+}
+
+var _ warning.Recorder = (*TestWarningRecorder)(nil)
+
+func (t *TestWarningRecorder) AddWarning(agent, text string) {
+	if t.Warnings == nil {
+		t.Warnings = []RecordedWarning{}
+	}
+	t.Warnings = append(t.Warnings, RecordedWarning{
+		Agent: agent,
+		Text:  text,
+	})
 }

--- a/internal/psession/pinniped_session.go
+++ b/internal/psession/pinniped_session.go
@@ -27,6 +27,11 @@ var _ openid.Session = &PinnipedSession{}
 // CustomSessionData is the custom session data needed by Pinniped. It should be treated as a union type,
 // where the value of ProviderType decides which other fields to use.
 type CustomSessionData struct {
+	// Username will contain the downstream username determined during initial authorization. We store this
+	// so that we can validate that it does not change upon refresh. This should normally never be empty, since
+	// all users must have a username.
+	Username string `json:"username"`
+
 	// The Kubernetes resource UID of the identity provider CRD for the upstream IDP used to start this session.
 	// This should be validated again upon downstream refresh to make sure that we are not refreshing against
 	// a different identity provider CRD which just happens to have the same name.

--- a/internal/testutil/oidctestutil/oidctestutil.go
+++ b/internal/testutil/oidctestutil/oidctestutil.go
@@ -1062,27 +1062,31 @@ func validateAuthcodeStorage(
 	// Now confirm the ID token claims.
 	actualClaims := storedSessionFromAuthcode.Fosite.Claims
 
+	// Should always have an azp claim.
+	require.Equal(t, wantDownstreamClientID, actualClaims.Extra["azp"])
+	wantDownstreamIDTokenExtraClaimsCount := 1 // should always have azp claim
+
 	// Check the user's identity, which are put into the downstream ID token's subject, username and groups claims.
 	require.Equal(t, wantDownstreamIDTokenSubject, actualClaims.Subject)
-	wantDownstreamIDTokenUsernameClaimToExist := 1
 	if wantDownstreamIDTokenUsername == "" {
-		wantDownstreamIDTokenUsernameClaimToExist = 0
 		require.NotContains(t, actualClaims.Extra, "username")
 	} else {
+		wantDownstreamIDTokenExtraClaimsCount++ // should also have username claim
 		require.Equal(t, wantDownstreamIDTokenUsername, actualClaims.Extra["username"])
 	}
 	if slices.Contains(wantDownstreamGrantedScopes, "groups") {
-		require.Len(t, actualClaims.Extra, wantDownstreamIDTokenUsernameClaimToExist+1)
+		wantDownstreamIDTokenExtraClaimsCount++ // should also have groups claim
 		actualDownstreamIDTokenGroups := actualClaims.Extra["groups"]
 		require.NotNil(t, actualDownstreamIDTokenGroups)
 		require.ElementsMatch(t, wantDownstreamIDTokenGroups, actualDownstreamIDTokenGroups)
 	} else {
 		require.Emptyf(t, wantDownstreamIDTokenGroups, "test case did not want the groups scope to be granted, "+
 			"but wanted something in the groups claim, which doesn't make sense. please review the test case's expectations.")
-		require.Len(t, actualClaims.Extra, wantDownstreamIDTokenUsernameClaimToExist)
 		actualDownstreamIDTokenGroups := actualClaims.Extra["groups"]
 		require.Nil(t, actualDownstreamIDTokenGroups)
 	}
+	// Make sure that we asserted on every extra claim.
+	require.Len(t, actualClaims.Extra, wantDownstreamIDTokenExtraClaimsCount)
 
 	// Check the rest of the downstream ID token's claims. Fosite wants us to set these (in UTC time).
 	testutil.RequireTimeInDelta(t, time.Now().UTC(), actualClaims.RequestedAt, timeComparisonFudgeFactor)

--- a/internal/testutil/psession.go
+++ b/internal/testutil/psession.go
@@ -24,6 +24,7 @@ func NewFakePinnipedSession() *psession.PinnipedSession {
 			Subject:   "panda",
 		},
 		Custom: &psession.CustomSessionData{
+			Username:     "fake-username",
 			ProviderUID:  "fake-provider-uid",
 			ProviderType: "fake-provider-type",
 			ProviderName: "fake-provider-name",

--- a/internal/upstreamldap/upstreamldap.go
+++ b/internal/upstreamldap/upstreamldap.go
@@ -23,10 +23,10 @@ import (
 	"k8s.io/utils/strings/slices"
 	"k8s.io/utils/trace"
 
+	oidcapi "go.pinniped.dev/generated/latest/apis/supervisor/oidc"
 	"go.pinniped.dev/internal/authenticators"
 	"go.pinniped.dev/internal/crypto/ptls"
 	"go.pinniped.dev/internal/endpointaddr"
-	"go.pinniped.dev/internal/oidc"
 	"go.pinniped.dev/internal/oidc/downstreamsession"
 	"go.pinniped.dev/internal/oidc/provider"
 	"go.pinniped.dev/internal/plog"
@@ -241,7 +241,7 @@ func (p *Provider) PerformRefresh(ctx context.Context, storedRefreshAttributes p
 		return storedRefreshAttributes.Groups, nil
 	}
 	// if we were not granted the groups scope, we should not search for groups or return any.
-	if !slices.Contains(storedRefreshAttributes.GrantedScopes, oidc.DownstreamGroupsScope) {
+	if !slices.Contains(storedRefreshAttributes.GrantedScopes, oidcapi.ScopeGroups) {
 		return nil, nil
 	}
 
@@ -593,7 +593,7 @@ func (p *Provider) searchAndBindUser(conn Conn, username string, grantedScopes [
 	}
 
 	var mappedGroupNames []string
-	if slices.Contains(grantedScopes, oidc.DownstreamGroupsScope) {
+	if slices.Contains(grantedScopes, oidcapi.ScopeGroups) {
 		mappedGroupNames, err = p.searchGroupsForUserDN(conn, userEntry.DN)
 		if err != nil {
 			return nil, err

--- a/pkg/oidcclient/nonce/nonce.go
+++ b/pkg/oidcclient/nonce/nonce.go
@@ -1,7 +1,7 @@
-// Copyright 2020 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package nonce implements
+// Package nonce implements helpers for OIDC nonce parameter handling.
 package nonce
 
 import (
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/coreos/go-oidc/v3/oidc"
+	coreosoidc "github.com/coreos/go-oidc/v3/oidc"
 	"golang.org/x/oauth2"
 )
 
@@ -36,11 +36,11 @@ func (n *Nonce) String() string {
 
 // Param returns the OAuth2 auth code parameter for sending the nonce during the authorization request.
 func (n *Nonce) Param() oauth2.AuthCodeOption {
-	return oidc.Nonce(string(*n))
+	return coreosoidc.Nonce(string(*n))
 }
 
 // Validate the returned ID token). Returns true iff the nonce matches or the returned JWT does not have a nonce.
-func (n *Nonce) Validate(token *oidc.IDToken) error {
+func (n *Nonce) Validate(token *coreosoidc.IDToken) error {
 	if subtle.ConstantTimeCompare([]byte(token.Nonce), []byte(*n)) != 1 {
 		return InvalidNonceError{Expected: *n, Got: Nonce(token.Nonce)}
 	}

--- a/site/content/docs/reference/code-walkthrough.md
+++ b/site/content/docs/reference/code-walkthrough.md
@@ -188,7 +188,7 @@ The Supervisor's endpoints are:
 - And a number of endpoints for each FederationDomain that is configured by the user.
 
 Each FederationDomain's endpoints are mounted under the path of the FederationDomain's `spec.issuer`,
-if the issuer as a path specified in its URL. If the issuer has no path, then they are mounted under `/`.
+if the `spec.issuer` URL has a path component specified. If the issuer has no path, then they are mounted under `/`.
 These per-FederationDomain endpoint are all mounted by the code in
 [internal/oidc/provider/manager/manager.go](https://github.com/vmware-tanzu/pinniped/blob/main/internal/oidc/provider/manager/manager.go).
 
@@ -202,6 +202,10 @@ The per-FederationDomain endpoints are:
   See [internal/oidc/auth/auth_handler.go](https://github.com/vmware-tanzu/pinniped/blob/main/internal/oidc/auth/auth_handler.go).
 - `<issuer_path>/oauth2/token` is the standard OIDC token endpoint.
   See [internal/oidc/token/token_handler.go](https://github.com/vmware-tanzu/pinniped/blob/main/internal/oidc/token/token_handler.go).
+  The token endpoint can handle the standard OIDC `authorization_code` and `refresh_token` grant types, and has also been
+  extended in [internal/oidc/token_exchange.go](https://github.com/vmware-tanzu/pinniped/blob/main/internal/oidc/token_exchange.go)
+  to handle an additional grant type for [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693) token exchanges to
+  reduce the applicable scope (technically, the `aud` claim) of ID tokens.
 - `<issuer_path>/callback` is a special endpoint that is used as the redirect URL when performing an OIDC authcode flow against an upstream OIDC identity provider as configured by an OIDCIdentityProvider custom resource.
   See [internal/oidc/callback/callback_handler.go](https://github.com/vmware-tanzu/pinniped/blob/main/internal/oidc/callback/callback_handler.go).
 - `<issuer_path>/v1alpha1/pinniped_identity_providers` is a custom discovery endpoint for clients to learn about available upstream identity providers.

--- a/test/integration/supervisor_discovery_test.go
+++ b/test/integration/supervisor_discovery_test.go
@@ -502,11 +502,11 @@ func requireWellKnownEndpointIsWorking(t *testing.T, supervisorScheme, superviso
       "token_endpoint": "%s/oauth2/token",
       "token_endpoint_auth_methods_supported": ["client_secret_basic"],
       "jwks_uri": "%s/jwks.json",
-      "scopes_supported": ["openid", "offline"],
+      "scopes_supported": ["openid", "offline_access", "pinniped:request-audience", "username", "groups"],
       "response_types_supported": ["code"],
       "response_modes_supported": ["query", "form_post"],
       "code_challenge_methods_supported": ["S256"],
-      "claims_supported": ["groups"],
+      "claims_supported": ["username", "groups"],
       "discovery.supervisor.pinniped.dev/v1alpha1": {"pinniped_identity_providers_endpoint": "%s/v1alpha1/pinniped_identity_providers"},
       "subject_types_supported": ["public"],
       "id_token_signing_alg_values_supported": ["ES256"]

--- a/test/integration/supervisor_login_test.go
+++ b/test/integration/supervisor_login_test.go
@@ -207,6 +207,9 @@ func TestSupervisorLogin_Browser(t *testing.T) {
 
 		// The scopes to request from the authorization endpoint. Defaults will be used when not specified.
 		downstreamScopes []string
+		// The scopes to want granted from the authorization endpoint. Defaults to the downstreamScopes value when not,
+		// specified, i.e. by default it expects that all requested scopes were granted.
+		wantDownstreamScopes []string
 
 		// When we want the localhost callback to have never happened, then the flow will stop there. The login was
 		// unable to finish so there is nothing to assert about what should have happened with the callback, and there
@@ -218,6 +221,7 @@ func TestSupervisorLogin_Browser(t *testing.T) {
 		// The expected ID token subject claim value as a regexp, for the original ID token and the refreshed ID token.
 		wantDownstreamIDTokenSubjectToMatch string
 		// The expected ID token username claim value as a regexp, for the original ID token and the refreshed ID token.
+		// This function should return an empty string when there should be no username claim in the ID tokens.
 		wantDownstreamIDTokenUsernameToMatch func(username string) string
 		// The expected ID token groups claim value, for the original ID token and the refreshed ID token.
 		wantDownstreamIDTokenGroups []string
@@ -240,7 +244,8 @@ func TestSupervisorLogin_Browser(t *testing.T) {
 		wantTokenExchangeResponse func(t *testing.T, status int, body string)
 
 		// Optionally edit the refresh session data between the initial login and the first refresh,
-		// which is still expected to succeed after these edits.
+		// which is still expected to succeed after these edits. Returns the group memberships expected after the
+		// refresh is performed.
 		editRefreshSessionDataWithoutBreaking func(t *testing.T, sessionData *psession.PinnipedSession, idpName, username string) []string
 		// Optionally either revoke the user's session on the upstream provider, or manipulate the user's session
 		// data in such a way that it should cause the next upstream refresh attempt to fail.
@@ -278,8 +283,8 @@ func TestSupervisorLogin_Browser(t *testing.T) {
 			},
 			requestAuthorization: requestAuthorizationUsingBrowserAuthcodeFlowOIDC,
 			breakRefreshSessionData: func(t *testing.T, pinnipedSession *psession.PinnipedSession, _, _ string) {
-				fositeSessionData := pinnipedSession.Fosite
-				fositeSessionData.Claims.Extra["username"] = "some-incorrect-username"
+				customSessionData := pinnipedSession.Custom
+				customSessionData.Username = "some-incorrect-username"
 			},
 			wantDownstreamIDTokenSubjectToMatch:  "^" + regexp.QuoteMeta(env.SupervisorUpstreamOIDC.Issuer+"?sub=") + ".+",
 			wantDownstreamIDTokenUsernameToMatch: func(_ string) string { return "^" + regexp.QuoteMeta(env.SupervisorUpstreamOIDC.Username) + "$" },
@@ -321,8 +326,8 @@ func TestSupervisorLogin_Browser(t *testing.T) {
 			},
 			requestAuthorization: requestAuthorizationUsingBrowserAuthcodeFlowOIDC,
 			breakRefreshSessionData: func(t *testing.T, pinnipedSession *psession.PinnipedSession, _, _ string) {
-				fositeSessionData := pinnipedSession.Fosite
-				fositeSessionData.Claims.Extra["username"] = "some-incorrect-username"
+				customSessionData := pinnipedSession.Custom
+				customSessionData.Username = "some-incorrect-username"
 			},
 			wantDownstreamIDTokenSubjectToMatch:  "^" + regexp.QuoteMeta(env.SupervisorUpstreamOIDC.Issuer+"?sub=") + ".+",
 			wantDownstreamIDTokenUsernameToMatch: func(_ string) string { return "^" + regexp.QuoteMeta(env.SupervisorUpstreamOIDC.Username) + "$" },
@@ -400,13 +405,14 @@ func TestSupervisorLogin_Browser(t *testing.T) {
 			wantDownstreamIDTokenGroups: env.SupervisorUpstreamLDAP.TestUserDirectGroupsDNs,
 		},
 		{
-			name:      "ldap without requesting groups scope",
+			name:      "ldap without requesting username and groups scope gets them anyway for pinniped-cli for backwards compatibility with old CLIs",
 			maybeSkip: skipLDAPTests,
 			createIDP: func(t *testing.T) string {
 				idp, _ := createLDAPIdentityProvider(t, nil)
 				return idp.Name
 			},
-			downstreamScopes: []string{"openid", "pinniped:request-audience", "offline_access"},
+			downstreamScopes:     []string{"openid", "pinniped:request-audience", "offline_access"},
+			wantDownstreamScopes: []string{"openid", "pinniped:request-audience", "offline_access", "username", "groups"},
 			requestAuthorization: func(t *testing.T, _, downstreamAuthorizeURL, _, _, _ string, httpClient *http.Client) {
 				requestAuthorizationUsingCLIPasswordFlow(t,
 					downstreamAuthorizeURL,
@@ -426,10 +432,10 @@ func TestSupervisorLogin_Browser(t *testing.T) {
 			wantDownstreamIDTokenUsernameToMatch: func(_ string) string {
 				return "^" + regexp.QuoteMeta(env.SupervisorUpstreamLDAP.TestUserMailAttributeValue) + "$"
 			},
-			wantDownstreamIDTokenGroups: []string{},
+			wantDownstreamIDTokenGroups: env.SupervisorUpstreamLDAP.TestUserDirectGroupsDNs,
 		},
 		{
-			name:      "oidc without requesting groups scope",
+			name:      "oidc without requesting username and groups scope gets them anyway for pinniped-cli for backwards compatibility with old CLIs",
 			maybeSkip: skipNever,
 			createIDP: func(t *testing.T) string {
 				spec := basicOIDCIdentityProviderSpec()
@@ -443,10 +449,11 @@ func TestSupervisorLogin_Browser(t *testing.T) {
 				return testlib.CreateTestOIDCIdentityProvider(t, spec, idpv1alpha1.PhaseReady).Name
 			},
 			downstreamScopes:                     []string{"openid", "pinniped:request-audience", "offline_access"},
+			wantDownstreamScopes:                 []string{"openid", "pinniped:request-audience", "offline_access", "username", "groups"},
 			requestAuthorization:                 requestAuthorizationUsingBrowserAuthcodeFlowOIDC,
 			wantDownstreamIDTokenSubjectToMatch:  "^" + regexp.QuoteMeta(env.SupervisorUpstreamOIDC.Issuer+"?sub=") + ".+",
 			wantDownstreamIDTokenUsernameToMatch: func(_ string) string { return "^" + regexp.QuoteMeta(env.SupervisorUpstreamOIDC.Username) + "$" },
-			wantDownstreamIDTokenGroups:          nil,
+			wantDownstreamIDTokenGroups:          env.SupervisorUpstreamOIDC.ExpectedGroups,
 		},
 		{
 			name:      "ldap with browser flow",
@@ -649,8 +656,7 @@ func TestSupervisorLogin_Browser(t *testing.T) {
 				customSessionData := pinnipedSession.Custom
 				require.Equal(t, psession.ProviderTypeLDAP, customSessionData.ProviderType)
 				require.NotEmpty(t, customSessionData.LDAP.UserDN)
-				fositeSessionData := pinnipedSession.Fosite
-				fositeSessionData.Claims.Extra["username"] = "not-the-same"
+				customSessionData.Username = "not-the-same"
 			},
 			// the ID token Subject should be the Host URL plus the value pulled from the requested UserSearch.Attributes.UID attribute
 			wantDownstreamIDTokenSubjectToMatch: "^" + regexp.QuoteMeta(
@@ -829,8 +835,7 @@ func TestSupervisorLogin_Browser(t *testing.T) {
 				customSessionData := pinnipedSession.Custom
 				require.Equal(t, psession.ProviderTypeActiveDirectory, customSessionData.ProviderType)
 				require.NotEmpty(t, customSessionData.ActiveDirectory.UserDN)
-				fositeSessionData := pinnipedSession.Fosite
-				fositeSessionData.Claims.Extra["username"] = "not-the-same"
+				customSessionData.Username = "not-the-same"
 			},
 			// the ID token Subject should be the Host URL plus the value pulled from the requested UserSearch.Attributes.UID attribute
 			wantDownstreamIDTokenSubjectToMatch: "^" + regexp.QuoteMeta(
@@ -1284,7 +1289,7 @@ func TestSupervisorLogin_Browser(t *testing.T) {
 			},
 		},
 		{
-			name:      "oidc upstream with downstream dynamic client happy path",
+			name:      "oidc upstream with downstream dynamic client happy path, requesting all scopes",
 			maybeSkip: skipNever,
 			createIDP: func(t *testing.T) string {
 				return testlib.CreateTestOIDCIdentityProvider(t, basicOIDCIdentityProviderSpec(), idpv1alpha1.PhaseReady).Name
@@ -1301,9 +1306,10 @@ func TestSupervisorLogin_Browser(t *testing.T) {
 			wantDownstreamIDTokenSubjectToMatch: "^" + regexp.QuoteMeta(env.SupervisorUpstreamOIDC.Issuer+"?sub=") + ".+",
 			// the ID token Username should include the upstream user ID after the upstream issuer name
 			wantDownstreamIDTokenUsernameToMatch: func(_ string) string { return "^" + regexp.QuoteMeta(env.SupervisorUpstreamOIDC.Issuer+"?sub=") + ".+" },
+			wantDownstreamIDTokenGroups:          env.SupervisorUpstreamOIDC.ExpectedGroups,
 		},
 		{
-			name:      "ldap upstream with downstream dynamic client happy path",
+			name:      "ldap upstream with downstream dynamic client happy path, requesting all scopes",
 			maybeSkip: skipLDAPTests,
 			createIDP: func(t *testing.T) string {
 				idp, _ := createLDAPIdentityProvider(t, nil)
@@ -1333,6 +1339,237 @@ func TestSupervisorLogin_Browser(t *testing.T) {
 				return "^" + regexp.QuoteMeta(env.SupervisorUpstreamLDAP.TestUserMailAttributeValue) + "$"
 			},
 			wantDownstreamIDTokenGroups: env.SupervisorUpstreamLDAP.TestUserDirectGroupsDNs,
+		},
+		{
+			name:      "ldap upstream with downstream dynamic client when dynamic client is not allowed to use the token exchange grant type, causes token exchange error",
+			maybeSkip: skipLDAPTests,
+			createIDP: func(t *testing.T) string {
+				idp, _ := createLDAPIdentityProvider(t, nil)
+				return idp.Name
+			},
+			createOIDCClient: func(t *testing.T, callbackURL string) (string, string) {
+				return testlib.CreateOIDCClient(t, configv1alpha1.OIDCClientSpec{
+					AllowedRedirectURIs: []configv1alpha1.RedirectURI{configv1alpha1.RedirectURI(callbackURL)},
+					AllowedGrantTypes:   []configv1alpha1.GrantType{"authorization_code", "refresh_token"},        // token exchange grant type not allowed
+					AllowedScopes:       []configv1alpha1.Scope{"openid", "offline_access", "username", "groups"}, // a validation requires that we also disallow the pinniped:request-audience scope
+				}, configv1alpha1.PhaseReady)
+			},
+			testUser: func(t *testing.T) (string, string) {
+				// return the username and password of the existing user that we want to use for this test
+				return env.SupervisorUpstreamLDAP.TestUserMailAttributeValue, // username to present to server during login
+					env.SupervisorUpstreamLDAP.TestUserPassword // password to present to server during login
+			},
+			downstreamScopes:     []string{"openid", "offline_access", "username", "groups"}, // does not request (or expect) pinniped:request-audience token exchange scope
+			requestAuthorization: requestAuthorizationUsingBrowserAuthcodeFlowLDAP,
+			// the ID token Username should have been pulled from the requested UserSearch.Attributes.Username attribute
+			wantDownstreamIDTokenUsernameToMatch: func(_ string) string {
+				return "^" + regexp.QuoteMeta(env.SupervisorUpstreamLDAP.TestUserMailAttributeValue) + "$"
+			},
+			wantDownstreamIDTokenGroups: env.SupervisorUpstreamLDAP.TestUserDirectGroupsDNs,
+			wantTokenExchangeResponse: func(t *testing.T, status int, body string) { // can't do token exchanges without the token exchange grant type
+				require.Equal(t, http.StatusBadRequest, status)
+				require.Equal(t,
+					`{"error":"unauthorized_client","error_description":"The client is not authorized to request a token using this method. `+
+						`The OAuth 2.0 Client is not allowed to use token exchange grant 'urn:ietf:params:oauth:grant-type:token-exchange'."}`,
+					body)
+			},
+		},
+		{
+			name:      "ldap upstream with downstream dynamic client when dynamic client that does not request the pinniped:request-audience scope, causes token exchange error",
+			maybeSkip: skipLDAPTests,
+			createIDP: func(t *testing.T) string {
+				idp, _ := createLDAPIdentityProvider(t, nil)
+				return idp.Name
+			},
+			createOIDCClient: func(t *testing.T, callbackURL string) (string, string) {
+				return testlib.CreateOIDCClient(t, configv1alpha1.OIDCClientSpec{
+					AllowedRedirectURIs: []configv1alpha1.RedirectURI{configv1alpha1.RedirectURI(callbackURL)},
+					AllowedGrantTypes:   []configv1alpha1.GrantType{"authorization_code", "urn:ietf:params:oauth:grant-type:token-exchange", "refresh_token"},
+					AllowedScopes:       []configv1alpha1.Scope{"openid", "offline_access", "pinniped:request-audience", "username", "groups"},
+				}, configv1alpha1.PhaseReady)
+			},
+			testUser: func(t *testing.T) (string, string) {
+				// return the username and password of the existing user that we want to use for this test
+				return env.SupervisorUpstreamLDAP.TestUserMailAttributeValue, // username to present to server during login
+					env.SupervisorUpstreamLDAP.TestUserPassword // password to present to server during login
+			},
+			downstreamScopes:     []string{"openid", "offline_access", "username", "groups"}, // does not request (or expect) pinniped:request-audience token exchange scope
+			requestAuthorization: requestAuthorizationUsingBrowserAuthcodeFlowLDAP,
+			// the ID token Username should have been pulled from the requested UserSearch.Attributes.Username attribute
+			wantDownstreamIDTokenUsernameToMatch: func(_ string) string {
+				return "^" + regexp.QuoteMeta(env.SupervisorUpstreamLDAP.TestUserMailAttributeValue) + "$"
+			},
+			wantDownstreamIDTokenGroups: env.SupervisorUpstreamLDAP.TestUserDirectGroupsDNs,
+			wantTokenExchangeResponse: func(t *testing.T, status int, body string) { // can't do token exchanges without the pinniped:request-audience token exchange scope
+				require.Equal(t, http.StatusForbidden, status)
+				require.Equal(t,
+					`{"error":"access_denied","error_description":"The resource owner or authorization server denied the request. `+
+						`missing the 'pinniped:request-audience' scope"}`,
+					body)
+			},
+		},
+		{
+			name:      "ldap upstream with downstream dynamic client when dynamic client is not allowed to request username but requests username anyway, causes authorization error",
+			maybeSkip: skipLDAPTests,
+			createIDP: func(t *testing.T) string {
+				idp, _ := createLDAPIdentityProvider(t, nil)
+				return idp.Name
+			},
+			createOIDCClient: func(t *testing.T, callbackURL string) (string, string) {
+				return testlib.CreateOIDCClient(t, configv1alpha1.OIDCClientSpec{
+					AllowedRedirectURIs: []configv1alpha1.RedirectURI{configv1alpha1.RedirectURI(callbackURL)},
+					AllowedGrantTypes:   []configv1alpha1.GrantType{"authorization_code", "refresh_token"}, // token exchange not allowed (required to exclude groups scope)
+					AllowedScopes:       []configv1alpha1.Scope{"openid", "offline_access", "groups"},      // username not allowed
+				}, configv1alpha1.PhaseReady)
+			},
+			testUser: func(t *testing.T) (string, string) {
+				// return the username and password of the existing user that we want to use for this test
+				return env.SupervisorUpstreamLDAP.TestUserMailAttributeValue, // username to present to server during login
+					env.SupervisorUpstreamLDAP.TestUserPassword // password to present to server during login
+			},
+			downstreamScopes: []string{"openid", "offline_access", "username"}, // request username, even though the client is not allowed to request it
+			// Should have been immediately redirected back to the local callback server with an error in this case,
+			// since we requested a scope that the client is not allowed to request. The login UI page is never shown.
+			requestAuthorization:              requestAuthorizationAndExpectImmediateRedirectToCallback,
+			wantAuthorizationErrorDescription: "The requested scope is invalid, unknown, or malformed. The OAuth 2.0 Client is not allowed to request scope 'username'.",
+			wantAuthorizationErrorType:        "invalid_scope",
+		},
+		{
+			name:      "ldap upstream with downstream dynamic client when dynamic client is not allowed to request groups but requests groups anyway, causes authorization error",
+			maybeSkip: skipLDAPTests,
+			createIDP: func(t *testing.T) string {
+				idp, _ := createLDAPIdentityProvider(t, nil)
+				return idp.Name
+			},
+			createOIDCClient: func(t *testing.T, callbackURL string) (string, string) {
+				return testlib.CreateOIDCClient(t, configv1alpha1.OIDCClientSpec{
+					AllowedRedirectURIs: []configv1alpha1.RedirectURI{configv1alpha1.RedirectURI(callbackURL)},
+					AllowedGrantTypes:   []configv1alpha1.GrantType{"authorization_code", "refresh_token"}, // token exchange not allowed (required to exclude groups scope)
+					AllowedScopes:       []configv1alpha1.Scope{"openid", "offline_access", "username"},    // groups not allowed
+				}, configv1alpha1.PhaseReady)
+			},
+			testUser: func(t *testing.T) (string, string) {
+				// return the username and password of the existing user that we want to use for this test
+				return env.SupervisorUpstreamLDAP.TestUserMailAttributeValue, // username to present to server during login
+					env.SupervisorUpstreamLDAP.TestUserPassword // password to present to server during login
+			},
+			downstreamScopes: []string{"openid", "offline_access", "groups"}, // request groups, even though the client is not allowed to request it
+			// Should have been immediately redirected back to the local callback server with an error in this case,
+			// since we requested a scope that the client is not allowed to request. The login UI page is never shown.
+			requestAuthorization:              requestAuthorizationAndExpectImmediateRedirectToCallback,
+			wantAuthorizationErrorDescription: "The requested scope is invalid, unknown, or malformed. The OAuth 2.0 Client is not allowed to request scope 'groups'.",
+			wantAuthorizationErrorType:        "invalid_scope",
+		},
+		{
+			name:      "ldap upstream with downstream dynamic client when dynamic client does not request groups happy path",
+			maybeSkip: skipLDAPTests,
+			createIDP: func(t *testing.T) string {
+				idp, _ := createLDAPIdentityProvider(t, nil)
+				return idp.Name
+			},
+			createOIDCClient: func(t *testing.T, callbackURL string) (string, string) {
+				return testlib.CreateOIDCClient(t, configv1alpha1.OIDCClientSpec{
+					AllowedRedirectURIs: []configv1alpha1.RedirectURI{configv1alpha1.RedirectURI(callbackURL)},
+					AllowedGrantTypes:   []configv1alpha1.GrantType{"authorization_code", "urn:ietf:params:oauth:grant-type:token-exchange", "refresh_token"},
+					AllowedScopes:       []configv1alpha1.Scope{"openid", "offline_access", "pinniped:request-audience", "username", "groups"},
+				}, configv1alpha1.PhaseReady)
+			},
+			testUser: func(t *testing.T) (string, string) {
+				// return the username and password of the existing user that we want to use for this test
+				return env.SupervisorUpstreamLDAP.TestUserMailAttributeValue, // username to present to server during login
+					env.SupervisorUpstreamLDAP.TestUserPassword // password to present to server during login
+			},
+			downstreamScopes:     []string{"openid", "pinniped:request-audience", "offline_access", "username"}, // do not request (or expect) groups
+			requestAuthorization: requestAuthorizationUsingBrowserAuthcodeFlowLDAP,
+			// the ID token Subject should be the Host URL plus the value pulled from the requested UserSearch.Attributes.UID attribute
+			wantDownstreamIDTokenSubjectToMatch: "^" + regexp.QuoteMeta(
+				"ldaps://"+env.SupervisorUpstreamLDAP.Host+
+					"?base="+url.QueryEscape(env.SupervisorUpstreamLDAP.UserSearchBase)+
+					"&sub="+base64.RawURLEncoding.EncodeToString([]byte(env.SupervisorUpstreamLDAP.TestUserUniqueIDAttributeValue)),
+			) + "$",
+			// the ID token Username should have been pulled from the requested UserSearch.Attributes.Username attribute
+			wantDownstreamIDTokenUsernameToMatch: func(_ string) string {
+				return "^" + regexp.QuoteMeta(env.SupervisorUpstreamLDAP.TestUserMailAttributeValue) + "$"
+			},
+			wantDownstreamIDTokenGroups: nil, // did not request groups, so should not have got any groups
+		},
+		{
+			name:      "ldap upstream with downstream dynamic client when dynamic client does not request username, is allowed to auth but cannot do token exchange",
+			maybeSkip: skipLDAPTests,
+			createIDP: func(t *testing.T) string {
+				idp, _ := createLDAPIdentityProvider(t, nil)
+				return idp.Name
+			},
+			createOIDCClient: func(t *testing.T, callbackURL string) (string, string) {
+				return testlib.CreateOIDCClient(t, configv1alpha1.OIDCClientSpec{
+					AllowedRedirectURIs: []configv1alpha1.RedirectURI{configv1alpha1.RedirectURI(callbackURL)},
+					AllowedGrantTypes:   []configv1alpha1.GrantType{"authorization_code", "urn:ietf:params:oauth:grant-type:token-exchange", "refresh_token"},
+					AllowedScopes:       []configv1alpha1.Scope{"openid", "offline_access", "pinniped:request-audience", "username", "groups"},
+				}, configv1alpha1.PhaseReady)
+			},
+			testUser: func(t *testing.T) (string, string) {
+				// return the username and password of the existing user that we want to use for this test
+				return env.SupervisorUpstreamLDAP.TestUserMailAttributeValue, // username to present to server during login
+					env.SupervisorUpstreamLDAP.TestUserPassword // password to present to server during login
+			},
+			downstreamScopes:     []string{"openid", "pinniped:request-audience", "offline_access", "groups"}, // do not request (or expect) username
+			requestAuthorization: requestAuthorizationUsingBrowserAuthcodeFlowLDAP,
+			// the ID token Subject should be the Host URL plus the value pulled from the requested UserSearch.Attributes.UID attribute
+			wantDownstreamIDTokenSubjectToMatch: "^" + regexp.QuoteMeta(
+				"ldaps://"+env.SupervisorUpstreamLDAP.Host+
+					"?base="+url.QueryEscape(env.SupervisorUpstreamLDAP.UserSearchBase)+
+					"&sub="+base64.RawURLEncoding.EncodeToString([]byte(env.SupervisorUpstreamLDAP.TestUserUniqueIDAttributeValue)),
+			) + "$",
+			wantDownstreamIDTokenUsernameToMatch: func(_ string) string {
+				return "" // username should not exist as a claim since we did not request it
+			},
+			wantDownstreamIDTokenGroups: env.SupervisorUpstreamLDAP.TestUserDirectGroupsDNs,
+			wantTokenExchangeResponse: func(t *testing.T, status int, body string) { // can't do token exchanges without a username
+				require.Equal(t, http.StatusForbidden, status)
+				require.Equal(t,
+					`{"error":"access_denied","error_description":"The resource owner or authorization server denied the request. `+
+						`No username found in session. Ensure that the 'username' scope was requested and granted at the authorization endpoint."}`,
+					body)
+			},
+		},
+		{
+			name:      "ldap upstream with downstream dynamic client when dynamic client is not allowed to request username or groups and does not request them, is allowed to auth but cannot do token exchange",
+			maybeSkip: skipLDAPTests,
+			createIDP: func(t *testing.T) string {
+				idp, _ := createLDAPIdentityProvider(t, nil)
+				return idp.Name
+			},
+			createOIDCClient: func(t *testing.T, callbackURL string) (string, string) {
+				return testlib.CreateOIDCClient(t, configv1alpha1.OIDCClientSpec{
+					AllowedRedirectURIs: []configv1alpha1.RedirectURI{configv1alpha1.RedirectURI(callbackURL)},
+					AllowedGrantTypes:   []configv1alpha1.GrantType{"authorization_code", "refresh_token"},
+					AllowedScopes:       []configv1alpha1.Scope{"openid", "offline_access"}, // validations require that when username/groups are excluded, then token exchange must also not be allowed
+				}, configv1alpha1.PhaseReady)
+			},
+			testUser: func(t *testing.T) (string, string) {
+				// return the username and password of the existing user that we want to use for this test
+				return env.SupervisorUpstreamLDAP.TestUserMailAttributeValue, // username to present to server during login
+					env.SupervisorUpstreamLDAP.TestUserPassword // password to present to server during login
+			},
+			downstreamScopes:     []string{"openid", "offline_access"}, // do not request (or expect) pinniped:request-audience or username or groups
+			requestAuthorization: requestAuthorizationUsingBrowserAuthcodeFlowLDAP,
+			// the ID token Subject should be the Host URL plus the value pulled from the requested UserSearch.Attributes.UID attribute
+			wantDownstreamIDTokenSubjectToMatch: "^" + regexp.QuoteMeta(
+				"ldaps://"+env.SupervisorUpstreamLDAP.Host+
+					"?base="+url.QueryEscape(env.SupervisorUpstreamLDAP.UserSearchBase)+
+					"&sub="+base64.RawURLEncoding.EncodeToString([]byte(env.SupervisorUpstreamLDAP.TestUserUniqueIDAttributeValue)),
+			) + "$",
+			wantDownstreamIDTokenUsernameToMatch: func(_ string) string {
+				return "" // username should not exist as a claim since we did not request it
+			},
+			wantDownstreamIDTokenGroups: nil, // did not request groups, so should not have got any groups
+			wantTokenExchangeResponse: func(t *testing.T, status int, body string) { // can't do token exchanges without the token exchange grant type
+				require.Equal(t, http.StatusBadRequest, status)
+				require.Equal(t,
+					`{"error":"unauthorized_client","error_description":"The client is not authorized to request a token using this method. `+
+						`The OAuth 2.0 Client is not allowed to use token exchange grant 'urn:ietf:params:oauth:grant-type:token-exchange'."}`,
+					body)
+			},
 		},
 		{
 			name:      "active directory with all default options with downstream dynamic client happy path",
@@ -1411,6 +1648,7 @@ func TestSupervisorLogin_Browser(t *testing.T) {
 				tt.createOIDCClient,
 				tt.downstreamScopes,
 				tt.requestTokenExchangeAud,
+				tt.wantDownstreamScopes,
 				tt.wantLocalhostCallbackToNeverHappen,
 				tt.wantDownstreamIDTokenSubjectToMatch,
 				tt.wantDownstreamIDTokenUsernameToMatch,
@@ -1552,6 +1790,7 @@ func testSupervisorLogin(
 	createOIDCClient func(t *testing.T, callbackURL string) (string, string),
 	downstreamScopes []string,
 	requestTokenExchangeAud string,
+	wantDownstreamScopes []string,
 	wantLocalhostCallbackToNeverHappen bool,
 	wantDownstreamIDTokenSubjectToMatch string,
 	wantDownstreamIDTokenUsernameToMatch func(username string) string,
@@ -1672,7 +1911,13 @@ func testSupervisorLogin(
 	}, 30*time.Second, 200*time.Millisecond)
 
 	if downstreamScopes == nil {
-		downstreamScopes = []string{"openid", "pinniped:request-audience", "offline_access", "groups"}
+		// By default, tests will request all the relevant groups.
+		downstreamScopes = []string{"openid", "pinniped:request-audience", "offline_access", "username", "groups"}
+	}
+	if wantDownstreamScopes == nil {
+		// By default, tests will want that all requested scopes were granted.
+		wantDownstreamScopes = make([]string, len(downstreamScopes))
+		copy(wantDownstreamScopes, downstreamScopes)
 	}
 
 	// Create the OAuth2 configuration.
@@ -1728,14 +1973,14 @@ func testSupervisorLogin(
 	if wantAuthorizationErrorType != "" {
 		errorDescription := callback.URL.Query().Get("error_description")
 		errorType := callback.URL.Query().Get("error")
-		require.Equal(t, errorDescription, wantAuthorizationErrorDescription)
-		require.Equal(t, errorType, wantAuthorizationErrorType)
+		require.Equal(t, wantAuthorizationErrorDescription, errorDescription)
+		require.Equal(t, wantAuthorizationErrorType, errorType)
 		// The authorization has failed, so can't continue the login flow, making this the end of the test case.
 		return
 	}
 
 	require.Equal(t, stateParam.String(), callback.URL.Query().Get("state"))
-	require.ElementsMatch(t, downstreamScopes, strings.Split(callback.URL.Query().Get("scope"), " "))
+	require.ElementsMatch(t, wantDownstreamScopes, strings.Split(callback.URL.Query().Get("scope"), " "))
 	authcode := callback.URL.Query().Get("code")
 	require.NotEmpty(t, authcode)
 
@@ -1750,8 +1995,14 @@ func testSupervisorLogin(
 		return
 	}
 	require.NoError(t, err)
-	expectedIDTokenClaims := []string{"iss", "exp", "sub", "aud", "auth_time", "iat", "jti", "nonce", "rat", "username"}
-	if slices.Contains(downstreamScopes, "groups") {
+
+	expectedIDTokenClaims := []string{"iss", "exp", "sub", "aud", "auth_time", "iat", "jti", "nonce", "rat"}
+	if slices.Contains(wantDownstreamScopes, "username") {
+		// If the test wants the username scope to have been granted, then also expect the claim in the ID token.
+		expectedIDTokenClaims = append(expectedIDTokenClaims, "username")
+	}
+	if slices.Contains(wantDownstreamScopes, "groups") {
+		// If the test wants the groups scope to have been granted, then also expect the claim in the ID token.
 		expectedIDTokenClaims = append(expectedIDTokenClaims, "groups")
 	}
 	verifyTokenResponse(t,
@@ -1764,7 +2015,7 @@ func testSupervisorLogin(
 	}
 	doTokenExchange(t, requestTokenExchangeAud, &downstreamOAuth2Config, tokenResponse, httpClient, discovery, wantTokenExchangeResponse)
 
-	refreshedGroups := wantDownstreamIDTokenGroups
+	wantRefreshedGroups := wantDownstreamIDTokenGroups
 	if editRefreshSessionDataWithoutBreaking != nil {
 		latestRefreshToken := tokenResponse.RefreshToken
 		signatureOfLatestRefreshToken := getFositeDataSignature(t, latestRefreshToken)
@@ -1780,7 +2031,7 @@ func testSupervisorLogin(
 		pinnipedSession, ok := storedRefreshSession.GetSession().(*psession.PinnipedSession)
 		require.True(t, ok, "should have been able to cast session data to PinnipedSession")
 
-		refreshedGroups = editRefreshSessionDataWithoutBreaking(t, pinnipedSession, idpName, username)
+		wantRefreshedGroups = editRefreshSessionDataWithoutBreaking(t, pinnipedSession, idpName, username)
 
 		// Then save the mutated Secret back to Kubernetes.
 		// There is no update function, so delete and create again at the same name.
@@ -1793,13 +2044,18 @@ func testSupervisorLogin(
 	require.NoError(t, err)
 
 	// When refreshing, expect to get an "at_hash" claim, but no "nonce" claim.
-	expectRefreshedIDTokenClaims := []string{"iss", "exp", "sub", "aud", "auth_time", "iat", "jti", "rat", "username", "at_hash"}
-	if slices.Contains(downstreamScopes, "groups") {
+	expectRefreshedIDTokenClaims := []string{"iss", "exp", "sub", "aud", "auth_time", "iat", "jti", "rat", "at_hash"}
+	if slices.Contains(wantDownstreamScopes, "username") {
+		// If the test wants the username scope to have been granted, then also expect the claim in the refreshed ID token.
+		expectRefreshedIDTokenClaims = append(expectRefreshedIDTokenClaims, "username")
+	}
+	if slices.Contains(wantDownstreamScopes, "groups") {
+		// If the test wants the groups scope to have been granted, then also expect the claim in the refreshed ID token.
 		expectRefreshedIDTokenClaims = append(expectRefreshedIDTokenClaims, "groups")
 	}
 	verifyTokenResponse(t,
 		refreshedTokenResponse, discovery, downstreamOAuth2Config, "",
-		expectRefreshedIDTokenClaims, wantDownstreamIDTokenSubjectToMatch, wantDownstreamIDTokenUsernameToMatch(username), refreshedGroups)
+		expectRefreshedIDTokenClaims, wantDownstreamIDTokenSubjectToMatch, wantDownstreamIDTokenUsernameToMatch(username), wantRefreshedGroups)
 
 	require.NotEqual(t, tokenResponse.AccessToken, refreshedTokenResponse.AccessToken)
 	require.NotEqual(t, tokenResponse.RefreshToken, refreshedTokenResponse.RefreshToken)
@@ -1892,8 +2148,11 @@ func verifyTokenResponse(
 	}
 	require.ElementsMatch(t, expectedIDTokenClaims, idTokenClaimNames)
 
-	// Check username claim of the ID token.
-	require.Regexp(t, wantDownstreamIDTokenUsernameToMatch, idTokenClaims["username"].(string))
+	// Check username claim of the ID token, if one is expected. Asserting on the lack of a username claim is
+	// handled above where the full list of claims are asserted.
+	if wantDownstreamIDTokenUsernameToMatch != "" {
+		require.Regexp(t, wantDownstreamIDTokenUsernameToMatch, idTokenClaims["username"].(string))
+	}
 
 	// Check the groups claim.
 	require.ElementsMatch(t, wantDownstreamIDTokenGroups, idTokenClaims["groups"])
@@ -1910,6 +2169,21 @@ func verifyTokenResponse(
 	require.NotEmpty(t, tokenResponse.RefreshToken)
 	// Refresh tokens should start with the custom prefix "pin_rt_" to make them identifiable as refresh tokens when seen by a user out of context.
 	require.True(t, strings.HasPrefix(tokenResponse.RefreshToken, "pin_rt_"), "token %q did not have expected prefix 'pin_rt_'", tokenResponse.RefreshToken)
+}
+
+func requestAuthorizationAndExpectImmediateRedirectToCallback(t *testing.T, _, downstreamAuthorizeURL, downstreamCallbackURL, _, _ string, _ *http.Client) {
+	t.Helper()
+
+	// Open the web browser and navigate to the downstream authorize URL.
+	page := browsertest.Open(t)
+	t.Logf("opening browser to downstream authorize URL %s", testlib.MaskTokens(downstreamAuthorizeURL))
+	require.NoError(t, page.Navigate(downstreamAuthorizeURL))
+
+	// Expect that it immediately redirects back to the callback, which is what happens for certain types of errors
+	// where it is not worth redirecting to the login UI page.
+	t.Logf("waiting for redirect to callback")
+	callbackURLPattern := regexp.MustCompile(`\A` + regexp.QuoteMeta(downstreamCallbackURL) + `\?.+\z`)
+	browsertest.WaitForURL(t, page, callbackURLPattern)
 }
 
 func requestAuthorizationUsingBrowserAuthcodeFlowOIDC(t *testing.T, _, downstreamAuthorizeURL, downstreamCallbackURL, _, _ string, httpClient *http.Client) {

--- a/test/integration/supervisor_warnings_test.go
+++ b/test/integration/supervisor_warnings_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	coreosoidc "github.com/coreos/go-oidc/v3/oidc"
 	"github.com/creack/pty"
 	"github.com/stretchr/testify/require"
 	authorizationv1 "k8s.io/api/authorization/v1"
@@ -173,7 +172,7 @@ func TestSupervisorWarnings_Browser(t *testing.T) {
 		}))
 
 		// construct the cache key
-		downstreamScopes := []string{coreosoidc.ScopeOfflineAccess, coreosoidc.ScopeOpenID, "pinniped:request-audience", "groups"}
+		downstreamScopes := []string{"offline_access", "openid", "pinniped:request-audience", "groups"}
 		sort.Strings(downstreamScopes)
 		sessionCacheKey := oidcclient.SessionCacheKey{
 			Issuer:      downstream.Spec.Issuer,
@@ -481,7 +480,7 @@ func TestSupervisorWarnings_Browser(t *testing.T) {
 		}))
 
 		// construct the cache key
-		downstreamScopes := []string{coreosoidc.ScopeOfflineAccess, coreosoidc.ScopeOpenID, "pinniped:request-audience", "groups"}
+		downstreamScopes := []string{"offline_access", "openid", "pinniped:request-audience", "groups"}
 		sort.Strings(downstreamScopes)
 		sessionCacheKey := oidcclient.SessionCacheKey{
 			Issuer:      downstream.Spec.Issuer,


### PR DESCRIPTION
- Create a new username scope, required for clients to get username in ID token
- For backwards compatibility with older Pinniped CLIs, the pinniped-cli
  client does not need to request the username or groups scopes for them
  to be granted. For dynamic clients, the usual OAuth2 rules apply:
  the client must be allowed to request the scopes according to its
  configuration, and the client must actually request the scopes in the
  authorization request.
- If the username scope was not granted, then there will be no username
  in the ID token, and the cluster-scoped token exchange will fail since
  there would be no username in the resulting cluster-scoped ID token.
- The OIDC well-known discovery endpoint lists the username and groups
  scopes in the scopes_supported list, and lists the username and groups
  claims in the claims_supported list.
- Add username and groups scopes to the default list of scopes
  put into kubeconfig files by "pinniped get kubeconfig" CLI command,
  and the default list of scopes used by "pinniped login oidc" when
  no list of scopes is specified in the kubeconfig file
- The warning header about group memberships changing during upstream
  refresh will only be sent to the pinniped-cli client, since it is
  only intended for kubectl and it could leak the username to the
  client (which may not have the username scope granted) through the
  warning message text.
- Add the user's username to the session storage as a new field, so that
  during upstream refresh we can compare the original username from the
  initial authorization to the refreshed username, even in the case when
  the username scope was not granted (and therefore the username is not
  stored in the ID token claims of the session storage)
- Bump the Supervisor session storage format version from 2 to 3
  due to the username field being added to the session struct
- Extract commonly used string constants related to OIDC flows to api
  package.
- Change some import names to make them consistent:
  - Always import github.com/coreos/go-oidc/v3/oidc as "coreosoidc"
  - Always import go.pinniped.dev/generated/latest/apis/supervisor/oidc
    as "oidcapi"
  - Always import go.pinniped.dev/internal/oidc as "oidc"
- `pinniped get kubeconfig` errors when the token exchange request
   audience value includes the reserved substring `.pinniped.dev` to give
   faster feedback in this corner case, since the token exchange endpoint
   would reject that request anyways
- Always add the `azp` claim to ID tokens to show the original client ID

**Release note**:

```release-note
TODO
```
