### PR TITLE
Fix deadlock during shutdown which prevented leader election cleanup

### DIFF
--- a/internal/concierge/apiserver/apiserver.go
+++ b/internal/concierge/apiserver/apiserver.go
@@ -107,39 +107,45 @@ func (c completedConfig) New() (*PinnipedServer, error) {
 		return nil, fmt.Errorf("could not install API groups: %w", err)
 	}
 
-	shutdown := &sync.WaitGroup{}
+	controllersShutdownWaitGroup := &sync.WaitGroup{}
+	controllersCtx, cancelControllerCtx := context.WithCancel(context.Background())
+
 	s.GenericAPIServer.AddPostStartHookOrDie("start-controllers",
 		func(postStartContext genericapiserver.PostStartHookContext) error {
 			plog.Debug("start-controllers post start hook starting")
+			defer plog.Debug("start-controllers post start hook completed")
 
-			ctx, cancel := context.WithCancel(context.Background())
-			go func() {
-				defer cancel()
-
-				<-postStartContext.StopCh
-			}()
-
-			runControllers, err := c.ExtraConfig.BuildControllersPostStartHook(ctx)
+			runControllers, err := c.ExtraConfig.BuildControllersPostStartHook(controllersCtx)
 			if err != nil {
 				return fmt.Errorf("cannot create run controller func: %w", err)
 			}
 
-			shutdown.Add(1)
+			controllersShutdownWaitGroup.Add(1)
 			go func() {
-				defer shutdown.Done()
+				// When this goroutine ends, then also end the WaitGroup, allowing anyone who called Wait() to proceed.
+				defer controllersShutdownWaitGroup.Done()
 
-				runControllers(ctx)
+				// Start the controllers and block until their context is cancelled and they have shut down.
+				runControllers(controllersCtx)
+				plog.Debug("start-controllers post start hook's background goroutine saw runControllers() finish")
 			}()
 
 			return nil
 		},
 	)
+
 	s.GenericAPIServer.AddPreShutdownHookOrDie("stop-controllers",
 		func() error {
 			plog.Debug("stop-controllers pre shutdown hook starting")
 			defer plog.Debug("stop-controllers pre shutdown hook completed")
 
-			shutdown.Wait()
+			// The generic api server is telling us that it wants to shut down, so tell our controllers that we
+			// want them to shut down by cancelling their context.
+			cancelControllerCtx()
+
+			// Now wait for the controllers to finish shutting down. By blocking here, we prevent the generic api server's
+			// graceful shutdown process from continuing until we are finished shutting down our own controllers.
+			controllersShutdownWaitGroup.Wait()
 
 			return nil
 		},

--- a/internal/controllerlib/controller.go
+++ b/internal/controllerlib/controller.go
@@ -1,4 +1,4 @@
-// Copyright 2020 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package controllerlib
@@ -102,6 +102,7 @@ func (c *controller) Run(ctx context.Context, workers int) {
 	workerContext, workerContextCancel := context.WithCancel(context.Background())
 
 	defer func() {
+		plog.Debug("starting to shut down controller workers", "controller", c.Name(), "workers", workers)
 		c.queue.ShutDown()    // shutdown the controller queue first
 		workerContextCancel() // cancel the worker context, which tell workers to initiate shutdown
 
@@ -126,7 +127,9 @@ func (c *controller) Run(ctx context.Context, workers int) {
 		}()
 	}
 
+	plog.Debug("controller started", "controller", c.Name(), "workers", workers)
 	<-ctx.Done() // wait for controller context to be cancelled
+	plog.Debug("controller context cancelled, next will terminate workers", "controller", c.Name(), "workers", workers)
 }
 
 func (c *controller) invokeAllRunOpts() {

--- a/internal/leaderelection/leaderelection.go
+++ b/internal/leaderelection/leaderelection.go
@@ -98,6 +98,7 @@ func New(podInfo *downward.PodInfo, deployment *appsv1.Deployment, opts ...kubec
 
 		go func() {
 			controllers(ctx) // run the controllers with the global context, this blocks until the context is canceled
+			plog.Debug("leader election saw controllers have stopped")
 
 			if isLeader.stop() { // remove our in-memory leader status before we release the lock
 				plog.Debug("leader lost", "identity", identity, "reason", "controller stop")

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package integration
@@ -65,8 +65,8 @@ func splitIntegrationTestsIntoBuckets(m *testing.M) {
 	serialTest := testing.InternalTest{
 		Name: "TestIntegrationSerial",
 		F: func(t *testing.T) {
-			_ = testlib.IntegrationEnv(t) // make sure these tests do not run during unit tests
-			t.Parallel()                  // outer test always runs in parallel for this bucket
+			testlib.SkipUnlessIntegration(t) // make sure these tests do not run during unit tests
+			t.Parallel()                     // outer test always runs in parallel for this bucket
 
 			for _, test := range serialTests {
 				test := test
@@ -80,8 +80,8 @@ func splitIntegrationTestsIntoBuckets(m *testing.M) {
 	parallelTest := testing.InternalTest{
 		Name: "TestIntegrationParallel",
 		F: func(t *testing.T) {
-			_ = testlib.IntegrationEnv(t) // make sure these tests do not run during unit tests
-			t.Parallel()                  // outer test always runs in parallel for this bucket
+			testlib.SkipUnlessIntegration(t) // make sure these tests do not run during unit tests
+			t.Parallel()                     // outer test always runs in parallel for this bucket
 
 			for _, test := range parallelTests {
 				test := test
@@ -97,7 +97,7 @@ func splitIntegrationTestsIntoBuckets(m *testing.M) {
 	disruptiveTest := testing.InternalTest{
 		Name: "TestIntegrationDisruptive",
 		F: func(t *testing.T) {
-			_ = testlib.IntegrationEnv(t) // make sure these tests do not run during unit tests
+			testlib.SkipUnlessIntegration(t) // make sure these tests do not run during unit tests
 			// outer test never runs in parallel for this bucket
 
 			for _, test := range disruptiveTests {

--- a/test/integration/pod_shutdown_test.go
+++ b/test/integration/pod_shutdown_test.go
@@ -1,0 +1,232 @@
+// Copyright 2023 the Pinniped contributors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/strings/slices"
+
+	"go.pinniped.dev/test/testlib"
+)
+
+// TestPodShutdown_Disruptive is intended to test that the Supervisor and Concierge pods can
+// perform a graceful shutdown. Most importantly, the leader pods should give up their leases
+// before they die.
+// Never run this test in parallel since deleting the pods is disruptive, see main_test.go.
+func TestPodShutdown_Disruptive(t *testing.T) {
+	// Only run this test in CI on Kind clusters, because something about restarting the pods
+	// in this test breaks the "kubectl port-forward" commands that we are using in CI for
+	// AKS, EKS, and GKE clusters. The Go code that we wrote for graceful pod shutdown should
+	// not be sensitive to which distribution it runs on, so running this test only on Kind
+	// should give us sufficient coverage for what we are trying to test here.
+	env := testlib.IntegrationEnv(t, testlib.SkipPodRestartAssertions()).
+		WithKubeDistribution(testlib.KindDistro)
+
+	testShutdownAllPodsOfApp(t, env, env.ConciergeNamespace, env.ConciergeAppName, "-kube-cert-agent-")
+	testShutdownAllPodsOfApp(t, env, env.SupervisorNamespace, env.SupervisorAppName, "")
+}
+
+func testShutdownAllPodsOfApp(t *testing.T, env *testlib.TestEnv, namespace string, appName string, ignorePodsWithNameSubstring string) {
+	// Precondition: the app should have some pods running initially.
+	initialPods := getRunningPodsByNamePrefix(t, namespace, appName+"-", ignorePodsWithNameSubstring)
+	require.Greater(t, len(initialPods), 0)
+
+	// Precondition: the leader election lease should contain the name of one of the initial pods as the lease's holder.
+	waitForLeaderElectionLeaseToHaveHolderIdentity(t, namespace, appName,
+		func(holder string) bool { return holder != "" && slices.Contains(namesOfPods(initialPods), holder) }, 2*time.Minute)
+
+	// Start tailing the logs of all the pods in background goroutines. This struct will keep track
+	// of each background log tail.
+	type podLog struct {
+		pod        corev1.Pod    // which pod's logs are being tailed
+		tailDoneCh chan struct{} // this channel will be closed when it is safe to read from logsBuf
+		logsBuf    *bytes.Buffer // the text of the logs will be put in this buffer
+	}
+	podLogs := make([]*podLog, 0)
+	// Skip tailing pod logs for test runs that are using alternate group suffixes. There seems to be a bug in our
+	// kubeclient package which causes an "unable to find resp serialier" (sic) error for pod log API responses when
+	// the middleware is active. Since we do not tail pod logs in production code (or anywhere else at this time),
+	// we don't need to fix that bug right now just for this test.
+	if env.APIGroupSuffix == "pinniped.dev" {
+		// For each pod, start tailing its logs.
+		for _, pod := range initialPods {
+			tailDoneCh, logTailBuf := tailFollowPodLogs(t, pod)
+			podLogs = append(podLogs, &podLog{
+				pod:        pod,
+				tailDoneCh: tailDoneCh,
+				logsBuf:    logTailBuf,
+			})
+		}
+	}
+
+	// Scale down the deployment's number of replicas to 0, which will shut down all the pods.
+	originalScale := updateDeploymentScale(t, namespace, appName, 0)
+
+	// When the test is over, restore the deployment to the original scale.
+	t.Cleanup(func() {
+		updateDeploymentScale(t, namespace, appName, originalScale)
+
+		// Wait for all the new pods to be running.
+		var newPods []corev1.Pod
+		testlib.RequireEventually(t, func(requireEventually *require.Assertions) {
+			newPods = getRunningPodsByNamePrefix(t, namespace, appName+"-", ignorePodsWithNameSubstring)
+			requireEventually.Len(newPods, originalScale, "wanted pods to return to original scale")
+		}, 2*time.Minute, 200*time.Millisecond)
+
+		// After a short time, leader election should have finished and the lease should contain the name of
+		// one of the new pods as the lease's holder.
+		waitForLeaderElectionLeaseToHaveHolderIdentity(t, namespace, appName,
+			func(holder string) bool { return holder != "" && slices.Contains(namesOfPods(newPods), holder) }, 1*time.Minute)
+
+		t.Logf("new pod of Deployment %s/%s has acquired the leader election lease", namespace, appName)
+	})
+
+	// Double check: the deployment's previous scale should have equaled the actual number of running pods from
+	// the start of the test (before we scaled down).
+	require.Equal(t, len(initialPods), originalScale)
+
+	// Now that we have adjusted the scale to 0, the pods should go away.
+	// Our pods are intended to gracefully shut down within a few seconds, so fail unless it happens fairly quickly.
+	testlib.RequireEventually(t, func(requireEventually *require.Assertions) {
+		pods := getRunningPodsByNamePrefix(t, namespace, appName+"-", ignorePodsWithNameSubstring)
+		requireEventually.Len(pods, 0, "wanted no pods but found some")
+	}, 20*time.Second, 200*time.Millisecond)
+
+	// Look for some interesting log messages in each of the now-dead pod's logs, if we started tailing them above.
+	for _, pl := range podLogs {
+		// Wait for the logs of the now-dead pod to be finished collecting.
+		t.Logf("waiting for tail of pod logs for pod %q", pl.pod.Name)
+		<-pl.tailDoneCh
+		// Assert that the Kubernetes generic apiserver library has started and finished a graceful
+		// shutdown according to its log messages. This is to make sure that the whole graceful shutdown
+		// process was performed successfully and without being blocked.
+		require.Containsf(t, pl.logsBuf.String(), `"[graceful-termination] shutdown event","name":"ShutdownInitiated"`,
+			"did not find expected message in pod log for pod %q", pl.pod.Name)
+		require.Containsf(t, pl.logsBuf.String(), `"[graceful-termination] apiserver is exiting\n"`,
+			"did not find expected message in pod log for pod %q", pl.pod.Name)
+		t.Logf("found expected graceful-termination messages in the logs of pod %q", pl.pod.Name)
+	}
+
+	// The leader election lease should already contain the empty string as the holder, because the old leader
+	// pod should have given up the lease during its graceful shutdown.
+	waitForLeaderElectionLeaseToHaveHolderIdentity(t, namespace, appName,
+		func(holder string) bool { return holder == "" }, 200*time.Millisecond)
+}
+
+// Given a list of pods, return a list of their names.
+func namesOfPods(pods []corev1.Pod) []string {
+	names := make([]string, len(pods))
+	for i, pod := range pods {
+		names[i] = pod.Name
+	}
+	return names
+}
+
+func getRunningPodsByNamePrefix(
+	t *testing.T,
+	namespace string,
+	podNamePrefix string,
+	podNameExcludeSubstring string,
+) (foundPods []corev1.Pod) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+	client := testlib.NewKubernetesClientset(t)
+
+	pods, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+
+	for _, pod := range pods.Items {
+		if !strings.HasPrefix(pod.Name, podNamePrefix) {
+			continue
+		}
+		if podNameExcludeSubstring != "" && strings.Contains(pod.Name, podNameExcludeSubstring) {
+			continue
+		}
+		if pod.Status.Phase != corev1.PodRunning {
+			continue
+		}
+		foundPods = append(foundPods, pod)
+	}
+
+	return foundPods
+}
+
+func updateDeploymentScale(t *testing.T, namespace string, deploymentName string, newScale int) int {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+	client := testlib.NewKubernetesClientset(t)
+
+	initialScale, err := client.AppsV1().Deployments(namespace).GetScale(ctx, deploymentName, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	desiredScale := initialScale.DeepCopy()
+	desiredScale.Spec.Replicas = int32(newScale)
+	updatedScale, err := client.AppsV1().Deployments(namespace).UpdateScale(ctx, deploymentName, desiredScale, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	t.Logf("updated scale of Deployment %s/%s from %d to %d",
+		namespace, deploymentName, initialScale.Spec.Replicas, updatedScale.Spec.Replicas)
+
+	return int(initialScale.Spec.Replicas)
+}
+
+func tailFollowPodLogs(t *testing.T, pod corev1.Pod) (chan struct{}, *bytes.Buffer) {
+	t.Helper()
+	done := make(chan struct{})
+	var buf bytes.Buffer
+	client := testlib.NewKubernetesClientset(t)
+
+	go func() {
+		// At the end of this block, signal that we are done writing to the returned buf,
+		// so it is now safe to read the logs from the returned buf.
+		defer close(done)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+
+		req := client.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+			Follow: true, // keep streaming until completion
+		})
+
+		// This line should block until the pod dies or the context expires.
+		body, err := req.Stream(ctx)
+		require.NoError(t, err)
+
+		_, err = io.Copy(&buf, body)
+		require.NoError(t, err)
+
+		require.NoError(t, body.Close())
+	}()
+
+	return done, &buf
+}
+
+func waitForLeaderElectionLeaseToHaveHolderIdentity(
+	t *testing.T,
+	namespace string,
+	leaseName string,
+	holderIdentityPredicate func(string) bool,
+	waitDuration time.Duration,
+) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	client := testlib.NewKubernetesClientset(t)
+
+	testlib.RequireEventually(t, func(requireEventually *require.Assertions) {
+		lease, err := client.CoordinationV1().Leases(namespace).Get(ctx, leaseName, metav1.GetOptions{})
+		requireEventually.NoError(err)
+		requireEventually.True(holderIdentityPredicate(*lease.Spec.HolderIdentity))
+	}, waitDuration, 200*time.Millisecond)
+}

--- a/test/testlib/skip.go
+++ b/test/testlib/skip.go
@@ -1,12 +1,12 @@
-// Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package testlib
 
 import "testing"
 
-// skipUnlessIntegration skips the current test if `-short` has been passed to `go test`.
-func skipUnlessIntegration(t *testing.T) {
+// SkipUnlessIntegration skips the current test if `-short` has been passed to `go test`.
+func SkipUnlessIntegration(t *testing.T) {
 	t.Helper()
 
 	if testing.Short() {


### PR DESCRIPTION
Before this fix, the deadlock would prevent the leader pod from giving up its lease, which would make it take several minutes for new pods to be allowed to elect a new leader. During that time, no Pinniped controllers could write to the Kube API, so important resources were not being updated during that window. It would also make pod shutdown take about 1 minute.

After this fix, the leader gives up its lease immediately, and pod shutdown takes about 1 second. This improves restart/upgrade time and also fixes the problem where there was no leader for several minutes after a restart/upgrade.

The deadlock was between the post-start hook and the pre-shutdown hook. The pre-shutdown hook blocked until a certain background goroutine in the post-start hook finished, but that goroutine could not finish until the pre-shutdown hook finished. Thus, they were both blocked, waiting for each other infinitely. Eventually the process would be externally killed.

This deadlock was most likely introduced by some change in Kube's generic api server package related to how the many complex channels used during server shutdown interact with each other, and was not noticed when we upgraded to the version which introduced the change.

The bug first appears in Pinniped v0.18.0, in which the Kube libraries were updated from 0.23.6 to 0.24.1. The relevant code in Pinniped had no changes around the time of that release. However, the kube library changed to wait for the pre-shutdown hooks to finish before continuing the remainder of the shutdown process (see the file genericapiserver.go in [this diff](https://github.com/kubernetes/apiserver/compare/v0.23.6...v0.24.1#diff-8a9e80dac2f71f42eec6f73ac6ed84f4475dd82e00123e592d134c9d5a43ab7c)) thus creating this deadlock.

**Release note**:

```release-note
Fix a bug introduced in v0.18.0 which slowed down the shutdown of the Pinniped pods and prevented
the leader pod from releasing its lease, which caused it take take several minutes before replacement
Pinniped pods could regain the lease and become fully operational.
```
