### PR TITLE
tolerate arm64 in tools deployments and jobs

### DIFF
--- a/test/deploy/tools/cert-issuer.yaml
+++ b/test/deploy/tools/cert-issuer.yaml
@@ -1,4 +1,4 @@
-#! Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+#! Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
 #! SPDX-License-Identifier: Apache-2.0
 
 #@ load("@ytt:data", "data")
@@ -126,3 +126,12 @@ spec:
       - name: certs
         emptyDir: {}
       restartPolicy: Never
+      tolerations:
+        - key: kubernetes.io/arch
+          effect: NoSchedule
+          operator: Equal
+          value: amd64 #! Allow running on amd64 nodes.
+        - key: kubernetes.io/arch
+          effect: NoSchedule
+          operator: Equal
+          value: arm64 #! Also allow running on arm64 nodes.

--- a/test/deploy/tools/dex.yaml
+++ b/test/deploy/tools/dex.yaml
@@ -1,4 +1,4 @@
-#! Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
+#! Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
 #! SPDX-License-Identifier: Apache-2.0
 
 #@ load("@ytt:data", "data")
@@ -94,6 +94,15 @@ spec:
       - name: certs
         secret:
           secretName: certs
+      tolerations:
+        - key: kubernetes.io/arch
+          effect: NoSchedule
+          operator: Equal
+          value: amd64 #! Allow running on amd64 nodes.
+        - key: kubernetes.io/arch
+          effect: NoSchedule
+          operator: Equal
+          value: arm64 #! Also allow running on arm64 nodes.
 ---
 apiVersion: v1
 kind: Service

--- a/test/deploy/tools/ldap.yaml
+++ b/test/deploy/tools/ldap.yaml
@@ -277,6 +277,15 @@ spec:
         - name: additional-schema
           secret:
             secretName: ldap-server-additional-schema-ldif-files
+      tolerations:
+        - key: kubernetes.io/arch
+          effect: NoSchedule
+          operator: Equal
+          value: amd64 #! Allow running on amd64 nodes.
+        - key: kubernetes.io/arch
+          effect: NoSchedule
+          operator: Equal
+          value: arm64 #! Also allow running on arm64 nodes.
 ---
 apiVersion: v1
 kind: Service

--- a/test/deploy/tools/proxy.yaml
+++ b/test/deploy/tools/proxy.yaml
@@ -51,6 +51,15 @@ spec:
           volumeMounts:
             - name: log-dir
               mountPath: "/var/log/squid/"
+      tolerations:
+        - key: kubernetes.io/arch
+          effect: NoSchedule
+          operator: Equal
+          value: amd64 #! Allow running on amd64 nodes.
+        - key: kubernetes.io/arch
+          effect: NoSchedule
+          operator: Equal
+          value: arm64 #! Also allow running on arm64 nodes.
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Kind clusters do not put taints on arm64 nodes. However, GKE (and maybe other) clusters do. Just in case we want to run the integration tests on a GKE arm64 cluster, I suspect that we will need this tolerations on our tools deployments.

**Release note**:

None, changes testing code only.

```release-note
NONE
```
