### PR TITLE
Stop using deprecated critical-pod annotation

### DIFF
--- a/deploy/concierge/deployment.yaml
+++ b/deploy/concierge/deployment.yaml
@@ -1,4 +1,4 @@
-#! Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
+#! Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
 #! SPDX-License-Identifier: Apache-2.0
 
 #@ load("@ytt:data", "data")
@@ -134,8 +134,6 @@ spec:
         #! More recently added the more unique deploymentPodLabel() so Services can select these Pods more specifically
         #! without accidentally selecting any other Deployment's Pods, especially the kube cert agent Deployment's Pods.
         _: #@ template.replace(deploymentPodLabel())
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
       securityContext:
         runAsUser: #@ data.values.run_as_user
@@ -247,9 +245,6 @@ spec:
           effect: NoSchedule
         - key: node-role.kubernetes.io/control-plane #! The new name for these nodes as of Kubernetes 1.24.
           effect: NoSchedule
-      #! "system-cluster-critical" cannot be used outside the kube-system namespace until Kubernetes >= 1.17,
-      #! so we skip setting this for now (see https://github.com/kubernetes/kubernetes/issues/60596).
-      #!priorityClassName: system-cluster-critical
       #! This will help make sure our multiple pods run on different nodes, making
       #! our deployment "more" "HA".
       affinity:


### PR DESCRIPTION
The Concierge pods were previously marked as critical pods using the annotation `scheduler.alpha.kubernetes.io/critical-pod`.

- `scheduler.alpha.kubernetes.io/critical-pod` annotation was removed in Kube 1.16. See https://kubernetes.io/docs/reference/labels-annotations-taints/#scheduler-alpha-kubernetes-io-critical-pod-deprecated. So this annotation is not doing anything for us anymore.
- Kube 1.16 is 3 years beyond its end of life date, so we don't care about supporting that version (or older versions) anymore. 

The first draft of this PR had replaced it with `priorityClassName: system-cluster-critical` on the Conciege pods.

- `critical-pod` was replaced by using a `priorityClassName`. See: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#how-to-use-priority-and-preemption.
- `priorityClassName` of `system-cluster-critical` could not be used outside the `kube-system` namespace until Kubernetes >= 1.17. See https://github.com/kubernetes/kubernetes/issues/60596. So we were not able to use this feature back when it was new.

However, that prevents Pinniped from deploying on GKE clusters due to GKE's quotas, so for now I am only removing the old `critical-pod` annotation (which was doing nothing anyways) and not replacing it with anything new. The Concierge has never used `priorityClassName` and seems to work fine without it, so I'm not too worried about adding it for this PR.

**Release note**:

```release-note
NONE
```
