### PR TITLE
Optionally use Contour in hack/prepare-supervisor-on-kind.sh

### DIFF
--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -5,9 +5,16 @@
 
 set -euo pipefail
 
-ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${ROOT}"
 
-# To choose a specific version of kube, add this option to the command below: `--image kindest/node:v1.28.0`.
-# To debug the kind config, add this option to the command below: `-v 10`
-kind create cluster --config "hack/lib/kind-config/single-node.yaml" --name pinniped
+if [[ "${PINNIPED_USE_CONTOUR:-}" != "" ]]; then
+  echo "Adding Contour port mapping to Kind config."
+  ytt -f "${ROOT}/hack/lib/kind-config/single-node.yaml" \
+    -f "${ROOT}/hack/lib/kind-config/contour-overlay.yaml" >/tmp/kind-config.yaml
+  kind create cluster --config /tmp/kind-config.yaml --name pinniped
+else
+  # To choose a specific version of kube, add this option to the command below: `--image kindest/node:v1.28.0`.
+  # To debug the kind config, add this option to the command below: `-v 10`
+  kind create cluster --config "hack/lib/kind-config/single-node.yaml" --name pinniped
+fi

--- a/hack/lib/kind-config/contour-overlay.yaml
+++ b/hack/lib/kind-config/contour-overlay.yaml
@@ -1,0 +1,16 @@
+#! Copyright 2023 the Pinniped contributors. All Rights Reserved.
+#! SPDX-License-Identifier: Apache-2.0
+
+#@ load("@ytt:overlay", "overlay")
+#@overlay/match by=overlay.subset({"kind": "Cluster"}), expects=1
+---
+#! Appends another port mapping to every node in the CLuster config.
+#! Contour will use this port mapping to expose the https endpoints
+#! of in-cluster apps at localhost:443 on your host.
+nodes:
+  #@overlay/match by=overlay.all, expects="1+"
+  - extraPortMappings:
+      - protocol: TCP
+        containerPort: 443
+        hostPort: 443
+        listenAddress: 127.0.0.1

--- a/hack/prepare-for-integration-tests.sh
+++ b/hack/prepare-for-integration-tests.sh
@@ -104,7 +104,7 @@ while (("$#")); do
     dockerfile_path=$1
     shift
     ;;
-  -d | --alternate-deploy)
+  --alternate-deploy)
     shift
     if [[ "$#" == "0" || "$1" == -* ]]; then
       log_error "--alternate-deploy requires a script path to be specified"
@@ -113,7 +113,7 @@ while (("$#")); do
     alternate_deploy=$1
     shift
     ;;
-  -p | --alternate-deploy-supervisor)
+  --alternate-deploy-supervisor)
     shift
     if [[ "$#" == "0" || "$1" == -* ]]; then
       log_error "--alternate-deploy-supervisor requires a script path to be specified"
@@ -122,7 +122,7 @@ while (("$#")); do
     alternate_deploy_supervisor=$1
     shift
     ;;
-  -c | --alternate-deploy-concierge)
+  --alternate-deploy-concierge)
     shift
     if [[ "$#" == "0" || "$1" == -* ]]; then
       log_error "--alternate-deploy-concierge requires a script path to be specified"
@@ -131,7 +131,7 @@ while (("$#")); do
     alternate_deploy_concierge=$1
     shift
     ;;
-  -l | --alternate-deploy-local-user-authenticator)
+  --alternate-deploy-local-user-authenticator)
     shift
     if [[ "$#" == "0" || "$1" == -* ]]; then
       log_error "--alternate-deploy-local-user-authenticator requires a script path to be specified"
@@ -165,10 +165,10 @@ if [[ "$help" == "yes" ]]; then
   log_note "   -g, --api-group-suffix:                            deploy Pinniped with an alternate API group suffix"
   log_note "   -s, --skip-build:                                  reuse the most recently built image of the app instead of building"
   log_note "   -a, --get-active-directory-vars:                   specify a script that exports active directory environment variables"
-  log_note "   -d, --alternate-deploy:                            specify an alternate deploy script to install each component of Pinniped (Supervisor, Concierge, local-user-authenticator)"
-  log_note "   -p, --alternate-deploy-supervisor:                 specify an alternate deploy script to install Pinniped Supervisor"
-  log_note "   -c, --alternate-deploy-concierge:                  specify an alternate deploy script to install Pinniped Concierge"
-  log_note "   -l, --alternate-deploy-local-user-authenticator:   specify an alternate deploy script to install Pinniped local-user-authenticator"
+  log_note "       --alternate-deploy:                            specify an alternate deploy script to install all components of Pinniped"
+  log_note "       --alternate-deploy-supervisor:                 specify an alternate deploy script to install Pinniped Supervisor"
+  log_note "       --alternate-deploy-concierge:                  specify an alternate deploy script to install Pinniped Concierge"
+  log_note "       --alternate-deploy-local-user-authenticator:   specify an alternate deploy script to install Pinniped local-user-authenticator"
   exit 1
 fi
 


### PR DESCRIPTION
Using Contour for ingress allows us to avoid using the hacky proxy server approach. This makes it easy to use any web browser to complete the login process, since there is no need to configure the proxy server for the browser.

Example usage:

```sh
PINNIPED_USE_CONTOUR=1 hack/prepare-for-integration-tests.sh -c
PINNIPED_USE_CONTOUR=1 hack/prepare-supervisor-on-kind.sh --oidc --ldap
```

This PR does not make using Contour the default behavior of these scripts. You need to use the `PINNIPED_USE_CONTOUR` environment variable as shown above to ask for Contour. The integration tests do not use or depend on Contour, so it seems appropriate for the default behavior of `prepare-for-integration-tests.sh` to also not configure anything for Contour.

This came about when I wanted to test logging in using Safari. It is very hard to configure Safari to use the local proxy server. This ended up being an easier solution.

**Release note**:

```release-note
NONE
```
