### PR TITLE
Upgrade dep github.com/go-logr/logr@v1.2.3 to v1.2.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/felixge/httpsnoop v1.0.3
 	github.com/go-ldap/ldap/v3 v3.4.4
-	github.com/go-logr/logr v1.2.3
+	github.com/go-logr/logr v1.2.4
 	github.com/go-logr/stdr v1.2.2
 	github.com/go-logr/zapr v1.2.3
 	github.com/gofrs/flock v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -199,8 +199,8 @@ github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KE
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
-github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
-github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
+github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-logr/zapr v1.2.3 h1:a9vnzlIBPQBBkeaR9IuMUfmVOrQlkoC4YfPoFkX3T7A=

--- a/internal/plog/plog_test.go
+++ b/internal/plog/plog_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 the Pinniped contributors. All Rights Reserved.
+// Copyright 2022-2023 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package plog
@@ -232,7 +232,7 @@ func TestPlog(t *testing.T) {
 				testAllPlogMethods(l.withDepth(-2))
 			},
 			want: `
-{"level":"error","timestamp":"2099-08-08T13:57:36.123456Z","caller":"logr@v1.2.3/logr.go:<line>$logr.Logger.Error","message":"e","panda":2,"error":"some err"}
+{"level":"error","timestamp":"2099-08-08T13:57:36.123456Z","caller":"logr@v1.2.4/logr.go:<line>$logr.Logger.Error","message":"e","panda":2,"error":"some err"}
 {"level":"info","timestamp":"2099-08-08T13:57:36.123456Z","caller":"plog/plog.go:<line>$plog.pLogger.warningDepth","message":"w","warning":true,"panda":2}
 {"level":"info","timestamp":"2099-08-08T13:57:36.123456Z","caller":"plog/plog.go:<line>$plog.pLogger.warningDepth","message":"we","warning":true,"error":"some err","panda":2}
 {"level":"info","timestamp":"2099-08-08T13:57:36.123456Z","caller":"plog/plog.go:<line>$plog.pLogger.infoDepth","message":"i","panda":2}
@@ -241,8 +241,8 @@ func TestPlog(t *testing.T) {
 {"level":"debug","timestamp":"2099-08-08T13:57:36.123456Z","caller":"plog/plog.go:<line>$plog.pLogger.debugDepth","message":"de","error":"some err","panda":2}
 {"level":"trace","timestamp":"2099-08-08T13:57:36.123456Z","caller":"plog/plog.go:<line>$plog.pLogger.traceDepth","message":"t","panda":2}
 {"level":"trace","timestamp":"2099-08-08T13:57:36.123456Z","caller":"plog/plog.go:<line>$plog.pLogger.traceDepth","message":"te","error":"some err","panda":2}
-{"level":"all","timestamp":"2099-08-08T13:57:36.123456Z","caller":"logr@v1.2.3/logr.go:<line>$logr.Logger.Info","message":"all","panda":2}
-{"level":"info","timestamp":"2099-08-08T13:57:36.123456Z","caller":"logr@v1.2.3/logr.go:<line>$logr.Logger.Info","message":"always","panda":2}
+{"level":"all","timestamp":"2099-08-08T13:57:36.123456Z","caller":"logr@v1.2.4/logr.go:<line>$logr.Logger.Info","message":"all","panda":2}
+{"level":"info","timestamp":"2099-08-08T13:57:36.123456Z","caller":"logr@v1.2.4/logr.go:<line>$logr.Logger.Info","message":"always","panda":2}
 `,
 		},
 		{
@@ -252,14 +252,14 @@ func TestPlog(t *testing.T) {
 			},
 			want: `
 {"level":"error","timestamp":"2099-08-08T13:57:36.123456Z","caller":"zapr@v1.2.3/zapr.go:<line>$zapr.(*zapLogger).Error","message":"e","panda":2,"error":"some err"}
-{"level":"info","timestamp":"2099-08-08T13:57:36.123456Z","caller":"logr@v1.2.3/logr.go:<line>$logr.Logger.Info","message":"w","warning":true,"panda":2}
-{"level":"info","timestamp":"2099-08-08T13:57:36.123456Z","caller":"logr@v1.2.3/logr.go:<line>$logr.Logger.Info","message":"we","warning":true,"error":"some err","panda":2}
-{"level":"info","timestamp":"2099-08-08T13:57:36.123456Z","caller":"logr@v1.2.3/logr.go:<line>$logr.Logger.Info","message":"i","panda":2}
-{"level":"info","timestamp":"2099-08-08T13:57:36.123456Z","caller":"logr@v1.2.3/logr.go:<line>$logr.Logger.Info","message":"ie","error":"some err","panda":2}
-{"level":"debug","timestamp":"2099-08-08T13:57:36.123456Z","caller":"logr@v1.2.3/logr.go:<line>$logr.Logger.Info","message":"d","panda":2}
-{"level":"debug","timestamp":"2099-08-08T13:57:36.123456Z","caller":"logr@v1.2.3/logr.go:<line>$logr.Logger.Info","message":"de","error":"some err","panda":2}
-{"level":"trace","timestamp":"2099-08-08T13:57:36.123456Z","caller":"logr@v1.2.3/logr.go:<line>$logr.Logger.Info","message":"t","panda":2}
-{"level":"trace","timestamp":"2099-08-08T13:57:36.123456Z","caller":"logr@v1.2.3/logr.go:<line>$logr.Logger.Info","message":"te","error":"some err","panda":2}
+{"level":"info","timestamp":"2099-08-08T13:57:36.123456Z","caller":"logr@v1.2.4/logr.go:<line>$logr.Logger.Info","message":"w","warning":true,"panda":2}
+{"level":"info","timestamp":"2099-08-08T13:57:36.123456Z","caller":"logr@v1.2.4/logr.go:<line>$logr.Logger.Info","message":"we","warning":true,"error":"some err","panda":2}
+{"level":"info","timestamp":"2099-08-08T13:57:36.123456Z","caller":"logr@v1.2.4/logr.go:<line>$logr.Logger.Info","message":"i","panda":2}
+{"level":"info","timestamp":"2099-08-08T13:57:36.123456Z","caller":"logr@v1.2.4/logr.go:<line>$logr.Logger.Info","message":"ie","error":"some err","panda":2}
+{"level":"debug","timestamp":"2099-08-08T13:57:36.123456Z","caller":"logr@v1.2.4/logr.go:<line>$logr.Logger.Info","message":"d","panda":2}
+{"level":"debug","timestamp":"2099-08-08T13:57:36.123456Z","caller":"logr@v1.2.4/logr.go:<line>$logr.Logger.Info","message":"de","error":"some err","panda":2}
+{"level":"trace","timestamp":"2099-08-08T13:57:36.123456Z","caller":"logr@v1.2.4/logr.go:<line>$logr.Logger.Info","message":"t","panda":2}
+{"level":"trace","timestamp":"2099-08-08T13:57:36.123456Z","caller":"logr@v1.2.4/logr.go:<line>$logr.Logger.Info","message":"te","error":"some err","panda":2}
 {"level":"all","timestamp":"2099-08-08T13:57:36.123456Z","caller":"zapr@v1.2.3/zapr.go:<line>$zapr.(*zapLogger).Info","message":"all","panda":2}
 {"level":"info","timestamp":"2099-08-08T13:57:36.123456Z","caller":"zapr@v1.2.3/zapr.go:<line>$zapr.(*zapLogger).Info","message":"always","panda":2}
 `,


### PR DESCRIPTION
Replaces Dependabot PR #1467.

**Release note**:

```release-note
NONE
```
