### PR TITLE
Update example configuration for Active Directory

### DIFF
--- a/site/content/docs/howto/configure-supervisor-with-activedirectory.md
+++ b/site/content/docs/howto/configure-supervisor-with-activedirectory.md
@@ -106,7 +106,7 @@ spec:
     # Specify how to filter the search to find the specific user by username.
     # "{}" will be replaced # by the username that the end-user had typed
     # when they tried to log in.
-    filter: "&(objectClass=person)(userPrincipleName={})"
+    filter: "&(objectClass=person)(userPrincipalName={})"
 
     # Specify which fields from the user entry should be used upon
     # successful login.


### PR DESCRIPTION
there was an typo in the example configuration for Microsoft Active Directory. Attribute was `userPrincipleName` but should be `userPrincipalName`