### PR TITLE
Display IDP name when prompting for username and password

### DIFF
--- a/pkg/oidcclient/login.go
+++ b/pkg/oidcclient/login.go
@@ -56,8 +56,8 @@ const (
 	// we set this to be relatively long.
 	overallTimeout = 90 * time.Minute
 
-	defaultLDAPUsernamePrompt = "Username: "
-	defaultLDAPPasswordPrompt = "Password: "
+	usernamePrompt = "Username: "
+	passwordPrompt = "Password: "
 
 	// For CLI-based auth, such as with LDAP upstream identity providers, the user may use these environment variables
 	// to avoid getting interactively prompted for username and password.
@@ -513,7 +513,7 @@ func (h *handlerState) getUsernameAndPassword() (string, string, error) {
 
 	username := h.getEnv(defaultUsernameEnvVarName)
 	if username == "" {
-		username, err = h.promptForValue(h.ctx, defaultLDAPUsernamePrompt)
+		username, err = h.promptForValue(h.ctx, usernamePrompt)
 		if err != nil {
 			return "", "", fmt.Errorf("error prompting for username: %w", err)
 		}
@@ -523,7 +523,7 @@ func (h *handlerState) getUsernameAndPassword() (string, string, error) {
 
 	password := h.getEnv(defaultPasswordEnvVarName)
 	if password == "" {
-		password, err = h.promptForSecret(defaultLDAPPasswordPrompt)
+		password, err = h.promptForSecret(passwordPrompt)
 		if err != nil {
 			return "", "", fmt.Errorf("error prompting for password: %w", err)
 		}

--- a/pkg/oidcclient/login.go
+++ b/pkg/oidcclient/login.go
@@ -513,6 +513,10 @@ func (h *handlerState) cliBasedAuth(authorizeOptions *[]oauth2.AuthCodeOption) (
 func (h *handlerState) getUsernameAndPassword() (string, string, error) {
 	var err error
 
+	if h.upstreamIdentityProviderName != "" {
+		_, _ = fmt.Fprintf(h.out, "\nLog in to %s\n\n", h.upstreamIdentityProviderName)
+	}
+
 	username := h.getEnv(defaultUsernameEnvVarName)
 	if username == "" {
 		username, err = h.promptForValue(h.ctx, usernamePrompt, h.out)

--- a/pkg/oidcclient/login.go
+++ b/pkg/oidcclient/login.go
@@ -78,6 +78,7 @@ type handlerState struct {
 	clientID string
 	scopes   []string
 	cache    SessionCache
+	out      io.Writer
 
 	upstreamIdentityProviderName string
 	upstreamIdentityProviderType string
@@ -109,8 +110,8 @@ type handlerState struct {
 	isTTY           func(int) bool
 	getProvider     func(*oauth2.Config, *coreosoidc.Provider, *http.Client) upstreamprovider.UpstreamOIDCIdentityProviderI
 	validateIDToken func(ctx context.Context, provider *coreosoidc.Provider, audience string, token string) (*coreosoidc.IDToken, error)
-	promptForValue  func(ctx context.Context, promptLabel string) (string, error)
-	promptForSecret func(promptLabel string) (string, error)
+	promptForValue  func(ctx context.Context, promptLabel string, out io.Writer) (string, error)
+	promptForSecret func(promptLabel string, out io.Writer) (string, error)
 
 	callbacks chan callbackResult
 }
@@ -292,6 +293,7 @@ func Login(issuer string, clientID string, opts ...Option) (*oidctypes.Token, er
 		},
 		promptForValue:  promptForValue,
 		promptForSecret: promptForSecret,
+		out:             os.Stderr,
 	}
 	for _, opt := range opts {
 		if err := opt(&h); err != nil {
@@ -513,7 +515,7 @@ func (h *handlerState) getUsernameAndPassword() (string, string, error) {
 
 	username := h.getEnv(defaultUsernameEnvVarName)
 	if username == "" {
-		username, err = h.promptForValue(h.ctx, usernamePrompt)
+		username, err = h.promptForValue(h.ctx, usernamePrompt, h.out)
 		if err != nil {
 			return "", "", fmt.Errorf("error prompting for username: %w", err)
 		}
@@ -523,7 +525,7 @@ func (h *handlerState) getUsernameAndPassword() (string, string, error) {
 
 	password := h.getEnv(defaultPasswordEnvVarName)
 	if password == "" {
-		password, err = h.promptForSecret(passwordPrompt)
+		password, err = h.promptForSecret(passwordPrompt, h.out)
 		if err != nil {
 			return "", "", fmt.Errorf("error prompting for password: %w", err)
 		}
@@ -581,7 +583,7 @@ func (h *handlerState) webBrowserBasedAuth(authorizeOptions *[]oauth2.AuthCodeOp
 
 	// Prompt the user to visit the authorize URL, and to paste a manually-copied auth code (if possible).
 	ctx, cancel := context.WithCancel(h.ctx)
-	cleanupPrompt := h.promptForWebLogin(ctx, authorizeURL, os.Stderr)
+	cleanupPrompt := h.promptForWebLogin(ctx, authorizeURL)
 	defer func() {
 		cancel()
 		cleanupPrompt()
@@ -599,8 +601,8 @@ func (h *handlerState) webBrowserBasedAuth(authorizeOptions *[]oauth2.AuthCodeOp
 	}
 }
 
-func (h *handlerState) promptForWebLogin(ctx context.Context, authorizeURL string, out io.Writer) func() {
-	_, _ = fmt.Fprintf(out, "Log in by visiting this link:\n\n    %s\n\n", authorizeURL)
+func (h *handlerState) promptForWebLogin(ctx context.Context, authorizeURL string) func() {
+	_, _ = fmt.Fprintf(h.out, "Log in by visiting this link:\n\n    %s\n\n", authorizeURL)
 
 	// If stdin is not a TTY, print the URL but don't prompt for the manual paste,
 	// since we have no way of reading it.
@@ -621,15 +623,15 @@ func (h *handlerState) promptForWebLogin(ctx context.Context, authorizeURL strin
 	go func() {
 		defer func() {
 			// Always emit a newline so the kubectl output is visually separated from the login prompts.
-			_, _ = fmt.Fprintln(os.Stderr)
+			_, _ = fmt.Fprintln(h.out)
 
 			wg.Done()
 		}()
-		code, err := h.promptForValue(ctx, "    Optionally, paste your authorization code: ")
+		code, err := h.promptForValue(ctx, "    Optionally, paste your authorization code: ", h.out)
 		if err != nil {
 			// Print a visual marker to show the the prompt is no longer waiting for user input, plus a trailing
 			// newline that simulates the user having pressed "enter".
-			_, _ = fmt.Fprint(os.Stderr, "[...]\n")
+			_, _ = fmt.Fprint(h.out, "[...]\n")
 
 			h.callbacks <- callbackResult{err: fmt.Errorf("failed to prompt for manual authorization code: %v", err)}
 			return
@@ -642,11 +644,11 @@ func (h *handlerState) promptForWebLogin(ctx context.Context, authorizeURL strin
 	return wg.Wait
 }
 
-func promptForValue(ctx context.Context, promptLabel string) (string, error) {
+func promptForValue(ctx context.Context, promptLabel string, out io.Writer) (string, error) {
 	if !term.IsTerminal(stdin()) {
 		return "", errors.New("stdin is not connected to a terminal")
 	}
-	_, err := fmt.Fprint(os.Stderr, promptLabel)
+	_, err := fmt.Fprint(out, promptLabel)
 	if err != nil {
 		return "", fmt.Errorf("could not print prompt to stderr: %w", err)
 	}
@@ -674,11 +676,11 @@ func promptForValue(ctx context.Context, promptLabel string) (string, error) {
 	}
 }
 
-func promptForSecret(promptLabel string) (string, error) {
+func promptForSecret(promptLabel string, out io.Writer) (string, error) {
 	if !term.IsTerminal(stdin()) {
 		return "", errors.New("stdin is not connected to a terminal")
 	}
-	_, err := fmt.Fprint(os.Stderr, promptLabel)
+	_, err := fmt.Fprint(out, promptLabel)
 	if err != nil {
 		return "", fmt.Errorf("could not print prompt to stderr: %w", err)
 	}
@@ -689,7 +691,7 @@ func promptForSecret(promptLabel string) (string, error) {
 	// term.ReadPassword swallows the newline that was typed by the user, so to
 	// avoid the next line of output from happening on same line as the password
 	// prompt, we need to print a newline.
-	_, err = fmt.Fprint(os.Stderr, "\n")
+	_, err = fmt.Fprint(out, "\n")
 	if err != nil {
 		return "", fmt.Errorf("could not print newline to stderr: %w", err)
 	}

--- a/pkg/oidcclient/login_test.go
+++ b/pkg/oidcclient/login_test.go
@@ -1080,9 +1080,10 @@ func TestLogin(t *testing.T) { //nolint:gocyclo
 					return nil
 				}
 			},
-			issuer:   successServer.URL,
-			wantLogs: []string{"\"level\"=4 \"msg\"=\"Pinniped: Performing OIDC discovery\"  \"issuer\"=\"" + successServer.URL + "\""},
-			wantErr:  "error prompting for username: some prompt error",
+			issuer:     successServer.URL,
+			wantLogs:   []string{"\"level\"=4 \"msg\"=\"Pinniped: Performing OIDC discovery\"  \"issuer\"=\"" + successServer.URL + "\""},
+			wantStdErr: "^\nLog in to some-upstream-name\n\n$",
+			wantErr:    "error prompting for username: some prompt error",
 		},
 		{
 			name:     "ldap login when prompting for password returns an error",
@@ -1094,9 +1095,10 @@ func TestLogin(t *testing.T) { //nolint:gocyclo
 					return nil
 				}
 			},
-			issuer:   successServer.URL,
-			wantLogs: []string{"\"level\"=4 \"msg\"=\"Pinniped: Performing OIDC discovery\"  \"issuer\"=\"" + successServer.URL + "\""},
-			wantErr:  "error prompting for password: some prompt error",
+			issuer:     successServer.URL,
+			wantLogs:   []string{"\"level\"=4 \"msg\"=\"Pinniped: Performing OIDC discovery\"  \"issuer\"=\"" + successServer.URL + "\""},
+			wantStdErr: "^\nLog in to some-upstream-name\n\n$",
+			wantErr:    "error prompting for password: some prompt error",
 		},
 		{
 			name:     "ldap login when there is a problem with parsing the authorize URL",
@@ -1149,8 +1151,9 @@ func TestLogin(t *testing.T) { //nolint:gocyclo
 					return defaultLDAPTestOpts(t, h, nil, errors.New("some error fetching authorize endpoint"))
 				}
 			},
-			issuer:   successServer.URL,
-			wantLogs: []string{"\"level\"=4 \"msg\"=\"Pinniped: Performing OIDC discovery\"  \"issuer\"=\"" + successServer.URL + "\""},
+			issuer:     successServer.URL,
+			wantLogs:   []string{"\"level\"=4 \"msg\"=\"Pinniped: Performing OIDC discovery\"  \"issuer\"=\"" + successServer.URL + "\""},
+			wantStdErr: "^\nLog in to some-upstream-name\n\n$",
 			wantErr: `authorization response error: Get "https://` + successServer.Listener.Addr().String() +
 				`/authorize?access_type=offline&client_id=test-client-id&code_challenge=` + testCodeChallenge +
 				`&code_challenge_method=S256&nonce=test-nonce&pinniped_idp_name=some-upstream-name&` +
@@ -1165,9 +1168,10 @@ func TestLogin(t *testing.T) { //nolint:gocyclo
 					return defaultLDAPTestOpts(t, h, &http.Response{StatusCode: http.StatusBadGateway, Status: "502 Bad Gateway"}, nil)
 				}
 			},
-			issuer:   successServer.URL,
-			wantLogs: []string{"\"level\"=4 \"msg\"=\"Pinniped: Performing OIDC discovery\"  \"issuer\"=\"" + successServer.URL + "\""},
-			wantErr:  `error getting authorization: expected to be redirected, but response status was 502 Bad Gateway`,
+			issuer:     successServer.URL,
+			wantLogs:   []string{"\"level\"=4 \"msg\"=\"Pinniped: Performing OIDC discovery\"  \"issuer\"=\"" + successServer.URL + "\""},
+			wantStdErr: "^\nLog in to some-upstream-name\n\n$",
+			wantErr:    `error getting authorization: expected to be redirected, but response status was 502 Bad Gateway`,
 		},
 		{
 			name:     "ldap login when the OIDC provider authorization endpoint redirect has an error and error description",
@@ -1182,9 +1186,10 @@ func TestLogin(t *testing.T) { //nolint:gocyclo
 					}, nil)
 				}
 			},
-			issuer:   successServer.URL,
-			wantLogs: []string{"\"level\"=4 \"msg\"=\"Pinniped: Performing OIDC discovery\"  \"issuer\"=\"" + successServer.URL + "\""},
-			wantErr:  `login failed with code "access_denied": optional-error-description`,
+			issuer:     successServer.URL,
+			wantLogs:   []string{"\"level\"=4 \"msg\"=\"Pinniped: Performing OIDC discovery\"  \"issuer\"=\"" + successServer.URL + "\""},
+			wantStdErr: "^\nLog in to some-upstream-name\n\n$",
+			wantErr:    `login failed with code "access_denied": optional-error-description`,
 		},
 		{
 			name:     "ldap login when the OIDC provider authorization endpoint redirects us to a different server",
@@ -1199,9 +1204,10 @@ func TestLogin(t *testing.T) { //nolint:gocyclo
 					}, nil)
 				}
 			},
-			issuer:   successServer.URL,
-			wantLogs: []string{"\"level\"=4 \"msg\"=\"Pinniped: Performing OIDC discovery\"  \"issuer\"=\"" + successServer.URL + "\""},
-			wantErr:  `error getting authorization: redirected to the wrong location: http://other-server.example.com/callback?code=foo&state=test-state`,
+			issuer:     successServer.URL,
+			wantLogs:   []string{"\"level\"=4 \"msg\"=\"Pinniped: Performing OIDC discovery\"  \"issuer\"=\"" + successServer.URL + "\""},
+			wantStdErr: "^\nLog in to some-upstream-name\n\n$",
+			wantErr:    `error getting authorization: redirected to the wrong location: http://other-server.example.com/callback?code=foo&state=test-state`,
 		},
 		{
 			name:     "ldap login when the OIDC provider authorization endpoint redirect has an error but no error description",
@@ -1216,9 +1222,10 @@ func TestLogin(t *testing.T) { //nolint:gocyclo
 					}, nil)
 				}
 			},
-			issuer:   successServer.URL,
-			wantLogs: []string{"\"level\"=4 \"msg\"=\"Pinniped: Performing OIDC discovery\"  \"issuer\"=\"" + successServer.URL + "\""},
-			wantErr:  `login failed with code "access_denied"`,
+			issuer:     successServer.URL,
+			wantLogs:   []string{"\"level\"=4 \"msg\"=\"Pinniped: Performing OIDC discovery\"  \"issuer\"=\"" + successServer.URL + "\""},
+			wantStdErr: "^\nLog in to some-upstream-name\n\n$",
+			wantErr:    `login failed with code "access_denied"`,
 		},
 		{
 			name:     "ldap login when the OIDC provider authorization endpoint redirect has the wrong state value",
@@ -1231,9 +1238,10 @@ func TestLogin(t *testing.T) { //nolint:gocyclo
 					}, nil)
 				}
 			},
-			issuer:   successServer.URL,
-			wantLogs: []string{"\"level\"=4 \"msg\"=\"Pinniped: Performing OIDC discovery\"  \"issuer\"=\"" + successServer.URL + "\""},
-			wantErr:  `missing or invalid state parameter in authorization response: http://127.0.0.1:0/callback?code=foo&state=wrong-state`,
+			issuer:     successServer.URL,
+			wantLogs:   []string{"\"level\"=4 \"msg\"=\"Pinniped: Performing OIDC discovery\"  \"issuer\"=\"" + successServer.URL + "\""},
+			wantStdErr: "^\nLog in to some-upstream-name\n\n$",
+			wantErr:    `missing or invalid state parameter in authorization response: http://127.0.0.1:0/callback?code=foo&state=wrong-state`,
 		},
 		{
 			name:     "ldap login when there is an error exchanging the authcode or validating the tokens",
@@ -1258,9 +1266,10 @@ func TestLogin(t *testing.T) { //nolint:gocyclo
 					return nil
 				}
 			},
-			issuer:   successServer.URL,
-			wantLogs: []string{"\"level\"=4 \"msg\"=\"Pinniped: Performing OIDC discovery\"  \"issuer\"=\"" + successServer.URL + "\""},
-			wantErr:  "could not complete authorization code exchange: some authcode exchange or token validation error",
+			issuer:     successServer.URL,
+			wantLogs:   []string{"\"level\"=4 \"msg\"=\"Pinniped: Performing OIDC discovery\"  \"issuer\"=\"" + successServer.URL + "\""},
+			wantStdErr: "^\nLog in to some-upstream-name\n\n$",
+			wantErr:    "could not complete authorization code exchange: some authcode exchange or token validation error",
 		},
 		{
 			name:     "successful ldap login with prompts for username and password",
@@ -1356,9 +1365,10 @@ func TestLogin(t *testing.T) { //nolint:gocyclo
 					return nil
 				}
 			},
-			issuer:    successServer.URL,
-			wantLogs:  []string{"\"level\"=4 \"msg\"=\"Pinniped: Performing OIDC discovery\"  \"issuer\"=\"" + successServer.URL + "\""},
-			wantToken: &testToken,
+			issuer:     successServer.URL,
+			wantLogs:   []string{"\"level\"=4 \"msg\"=\"Pinniped: Performing OIDC discovery\"  \"issuer\"=\"" + successServer.URL + "\""},
+			wantStdErr: "^\nLog in to some-upstream-name\n\n$",
+			wantToken:  &testToken,
 		},
 		{
 			name:     "successful ldap login with env vars for username and password",
@@ -1572,7 +1582,8 @@ func TestLogin(t *testing.T) { //nolint:gocyclo
 				"\"level\"=4 \"msg\"=\"Pinniped: Read username from environment variable\"  \"name\"=\"PINNIPED_USERNAME\"",
 				"\"level\"=4 \"msg\"=\"Pinniped: Read password from environment variable\"  \"name\"=\"PINNIPED_PASSWORD\"",
 			},
-			wantToken: &testToken,
+			wantStdErr: "^\nLog in to some-upstream-name\n\n$",
+			wantToken:  &testToken,
 		},
 		{
 			name:     "with requested audience, session cache hit with valid token, but discovery fails",


### PR DESCRIPTION
[#181927293](https://www.pivotaltracker.com/story/show/181927293)

Note that this PR only shows the IDP name (if provided to `pinniped login oidc` via `--upstream-identity-provider-name`), and does not perform any verification that the user's login flags will result in a acceptable configuration.