### PR TITLE
[WIP] deploy dir values.yaml files for supervisor,concierge as schemas

### DIFF
--- a/deploy/concierge/values.yaml
+++ b/deploy/concierge/values.yaml
@@ -1,75 +1,98 @@
 #! Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
 #! SPDX-License-Identifier: Apache-2.0
 
-#@data/values
+#@data/values-schema
 ---
-
+#@schema/desc "Name of pinniped-concierge."
 app_name: pinniped-concierge
 
-#! Creates a new namespace statically in yaml with the given name and installs the app into that namespace.
+#@schema/desc "Creates a new namespace statically in yaml with the given name and installs the app into that namespace."
 namespace: pinniped-concierge
-#! If specified, assumes that a namespace of the given name already exists and installs the app into that namespace.
-#! If both `namespace` and `into_namespace` are specified, then only `into_namespace` is used.
-into_namespace: #! e.g. my-preexisting-namespace
+#@ into_namespace_desc = "If specified, assumes that a namespace of the given name already exists and installs the app into that namespace. \
+#@ If both `namespace` and `into_namespace` are specified, then only `into_namespace` is used."
+#@schema/desc into_namespace_desc
+#@schema/nullable
+into_namespace: my-preexisting-namespace
 
-#! All resources created statically by yaml at install-time and all resources created dynamically
-#! by controllers at runtime will be labelled with `app: $app_name` and also with the labels
-#! specified here. The value of `custom_labels` must be a map of string keys to string values.
-#! The app can be uninstalled either by:
-#! 1. Deleting the static install-time yaml resources including the static namespace, which will cascade and also delete
-#!    resources that were dynamically created by controllers at runtime
-#! 2. Or, deleting all resources by label, which does not assume that there was a static install-time yaml namespace.
-custom_labels: {} #! e.g. {myCustomLabelName: myCustomLabelValue, otherCustomLabelName: otherCustomLabelValue}
+#@ custom_labels_desc = "All resources created statically by yaml at install-time and all resources created dynamically \
+#@ by controllers at runtime will be labelled with `app: $app_name` and also with the labels \
+#@ specified here. The value of `custom_labels` must be a map of string keys to string values. \
+#@ The app can be uninstalled either by: \
+#@ 1. Deleting the static install-time yaml resources including the static namespace, which will cascade and also delete \
+#@    resources that were dynamically created by controllers at runtime \
+#@ 2. Or, deleting all resources by label, which does not assume that there was a static install-time yaml namespace."
+#@schema/desc custom_labels_desc
+#@schema/nullable
+custom_labels: {myCustomLabelName: myCustomLabelValue, otherCustomLabelName: otherCustomLabelValue}
 
-#! Specify how many replicas of the Pinniped server to run.
+#@schema/desc "Specify how many replicas of the Pinniped server to run."
 replicas: 2
 
-#! Specify either an image_digest or an image_tag. If both are given, only image_digest will be used.
+#@schema/desc "Specify either an image_digest or an image_tag. If both are given, only image_digest will be used."
 image_repo: projects.registry.vmware.com/pinniped/pinniped-server
-image_digest: #! e.g. sha256:f3c4fdfd3ef865d4b97a1fd295d94acc3f0c654c46b6f27ffad5cf80216903c8
+#@schema/desc "Specify either an image_digest or an image_tag. If both are given, only image_digest will be used."
+#@schema/nullable
+image_digest: sha256:f3c4fdfd3ef865d4b97a1fd295d94acc3f0c654c46b6f27ffad5cf80216903c8
+#@schema/desc "Specify either an image_digest or an image_tag. If both are given, only image_digest will be used."
 image_tag: latest
 
-#! Optionally specify a different image for the "kube-cert-agent" pod which is scheduled
-#! on the control plane. This image needs only to include `sleep` and `cat` binaries.
-#! By default, the same image specified for image_repo/image_digest/image_tag will be re-used.
-kube_cert_agent_image:
+#@ kube_cert_agent_image = "Optionally specify a different image for the 'kube-cert-agent' pod which is scheduled \
+#@ on the control plane. This image needs only to include `sleep` and `cat` binaries. \
+#@ By default, the same image specified for image_repo/image_digest/image_tag will be re-used."
+#@schema/desc kube_cert_agent_image
+#@schema/nullable
+kube_cert_agent_image: projects.registry.vmware.com/pinniped/pinniped-server
 
-#! Specifies a secret to be used when pulling the above `image_repo` container image.
-#! Can be used when the above image_repo is a private registry.
-#! Typically the value would be the output of: kubectl create secret docker-registry x --docker-server=https://example.io --docker-username="USERNAME" --docker-password="PASSWORD" --dry-run=client -o json | jq -r '.data[".dockerconfigjson"]'
-#! Optional.
-image_pull_dockerconfigjson: #! e.g. {"auths":{"https://registry.example.com":{"username":"USERNAME","password":"PASSWORD","auth":"BASE64_ENCODED_USERNAME_COLON_PASSWORD"}}}
+#@ image_pull_dockerconfigjson_desc = "Specifies a secret to be used when pulling the above `image_repo` container image. \
+#@ Can be used when the above image_repo is a private registry. \
+#@ Typically the value would be the output of: kubectl create secret docker-registry x --docker-server=https://example.io --docker-username='USERNAME' --docker-password='PASSWORD' --dry-run=client -o json | jq -r '.data['.dockerconfigjson']' \
+#@ Optional."
+#@schema/desc image_pull_dockerconfigjson_desc
+#@schema/nullable
+image_pull_dockerconfigjson: {"auths":{"https://registry.example.com":{"username":"USERNAME","password":"PASSWORD","auth":"BASE64_ENCODED_USERNAME_COLON_PASSWORD"}}}
 
-#! Pinniped will try to guess the right K8s API URL for sharing that information with potential clients.
-#! This setting allows the guess to be overridden.
-#! Optional.
-discovery_url: #! e.g., https://example.com
+#@schema/desc "Pinniped will try to guess the right K8s API URL for sharing that information with potential clients. This setting allows the guess to be overridden."
+#@schema/nullable
+discovery_url: https://example.com
 
-#! Specify the duration and renewal interval for the API serving certificate.
-#! The defaults are set to expire the cert about every 30 days, and to rotate it
-#! about every 25 days.
+
+#@ api_serving_certificate_desc = "Specify the duration and renewal interval for the API serving certificate. \
+#@ The defaults are set to expire the cert about every 30 days, and to rotate it \
+#@ about every 25 days."
+#@schema/desc api_serving_certificate_desc
+#@schema/nullable
 api_serving_certificate_duration_seconds: 2592000
+#@schema/desc api_serving_certificate_desc
+#@schema/nullable
 api_serving_certificate_renew_before_seconds: 2160000
 
-#! Specify the verbosity of logging: info ("nice to know" information), debug (developer
-#! information), trace (timing information), all (kitchen sink).
-log_level: #! By default, when this value is left unset, only warnings and errors are printed. There is no way to suppress warning and error logs.
-#! Specify the format of logging: json (for machine parsable logs) and text (for legacy klog formatted logs).
-#! By default, when this value is left unset, logs are formatted in json.
-#! This configuration is deprecated and will be removed in a future release at which point logs will always be formatted as json.
-deprecated_log_format:
+#! Specify the verbosity of logging: info ("nice to know" information), debug (developer information), trace (timing information),
+#! or all (kitchen sink). Do not use trace or all on production systems, as credentials may get logged.
+#@schema/desc "default, when this value is left unset, only warnings and errors are printed. There is no way to suppress warning and error logs."
+#@schema/nullable
+log_level: info
+#@ deprecated_log_format_desc = "Specify the format of logging: json (for machine parsable logs) and text (for legacy klog formatted logs). \
+#@ By default, when this value is left unset, logs are formatted in json. \
+#@ This configuration is deprecated and will be removed in a future release at which point logs will always be formatted as json."
+#@schema/desc deprecated_log_format_desc
+#@schema/nullable
+deprecated_log_format: json
 
-run_as_user: 65532 #! run_as_user specifies the user ID that will own the process, see the Dockerfile for the reasoning behind this choice
-run_as_group: 65532 #! run_as_group specifies the group ID that will own the process, see the Dockerfile for the reasoning behind this choice
+#@schema/desc "run_as_user specifies the user ID that will own the process, see the Dockerfile for the reasoning behind this choice"
+run_as_user: 65532
+#@schema/desc "run_as_group specifies the group ID that will own the process, see the Dockerfile for the reasoning behind this choice"
+run_as_group: 65532
 
-#! Specify the API group suffix for all Pinniped API groups. By default, this is set to
-#! pinniped.dev, so Pinniped API groups will look like foo.pinniped.dev,
-#! authentication.concierge.pinniped.dev, etc. As an example, if this is set to tuna.io, then
-#! Pinniped API groups will look like foo.tuna.io. authentication.concierge.tuna.io, etc.
+#@ api_group_suffix_desc = "Specify the API group suffix for all Pinniped API groups. By default, this is set to \
+#@ pinniped.dev, so Pinniped API groups will look like foo.pinniped.dev, \
+#@ authentication.concierge.pinniped.dev, etc. As an example, if this is set to tuna.io, then \
+#@ Pinniped API groups will look like foo.tuna.io. authentication.concierge.tuna.io, etc."
+#@schema/desc api_group_suffix_desc
 api_group_suffix: pinniped.dev
 
-#! Customize CredentialIssuer.spec.impersonationProxy to change how the concierge
-#! handles impersonation.
+
+#@schema/desc "Customize CredentialIssuer.spec.impersonationProxy to change how the concierge handles impersonation."
+#@schema/nullable
 impersonation_proxy_spec:
   #! options are "auto", "disabled" or "enabled".
   #! If auto, the impersonation proxy will run only if the cluster signing key is not available
@@ -77,11 +100,13 @@ impersonation_proxy_spec:
   #! If disabled, the impersonation proxy will never run, which could mean that the concierge
   #! doesn't work at all.
   #! If enabled, the impersonation proxy will always run regardless of other strategies available.
+  #@schema/desc "If enabled, the impersonation proxy will always run regardless of other strategies available."
   mode: auto
-  #! The endpoint which the client should use to connect to the impersonation proxy.
-  #! If left unset, the client will default to connecting based on the ClusterIP or LoadBalancer
-  #! endpoint.
-  external_endpoint:
+  #@ external_endpoint_desc = "The endpoint which the client should use to connect to the impersonation proxy. \
+  #@ If left unset, the client will default to connecting based on the ClusterIP or LoadBalancer endpoint."
+  #@schema/desc external_endpoint_desc
+  #@schema/nullable
+  external_endpoint: 1.2.3.4:5678
   service:
     #! Options are "LoadBalancer", "ClusterIP" and "None".
     #! LoadBalancer automatically provisions a Service of type LoadBalancer pointing at
@@ -91,17 +116,21 @@ impersonation_proxy_spec:
     #! impersonation proxy.
     #! None does not provision either and assumes that you have set the external_endpoint
     #! and set up your own ingress to connect to the impersonation proxy.
+    #@schema/desc "Options are 'LoadBalancer', 'ClusterIP' and 'None'."
     type: LoadBalancer
-    #! The annotations that should be set on the ClusterIP or LoadBalancer Service.
+    #@schema/desc "The annotations that should be set on the ClusterIP or LoadBalancer Service."
     annotations:
       {service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "4000"}
-    #! When mode LoadBalancer is set, this will set the LoadBalancer Service's Spec.LoadBalancerIP.
-    load_balancer_ip:
+    #@schema/desc "When mode LoadBalancer is set, this will set the LoadBalancer Service's Spec.LoadBalancerIP."
+    load_balancer_ip: 1.2.3.4:5678
 
-#! Set the standard golang HTTPS_PROXY and NO_PROXY environment variables on the Concierge containers.
-#! These will be used when the Concierge makes backend-to-backend calls to authenticators using HTTPS,
-#! e.g. when the Concierge fetches discovery documents, JWKS keys, and POSTs to token webhooks.
-#! The Concierge never makes insecure HTTP calls, so there is no reason to set HTTP_PROXY.
-#! Optional.
-https_proxy: #! e.g. http://proxy.example.com
+#@ https_proxy_desc = "Set the standard golang HTTPS_PROXY and NO_PROXY environment variables on the Supervisor containers. \
+#@ These will be used when the Supervisor makes backend-to-backend calls to upstream identity providers using HTTPS, \
+#@ e.g. when the Supervisor fetches discovery documents, JWKS keys, and tokens from an upstream OIDC Provider. \
+#@ The Supervisor never makes insecure HTTP calls, so there is no reason to set HTTP_PROXY. \
+#@ Optional."
+#@schema/desc https_proxy_desc
+#@schema/nullable
+https_proxy: http://proxy.example.com
+#@schema/desc "do not proxy Kubernetes endpoints"
 no_proxy: "$(KUBERNETES_SERVICE_HOST),169.254.169.254,127.0.0.1,localhost,.svc,.cluster.local" #! do not proxy Kubernetes endpoints

--- a/deploy/concierge/values.yaml
+++ b/deploy/concierge/values.yaml
@@ -22,8 +22,9 @@ into_namespace: my-preexisting-namespace
 #@    resources that were dynamically created by controllers at runtime \
 #@ 2. Or, deleting all resources by label, which does not assume that there was a static install-time yaml namespace."
 #@schema/desc custom_labels_desc
+#@schema/type any=True
 #@schema/nullable
-custom_labels: {myCustomLabelName: myCustomLabelValue, otherCustomLabelName: otherCustomLabelValue}
+custom_labels: {} #! {myCustomLabelName: myCustomLabelValue, otherCustomLabelName: otherCustomLabelValue}
 
 #@schema/desc "Specify how many replicas of the Pinniped server to run."
 replicas: 2
@@ -60,10 +61,8 @@ discovery_url: https://example.com
 #@ The defaults are set to expire the cert about every 30 days, and to rotate it \
 #@ about every 25 days."
 #@schema/desc api_serving_certificate_desc
-#@schema/nullable
 api_serving_certificate_duration_seconds: 2592000
 #@schema/desc api_serving_certificate_desc
-#@schema/nullable
 api_serving_certificate_renew_before_seconds: 2160000
 
 #! Specify the verbosity of logging: info ("nice to know" information), debug (developer information), trace (timing information),
@@ -92,7 +91,6 @@ api_group_suffix: pinniped.dev
 
 
 #@schema/desc "Customize CredentialIssuer.spec.impersonationProxy to change how the concierge handles impersonation."
-#@schema/nullable
 impersonation_proxy_spec:
   #! options are "auto", "disabled" or "enabled".
   #! If auto, the impersonation proxy will run only if the cluster signing key is not available
@@ -107,6 +105,7 @@ impersonation_proxy_spec:
   #@schema/desc external_endpoint_desc
   #@schema/nullable
   external_endpoint: 1.2.3.4:5678
+  #@schema/desc "The impersonation proxy service configuration"
   service:
     #! Options are "LoadBalancer", "ClusterIP" and "None".
     #! LoadBalancer automatically provisions a Service of type LoadBalancer pointing at
@@ -117,11 +116,14 @@ impersonation_proxy_spec:
     #! None does not provision either and assumes that you have set the external_endpoint
     #! and set up your own ingress to connect to the impersonation proxy.
     #@schema/desc "Options are 'LoadBalancer', 'ClusterIP' and 'None'."
+    #@schema/nullable
     type: LoadBalancer
     #@schema/desc "The annotations that should be set on the ClusterIP or LoadBalancer Service."
+    #@schema/nullable
     annotations:
       {service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "4000"}
     #@schema/desc "When mode LoadBalancer is set, this will set the LoadBalancer Service's Spec.LoadBalancerIP."
+    #@schema/nullable
     load_balancer_ip: 1.2.3.4:5678
 
 #@ https_proxy_desc = "Set the standard golang HTTPS_PROXY and NO_PROXY environment variables on the Supervisor containers. \

--- a/deploy/supervisor/values.yaml
+++ b/deploy/supervisor/values.yaml
@@ -3,7 +3,7 @@
 
 #@data/values-schema
 ---
-#@schema/desc "Namespace of pinniped-supervisor."
+#@schema/desc "Name of pinniped-supervisor."
 app_name: pinniped-supervisor
 
 #@schema/desc "Creates a new namespace statically in yaml with the given name and installs the app into that namespace."

--- a/deploy/supervisor/values.yaml
+++ b/deploy/supervisor/values.yaml
@@ -22,8 +22,9 @@ into_namespace: my-preexisting-namespace
 #@    resources that were dynamically created by controllers at runtime \
 #@ 2. Or, deleting all resources by label, which does not assume that there was a static install-time yaml namespace."
 #@schema/desc custom_labels_desc
+#@schema/type any=True
 #@schema/nullable
-custom_labels: {myCustomLabelName: myCustomLabelValue, otherCustomLabelName: otherCustomLabelValue}
+custom_labels: {} #! {myCustomLabelName: myCustomLabelValue, otherCustomLabelName: otherCustomLabelValue}
 
 #@schema/desc "Specify how many replicas of the Pinniped server to run."
 replicas: 2

--- a/deploy/supervisor/values.yaml
+++ b/deploy/supervisor/values.yaml
@@ -1,39 +1,48 @@
 #! Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
 #! SPDX-License-Identifier: Apache-2.0
 
-#@data/values
+#@data/values-schema
 ---
-
+#@schema/desc "Namespace of pinniped-supervisor."
 app_name: pinniped-supervisor
 
-#! Creates a new namespace statically in yaml with the given name and installs the app into that namespace.
+#@schema/desc "Creates a new namespace statically in yaml with the given name and installs the app into that namespace."
 namespace: pinniped-supervisor
-#! If specified, assumes that a namespace of the given name already exists and installs the app into that namespace.
-#! If both `namespace` and `into_namespace` are specified, then only `into_namespace` is used.
-into_namespace: #! e.g. my-preexisting-namespace
+#@ into_namespace_desc = "If specified, assumes that a namespace of the given name already exists and installs the app into that namespace. \
+#@ If both `namespace` and `into_namespace` are specified, then only `into_namespace` is used."
+#@schema/desc into_namespace_desc
+#@schema/nullable
+into_namespace: my-preexisting-namespace
 
-#! All resources created statically by yaml at install-time and all resources created dynamically
-#! by controllers at runtime will be labelled with `app: $app_name` and also with the labels
-#! specified here. The value of `custom_labels` must be a map of string keys to string values.
-#! The app can be uninstalled either by:
-#! 1. Deleting the static install-time yaml resources including the static namespace, which will cascade and also delete
-#!    resources that were dynamically created by controllers at runtime
-#! 2. Or, deleting all resources by label, which does not assume that there was a static install-time yaml namespace.
-custom_labels: {} #! e.g. {myCustomLabelName: myCustomLabelValue, otherCustomLabelName: otherCustomLabelValue}
+#@ custom_labels_desc = "All resources created statically by yaml at install-time and all resources created dynamically \
+#@ by controllers at runtime will be labelled with `app: $app_name` and also with the labels \
+#@ specified here. The value of `custom_labels` must be a map of string keys to string values. \
+#@ The app can be uninstalled either by: \
+#@ 1. Deleting the static install-time yaml resources including the static namespace, which will cascade and also delete \
+#@    resources that were dynamically created by controllers at runtime \
+#@ 2. Or, deleting all resources by label, which does not assume that there was a static install-time yaml namespace."
+#@schema/desc custom_labels_desc
+#@schema/nullable
+custom_labels: {myCustomLabelName: myCustomLabelValue, otherCustomLabelName: otherCustomLabelValue}
 
-#! Specify how many replicas of the Pinniped server to run.
+#@schema/desc "Specify how many replicas of the Pinniped server to run."
 replicas: 2
 
-#! Specify either an image_digest or an image_tag. If both are given, only image_digest will be used.
+#@schema/desc "Specify either an image_digest or an image_tag. If both are given, only image_digest will be used."
 image_repo: projects.registry.vmware.com/pinniped/pinniped-server
-image_digest: #! e.g. sha256:f3c4fdfd3ef865d4b97a1fd295d94acc3f0c654c46b6f27ffad5cf80216903c8
+#@schema/desc "Specify either an image_digest or an image_tag. If both are given, only image_digest will be used."
+#@schema/nullable
+image_digest: sha256:f3c4fdfd3ef865d4b97a1fd295d94acc3f0c654c46b6f27ffad5cf80216903c8
+#@schema/desc "Specify either an image_digest or an image_tag. If both are given, only image_digest will be used."
 image_tag: latest
 
-#! Specifies a secret to be used when pulling the above `image_repo` container image.
-#! Can be used when the above image_repo is a private registry.
-#! Typically the value would be the output of: kubectl create secret docker-registry x --docker-server=https://example.io --docker-username="USERNAME" --docker-password="PASSWORD" --dry-run=client -o json | jq -r '.data[".dockerconfigjson"]'
-#! Optional.
-image_pull_dockerconfigjson: #! e.g. {"auths":{"https://registry.example.com":{"username":"USERNAME","password":"PASSWORD","auth":"BASE64_ENCODED_USERNAME_COLON_PASSWORD"}}}
+#@ image_pull_dockerconfigjson_desc = "Specifies a secret to be used when pulling the above `image_repo` container image. \
+#@ Can be used when the above image_repo is a private registry. \
+#@ Typically the value would be the output of: kubectl create secret docker-registry x --docker-server=https://example.io --docker-username='USERNAME' --docker-password='PASSWORD' --dry-run=client -o json | jq -r '.data['.dockerconfigjson']' \
+#@ Optional."
+#@schema/desc image_pull_dockerconfigjson_desc
+#@schema/nullable
+image_pull_dockerconfigjson: {"auths":{"https://registry.example.com":{"username":"USERNAME","password":"PASSWORD","auth":"BASE64_ENCODED_USERNAME_COLON_PASSWORD"}}}
 
 #! Specify how to expose the Supervisor app's HTTPS port as a Service.
 #! Typically, you would set a value for only one of the following service types.
@@ -41,43 +50,70 @@ image_pull_dockerconfigjson: #! e.g. {"auths":{"https://registry.example.com":{"
 #! Note that all port numbers should be numbers (not strings), i.e. use ytt's `--data-value-yaml` instead of `--data-value`.
 #! Several of these values have been deprecated and will be removed in a future release. Their names have been changed to
 #! mark them as deprecated and to make it obvious upon upgrade to anyone who was using them that they have been deprecated.
-deprecated_service_http_nodeport_port: #! will be removed in a future release; when specified, creates a NodePort Service with this `port` value, with port 8080 as its `targetPort`; e.g. 31234
-deprecated_service_http_nodeport_nodeport: #! will be removed in a future release; the `nodePort` value of the NodePort Service, optional when `deprecated_service_http_nodeport_port` is specified; e.g. 31234
-deprecated_service_http_loadbalancer_port: #! will be removed in a future release; when specified, creates a LoadBalancer Service with this `port` value, with port 8080 as its `targetPort`; e.g. 8443
-deprecated_service_http_clusterip_port: #! will be removed in a future release; when specified, creates a ClusterIP Service with this `port` value, with port 8080 as its `targetPort`; e.g. 8443
-service_https_nodeport_port: #! when specified, creates a NodePort Service with this `port` value, with port 8443 as its `targetPort`; e.g. 31243
-service_https_nodeport_nodeport: #! the `nodePort` value of the NodePort Service, optional when `service_https_nodeport_port` is specified; e.g. 31243
-service_https_loadbalancer_port: #! when specified, creates a LoadBalancer Service with this `port` value, with port 8443 as its `targetPort`; e.g. 8443
-service_https_clusterip_port: #! when specified, creates a ClusterIP Service with this `port` value, with port 8443 as its `targetPort`; e.g. 8443
-#! The `loadBalancerIP` value of the LoadBalancer Service.
-#! Ignored unless service_https_loadbalancer_port is provided.
-#! Optional.
-service_loadbalancer_ip: #! e.g. 1.2.3.4
+#@schema/desc "will be removed in a future release; when specified, creates a NodePort Service with this `port` value, with port 8080 as its `targetPort`"
+#@schema/nullable
+deprecated_service_http_nodeport_port: 31234
+#@schema/desc "will be removed in a future release; the `nodePort` value of the NodePort Service, optional when `deprecated_service_http_nodeport_port` is specified"
+#@schema/nullable
+deprecated_service_http_nodeport_nodeport: 31234
+#@schema/desc "will be removed in a future release; when specified, creates a LoadBalancer Service with this `port` value, with port 8080 as its `targetPort`"
+#@schema/nullable
+deprecated_service_http_loadbalancer_port: 8443
+#@schema/desc "#! will be removed in a future release; when specified, creates a ClusterIP Service with this `port` value, with port 8080 as its `targetPort`"
+#@schema/nullable
+deprecated_service_http_clusterip_port: 8443
+#@schema/desc "#! when specified, creates a NodePort Service with this `port` value, with port 8443 as its `targetPort`"
+#@schema/nullable
+service_https_nodeport_port: 31243
+#@schema/desc "#! the `nodePort` value of the NodePort Service, optional when `service_https_nodeport_port` is specified"
+#@schema/nullable
+service_https_nodeport_nodeport: 31243
+#@schema/desc "#! when specified, creates a LoadBalancer Service with this `port` value, with port 8443 as its `targetPort`"
+#@schema/nullable
+service_https_loadbalancer_port: 8443
+#@schema/desc "#! when specified, creates a ClusterIP Service with this `port` value, with port 8443 as its `targetPort`"
+#@schema/nullable
+service_https_clusterip_port: 8443
+#@ service_loadbalancer_ip_desc="The `loadBalancerIP` value of the LoadBalancer Service. \
+#@ Ignored unless service_https_loadbalancer_port is provided."
+#@schema/desc service_loadbalancer_ip_desc
+#@schema/nullable
+service_loadbalancer_ip: 1.2.3.4
 
 #! Specify the verbosity of logging: info ("nice to know" information), debug (developer information), trace (timing information),
 #! or all (kitchen sink). Do not use trace or all on production systems, as credentials may get logged.
-log_level: #! By default, when this value is left unset, only warnings and errors are printed. There is no way to suppress warning and error logs.
-#! Specify the format of logging: json (for machine parsable logs) and text (for legacy klog formatted logs).
-#! By default, when this value is left unset, logs are formatted in json.
-#! This configuration is deprecated and will be removed in a future release at which point logs will always be formatted as json.
-deprecated_log_format:
+#@schema/desc "default, when this value is left unset, only warnings and errors are printed. There is no way to suppress warning and error logs."
+#@schema/nullable
+log_level: info
+#@ deprecated_log_format_desc = "Specify the format of logging: json (for machine parsable logs) and text (for legacy klog formatted logs). \
+#@ By default, when this value is left unset, logs are formatted in json. \
+#@ This configuration is deprecated and will be removed in a future release at which point logs will always be formatted as json."
+#@schema/desc deprecated_log_format_desc
+#@schema/nullable
+deprecated_log_format: json
 
-run_as_user: 65532 #! run_as_user specifies the user ID that will own the process, see the Dockerfile for the reasoning behind this choice
-run_as_group: 65532 #! run_as_group specifies the group ID that will own the process, see the Dockerfile for the reasoning behind this choice
+#@schema/desc "run_as_user specifies the user ID that will own the process, see the Dockerfile for the reasoning behind this choice"
+run_as_user: 65532
+#@schema/desc "run_as_group specifies the group ID that will own the process, see the Dockerfile for the reasoning behind this choice"
+run_as_group: 65532
 
-#! Specify the API group suffix for all Pinniped API groups. By default, this is set to
-#! pinniped.dev, so Pinniped API groups will look like foo.pinniped.dev,
-#! authentication.concierge.pinniped.dev, etc. As an example, if this is set to tuna.io, then
-#! Pinniped API groups will look like foo.tuna.io. authentication.concierge.tuna.io, etc.
+#@ api_group_suffix_desc = "Specify the API group suffix for all Pinniped API groups. By default, this is set to \
+#@ pinniped.dev, so Pinniped API groups will look like foo.pinniped.dev, \
+#@ authentication.concierge.pinniped.dev, etc. As an example, if this is set to tuna.io, then \
+#@ Pinniped API groups will look like foo.tuna.io. authentication.concierge.tuna.io, etc."
+#@schema/desc api_group_suffix_desc
 api_group_suffix: pinniped.dev
 
-#! Set the standard golang HTTPS_PROXY and NO_PROXY environment variables on the Supervisor containers.
-#! These will be used when the Supervisor makes backend-to-backend calls to upstream identity providers using HTTPS,
-#! e.g. when the Supervisor fetches discovery documents, JWKS keys, and tokens from an upstream OIDC Provider.
-#! The Supervisor never makes insecure HTTP calls, so there is no reason to set HTTP_PROXY.
-#! Optional.
-https_proxy: #! e.g. http://proxy.example.com
-no_proxy: "$(KUBERNETES_SERVICE_HOST),169.254.169.254,127.0.0.1,localhost,.svc,.cluster.local" #! do not proxy Kubernetes endpoints
+#@ https_proxy_desc = "Set the standard golang HTTPS_PROXY and NO_PROXY environment variables on the Supervisor containers. \
+#@ These will be used when the Supervisor makes backend-to-backend calls to upstream identity providers using HTTPS, \
+#@ e.g. when the Supervisor fetches discovery documents, JWKS keys, and tokens from an upstream OIDC Provider. \
+#@ The Supervisor never makes insecure HTTP calls, so there is no reason to set HTTP_PROXY. \
+#@ Optional."
+#@schema/desc https_proxy_desc
+#@schema/nullable
+https_proxy: http://proxy.example.com
+#@schema/desc "do not proxy Kubernetes endpoints"
+no_proxy: "$(KUBERNETES_SERVICE_HOST),169.254.169.254,127.0.0.1,localhost,.svc,.cluster.local"
 
 #! Control the HTTP and HTTPS listeners of the Supervisor.
 #!
@@ -118,16 +154,22 @@ no_proxy: "$(KUBERNETES_SERVICE_HOST),169.254.169.254,127.0.0.1,localhost,.svc,.
 #! Changing the HTTPS port number must be accompanied by matching changes to the service and deployment
 #! manifests. Changes to the HTTPS listener must be coordinated with the deployment health checks.
 #!
-#! Optional.
+#@schema/desc "Control the HTTP and HTTPS listeners of the Supervisor."
+#@schema/nullable
 endpoints:
+  https:
+    network: tcp
+    address: 1.2.3.4:5678
 
-#! Optionally override the validation on the endpoints.http value which checks that only loopback interfaces are used.
-#! When deprecated_insecure_accept_external_unencrypted_http_requests is true, the HTTP listener is allowed to bind to any
-#! interface, including interfaces that are listening for traffic from outside the pod. This value is being introduced
-#! to ease the transition to the new loopback interface validation for the HTTP port for any users who need more time
-#! to change their ingress strategy to avoid using plain HTTP into the Supervisor pods.
-#! This value is immediately deprecated upon its introduction. It will be removed in some future release, at which time
-#! traffic from outside the pod will need to be sent to the HTTPS listener instead, with no simple workaround available.
-#! Allowed values are true (boolean), "true" (string), false (boolean), and "false" (string). The default is false.
-#! Optional.
+#! deprecated_insecure_accept_external_unencrypted_http_requests_desc = "Optionally override the validation on the endpoints. \
+#! http value which checks that only loopback interfaces are used. \
+#! When deprecated_insecure_accept_external_unencrypted_http_requests is true, the HTTP listener is allowed to bind to any \
+#! interface, including interfaces that are listening for traffic from outside the pod. This value is being introduced \
+#! to ease the transition to the new loopback interface validation for the HTTP port for any users who need more time \
+#! to change their ingress strategy to avoid using plain HTTP into the Supervisor pods. \
+#! This value is immediately deprecated upon its introduction. It will be removed in some future release, at which time \
+#! traffic from outside the pod will need to be sent to the HTTPS listener instead, with no simple workaround available. \
+#! Allowed values are true (boolean), "true" (string), false (boolean), and "false" (string). The default is false. \
+#! Optional."
+#@schema/desc https_proxy_desc
 deprecated_insecure_accept_external_unencrypted_http_requests: false


### PR DESCRIPTION
To improve the values.yaml file by enhancing it into a schema (and to prepare for the Carvel package work) the following files are converted:
- supervisor/values.yaml
- concierge/values.yaml

The `openapi-v3` schema generation can be validated via:

```bash
# generate an openapi doc via the schema w/o error
ytt --file ./deploy/supervisor --data-values-schema-inspect --output openapi-v3
# generate an openapi doc via the schema w/o error
ytt --file ./deploy/supervisor --data-values-schema-inspect --output openapi-v3
```
⚠️ These should be dumped out into `./deploy/{supervisor,concierge}/` but not inside the `./deploy/{supervisor,concierge}/config` directories as `kapp` will be confused when deploying as they are not kubernetes resources.

The basic template generation can be validated via:

```bash
# output of supervisor templates render w/o error
ytt --file ./deploy/supervisor \
    --data-value "app_name=test-app-name" \
    --data-value "namespace=test-app-namespace" \
    --data-value "api_group_suffix=pinnnnnnnipeeeed.dev" \
    --data-value "image_repo=pinniped.local/test/build/tttteeeessst" \
    --data-value "image_tag=12345" \
    --data-value "log_level=debug" \
    --data-value-yaml "custom_labels={}" \
    --data-value-yaml "service_https_nodeport_port=1234" \
    --data-value-yaml "service_https_nodeport_nodeport=4567" \
    --data-value-yaml "service_https_clusterip_port=8901"

# output of concierge templates render w/o error
ytt --file ./deploy/concierge \
    --data-value "app_name=test-app-name" \
    --data-value "namespace=test-app-namespace" \
    --data-value "api_group_suffix=pinnnnnnnipeeeed.dev" \
    --data-value "log_level=debug" \
    --data-value-yaml "custom_labels={}" \
    --data-value "image_repo=pinniped.local/test/build/tttteeeessst" \
    --data-value "image_tag=12345" \
    --data-value "discovery_url=1.2.3.4.5:7891"
```


The real test now is:
- [x] Run the above `ytt` against `main` and this branch for `supervisor` and diff the files.  We want the same (or perhaps close, with documented differences) output.
 - [x] Run the above `ytt` against `main` and this branch for `concierge` and diff the files.  We want the same (or perhaps close, with documented differences) output.

Open:
- [ ] Should we generate and save the `openapi-v3` schema files as well for both supervisor and concierge?  It is generally expected to be included in a Package. 
- [ ] Should we add something to CI to ensure that the `openapi-v3` generation is done and kept up to date?

