### PR TITLE
Increase flexibility around the 'pinniped get kubeconfig' client-go credential plugin command 

### DIFF
--- a/cmd/pinniped/cmd/kubeconfig.go
+++ b/cmd/pinniped/cmd/kubeconfig.go
@@ -96,6 +96,7 @@ type getKubeconfigParams struct {
 	credentialCachePath       string
 	credentialCachePathSet    bool
 	installHint               string
+	pinnipedCliPath           string
 }
 
 type discoveryResponseScopesSupported struct {
@@ -151,6 +152,7 @@ func kubeconfigCommand(deps kubeconfigDeps) *cobra.Command {
 	f.StringVarP(&flags.outputPath, "output", "o", "", "Output file path (default: stdout)")
 	f.StringVar(&flags.generatedNameSuffix, "generated-name-suffix", "-pinniped", "Suffix to append to generated cluster, context, user kubeconfig entries")
 	f.StringVar(&flags.credentialCachePath, "credential-cache", "", "Path to cluster-specific credentials cache")
+	f.StringVar(&flags.pinnipedCliPath, "pinniped-cli-path", "", "Full path or executable name for the Pinniped CLI binary to be embedded in the resulting kubeconfig output (e.g. 'pinniped') (default: full path of the binary used to execute this command)")
 	f.StringVar(&flags.installHint, "install-hint", "The pinniped CLI does not appear to be installed.  See https://get.pinniped.dev/cli for more details", "This text is shown to the user when the pinniped CLI is not installed.")
 	mustMarkHidden(cmd, "oidc-debug-session-cache")
 
@@ -268,7 +270,12 @@ func newExecConfig(deps kubeconfigDeps, flags getKubeconfigParams) (*clientcmdap
 
 	execConfig.InstallHint = flags.installHint
 	var err error
-	execConfig.Command, err = deps.getPathToSelf()
+	execConfig.Command, err = func() (string, error) {
+		if flags.pinnipedCliPath != "" {
+			return flags.pinnipedCliPath, nil
+		}
+		return deps.getPathToSelf()
+	}()
 	if err != nil {
 		return nil, fmt.Errorf("could not determine the Pinniped executable path: %w", err)
 	}

--- a/cmd/pinniped/cmd/kubeconfig.go
+++ b/cmd/pinniped/cmd/kubeconfig.go
@@ -154,13 +154,14 @@ func kubeconfigCommand(deps kubeconfigDeps) *cobra.Command {
 	f.StringVar(&flags.credentialCachePath, "credential-cache", "", "Path to cluster-specific credentials cache")
 	f.StringVar(&flags.pinnipedCliPath, "pinniped-cli-path", "", "Full path or executable name for the Pinniped CLI binary to be embedded in the resulting kubeconfig output (e.g. 'pinniped') (default: full path of the binary used to execute this command)")
 	f.StringVar(&flags.installHint, "install-hint", "The pinniped CLI does not appear to be installed.  See https://get.pinniped.dev/cli for more details", "This text is shown to the user when the pinniped CLI is not installed.")
-	mustMarkHidden(cmd, "oidc-debug-session-cache")
 
-	// --oidc-skip-listen is mainly needed for testing. We'll leave it hidden until we have a non-testing use case.
-	mustMarkHidden(cmd, "oidc-skip-listen")
+	mustMarkHidden(cmd,
+		"oidc-debug-session-cache",
+		"oidc-skip-listen", // --oidc-skip-listen is mainly needed for testing. We'll leave it hidden until we have a non-testing use case.
+		"concierge-namespace",
+	)
 
 	mustMarkDeprecated(cmd, "concierge-namespace", "not needed anymore")
-	mustMarkHidden(cmd, "concierge-namespace")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		if flags.outputPath != "" {

--- a/cmd/pinniped/cmd/kubeconfig_test.go
+++ b/cmd/pinniped/cmd/kubeconfig_test.go
@@ -147,6 +147,7 @@ func TestGetKubeconfig(t *testing.T) {
 				      --oidc-session-cache string                Path to OpenID Connect session cache file
 				      --oidc-skip-browser                        During OpenID Connect login, skip opening the browser (just print the URL)
 				  -o, --output string                            Output file path (default: stdout)
+				      --pinniped-cli-path string                 Full path or executable name for the Pinniped CLI binary to be embedded in the resulting kubeconfig output (e.g. 'pinniped') (default: full path of the binary used to execute this command)
 				      --skip-validation                          Skip final validation of the kubeconfig (default: false)
 				      --static-token string                      Instead of doing an OIDC-based login, specify a static token
 				      --static-token-env string                  Instead of doing an OIDC-based login, read a static token from the environment
@@ -1583,7 +1584,6 @@ func TestGetKubeconfig(t *testing.T) {
 			},
 		},
 		{
-
 			name: "autodetect nothing, set a bunch of options",
 			args: func(issuerCABundle string, issuerURL string) []string {
 				f := testutil.WriteStringToTempFile(t, "testca-*.pem", issuerCABundle)
@@ -1607,6 +1607,7 @@ func TestGetKubeconfig(t *testing.T) {
 					"--skip-validation",
 					"--generated-name-suffix", "-sso",
 					"--credential-cache", "/path/to/cache/dir/credentials.yaml",
+					"--pinniped-cli-path", "/some/path/to/command-exe",
 				}
 			},
 			conciergeObjects: func(issuerCABundle string, issuerURL string) []runtime.Object {
@@ -1658,7 +1659,7 @@ func TestGetKubeconfig(t *testing.T) {
 						  - --session-cache=/path/to/cache/dir/sessions.yaml
 						  - --debug-session-cache
 						  - --request-audience=test-audience
-						  command: '.../path/to/pinniped'
+						  command: /some/path/to/command-exe
 						  env: []
 						  installHint: The pinniped CLI does not appear to be installed.  See https://get.pinniped.dev/cli
 						    for more details


### PR DESCRIPTION
Increase flexibility around the 'pinniped get kubeconfig' client-go credential plugin command 


[#184673465](https://www.pivotaltracker.com/story/show/184673465)