### PR TITLE
use apiGroup without version in webapp auth howto

### DIFF
--- a/site/content/docs/howto/configure-auth-for-webapps.md
+++ b/site/content/docs/howto/configure-auth-for-webapps.md
@@ -374,7 +374,7 @@ kind: TokenCredentialRequest
 spec:
   token: <cluster-scoped ID token value>
   authenticator:
-    apiGroup: authentication.concierge.pinniped.dev/v1alpha1
+    apiGroup: authentication.concierge.pinniped.dev
     kind: JWTAuthenticator
     name: <the metadata.name of the JWTAuthenticator to be used>
 ```


### PR DESCRIPTION
This is purely a docs change. While I was attempting to follow these instructions, I kept seeing errors like

```
{"level":"info","timestamp":"2023-03-16T19:42:34.050803Z","caller":"k8s.io/utils@v0.0.0-20230115233650-391b47cb4029/trace/trace.go:219$trace.(*Trace).logTrace","message":"Trace[580760707]: \"create\" kind:TokenCredentialRequest (16-Mar-2023 19:42:34.050) (total time: 0ms):\nTrace[580760707]: ---\"failure\" failureType:token authentication,msg:no such authenticator 0ms (19:42:34.050)\nTrace[580760707]: [51.899µs] [51.899µs] END\n"}
```

I googled around for this error and encountered the similar (but not the same, due to their use of the CLI) #1211. Anyway, upon digging through the code I figured out that the error was being raised here:

https://github.com/vmware-tanzu/pinniped/blob/0aa4892353afc811898d391d439b15b293100c9c/internal/controller/authenticator/authncache/cache.go#L100

Which suggested to me that the `authncache` was not being populated correctly. After a bit more digging I found that it was the `jwtcachefiller` who was responsible for this, and it was using cache keys like this:

https://github.com/vmware-tanzu/pinniped/blob/0aa4892353afc811898d391d439b15b293100c9c/internal/controller/authenticator/jwtcachefiller/jwtcachefiller.go#L104-L108

Looking a little closer at the `APIGroup` value there, I found

https://github.com/vmware-tanzu/pinniped/blob/0aa4892353afc811898d391d439b15b293100c9c/generated/latest/apis/concierge/authentication/v1alpha1/register.go#L12

There's no `/v1alpha1` at the end there! Stripping this from my `TokenCredentialRequest` allowed me to move forward.

**Release note**:

<!--
Does this PR introduce a user-facing change?

If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
-->
```release-note
NONE
```
