### PR TITLE
Reduce memory consumption of pinniped-concierge-kube-cert-agent binary

### DIFF
--- a/cmd/pinniped-concierge-kube-cert-agent/main.go
+++ b/cmd/pinniped-concierge-kube-cert-agent/main.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2022 the Pinniped contributors. All Rights Reserved.
+// Copyright 2021-2023 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package main is the combined entrypoint for the Pinniped "kube-cert-agent" component.
@@ -13,8 +13,23 @@ import (
 	"os"
 	"time"
 
-	// this side effect import ensures that we use fipsonly crypto in fips_strict mode.
-	_ "go.pinniped.dev/internal/crypto/ptls"
+	// This side effect import ensures that we use fipsonly crypto during TLS in fips_strict mode.
+	//
+	// Commenting this out because it causes the runtime memory consumption of this binary to increase
+	// from ~1 MB to ~8 MB (as measured when running the sleep subcommand). This binary does not use TLS,
+	// so it should not be needed. If this binary is ever changed to make use of TLS client and/or server
+	// code, then we should bring this import back to support the use of the ptls library for client and
+	// server code, and we should also increase the memory limits on the kube cert agent deployment (as
+	// decided by the kube cert agent controller in the Concierge).
+	//
+	//nolint:godot // This is not sentence, it is a commented out line of import code.
+	// _ "go.pinniped.dev/internal/crypto/ptls"
+
+	// This side effect imports cgo so that runtime/cgo gets linked, when in fips_strict mode.
+	// Without this line, the binary will exit 133 upon startup in fips_strict mode.
+	// It also enables fipsonly tls mode, just to be absolutely sure that the fips code is enabled,
+	// even though it shouldn't be used currently by this binary.
+	_ "go.pinniped.dev/internal/crypto/fips"
 )
 
 //nolint:gochecknoglobals // these are swapped during unit tests.

--- a/internal/crypto/fips/doc.go
+++ b/internal/crypto/fips/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2023 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package fips can be imported to enable fipsonly tls mode when compiling with fips_strict.
+// It will also cause cgo to be explicitly imported when compiling with fips_strict.
+package fips

--- a/internal/crypto/fips/fips_strict.go
+++ b/internal/crypto/fips/fips_strict.go
@@ -1,0 +1,12 @@
+// Copyright 2023 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build fips_strict
+// +build fips_strict
+
+package fips
+
+import (
+	"C"                     // explicitly import cgo so that runtime/cgo gets linked into the kube-cert-agent
+	_ "crypto/tls/fipsonly" // restricts all TLS configuration to FIPS-approved settings.
+)

--- a/internal/crypto/ptls/fips_strict.go
+++ b/internal/crypto/ptls/fips_strict.go
@@ -1,4 +1,4 @@
-// Copyright 2022 the Pinniped contributors. All Rights Reserved.
+// Copyright 2022-2023 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // The configurations here override the usual ptls.Secure, ptls.Default, and ptls.DefaultLDAP
@@ -16,11 +16,10 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"C"                     // explicitly import cgo so that runtime/cgo gets linked into the kube-cert-agent
-	_ "crypto/tls/fipsonly" // restricts all TLS configuration to FIPS-approved settings.
-
 	"k8s.io/apiserver/pkg/server/options"
 
+	// Cause fipsonly tls mode with this side effect import.
+	_ "go.pinniped.dev/internal/crypto/fips"
 	"go.pinniped.dev/internal/plog"
 )
 


### PR DESCRIPTION
Starting in Pinniped v0.16.0, the memory usage of the `pinniped-concierge-kube-cert-agent` binary increased. This is the binary that runs inside the Kube cert agent pod. This PR reduces the memory usage of that binary back to pre-v0.16.0 levels.

There can be multiple copies of the binary running simultaneously at times, but there is only one when the pod first starts, which is executing the `sleep` subcommand. Other copies of the binary will get started occasionally when the pinniped controller running in each concierge pod performs the equivalent of a `kubectl exec` to run another copy of the binary inside the running pod.

Before v0.16.0 it used to use less than 1 MB of memory to run sleep. Starting in v0.16.0 it started to use almost 8 MB of memory to run sleep (as measured on my Mac laptop). So if there are four copies of the binary running inside the pod at the same time, it will reach the [memory limit for those pods](https://github.com/vmware-tanzu/pinniped/blob/976035115e76da341e87c2baa8ccca87def7705e/internal/controller/kubecertagent/kubecertagent.go#L546) as specified in the Deployment (which is created automatically by the kube cert agent controller running in the Concierge pods).

You can see this memory usage by running `docker run --entrypoint /usr/local/bin/pinniped-concierge-kube-cert-agent --rm docker.io/getpinniped/pinniped-server:v0.16.0 sleep` and then in a different window running `docker stats`. I did this experiment on a Mac with docker, so the memory usage could be different on a linux Kubernetes node, but this gives a rough expectation expectation of memory usage by that pod.

**Release note**:

```release-note
Reduced memory consumption of pinniped-concierge-kube-cert-agent binary
```
