### PR TITLE
Infinite default timeout for WhoAmI API call and add `--timeout` CLI flag

### DIFF
--- a/cmd/pinniped/cmd/whoami_test.go
+++ b/cmd/pinniped/cmd/whoami_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2023 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package cmd
@@ -45,6 +45,7 @@ func TestWhoami(t *testing.T) {
 				      --kubeconfig string           Path to kubeconfig file
 				      --kubeconfig-context string   Kubeconfig context name (default: current active context)
 				  -o, --output string               Output format (e.g., 'yaml', 'json', 'text') (default "text")
+				      --timeout duration            Timeout for the WhoAmI API request (default: 0, meaning no timeout)
 			`),
 		},
 		{
@@ -312,7 +313,12 @@ func TestWhoami(t *testing.T) {
 			stdout, stderr := bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{})
 			cmd.SetOut(stdout)
 			cmd.SetErr(stderr)
-			cmd.SetArgs(test.args)
+			if test.args == nil {
+				// cobra uses os.Args[1:] when SetArgs is called with nil, so avoid using nil for tests.
+				cmd.SetArgs([]string{})
+			} else {
+				cmd.SetArgs(test.args)
+			}
 
 			err := cmd.Execute()
 			if test.wantError {


### PR DESCRIPTION
The `pinniped whoami` CLI command has always had a hardcoded timeout of 20 seconds for the `WhoAmI` API call. However, this has always been a problem. When a user needs to interactively authenticate, and when they take more than 20 seconds to do so, then the `WhoAmI` request always fails due to the timeout being exceeded, even though they successfully logged in.

To fix this, copy how kubectl timeouts work. Introduce a new `--timeout` flag (name of flag copied from the pre-existing `pinniped get kubeconfg` flag) and default it to `0` which means no timeout (i.e. infinite timeout).

The fake Kube client used in the unit tests ignores the context param that is passed to it, so unfortunately there is no easy way to unit test this timeout.

**Release note**:

```release-note
`pinniped whoami` has a new `--timeout` parameter, which defaults to no timeout.
```
