### PR TITLE
Bump Go 1.19.1 -> 1.19.4, and go-boringcrypto 1.18.6b7 -> 1.18.9b7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.19.1 as build-env
+FROM golang:1.19.4 as build-env
 
 WORKDIR /work
 COPY . .

--- a/hack/Dockerfile_fips
+++ b/hack/Dockerfile_fips
@@ -12,7 +12,7 @@
 # any type of fips certification.
 
 # use go-boringcrypto rather than main go
-FROM us-docker.pkg.dev/google.com/api-project-999119582588/go-boringcrypto/golang:1.18.6b7 as build-env
+FROM us-docker.pkg.dev/google.com/api-project-999119582588/go-boringcrypto/golang:1.18.9b7 as build-env
 
 WORKDIR /work
 COPY . .


### PR DESCRIPTION
**Release note**:

```release-note
Bump Go 1.19.1 -> 1.19.4, and go-boringcrypto 1.18.6b7 -> 1.18.9b7
```
