### PR TITLE
Lightly standardize import aliases

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 exclude: '^(site|generated)/'
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.2.0
+  rev: v4.5.0
   hooks:
   # TODO: find a version of this to validate ytt templates?
   # - id: check-yaml

--- a/internal/clusterhost/clusterhost_test.go
+++ b/internal/clusterhost/clusterhost_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2021-2023 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package clusterhost
@@ -8,20 +8,18 @@ import (
 	"errors"
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubernetesfake "k8s.io/client-go/kubernetes/fake"
 	coretesting "k8s.io/client-go/testing"
-
-	v1 "k8s.io/api/core/v1"
 )
 
 func TestHasControlPlaneNodes(t *testing.T) {
 	tests := []struct {
 		name            string
-		nodes           []*v1.Node
+		nodes           []*corev1.Node
 		listNodesErr    error
 		wantErr         error
 		wantReturnValue bool
@@ -33,12 +31,12 @@ func TestHasControlPlaneNodes(t *testing.T) {
 		},
 		{
 			name:    "Fetching nodes returns an empty array",
-			nodes:   []*v1.Node{},
+			nodes:   []*corev1.Node{},
 			wantErr: errors.New("no nodes found"),
 		},
 		{
 			name: "Nodes found, but not control plane nodes",
-			nodes: []*v1.Node{
+			nodes: []*corev1.Node{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node-1",
@@ -59,7 +57,7 @@ func TestHasControlPlaneNodes(t *testing.T) {
 		},
 		{
 			name: "Nodes found, including a control-plane role in node-role.kubernetes.io/<role> format",
-			nodes: []*v1.Node{
+			nodes: []*corev1.Node{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   "node-1",
@@ -80,7 +78,7 @@ func TestHasControlPlaneNodes(t *testing.T) {
 		},
 		{
 			name: "Nodes found, including a master role in node-role.kubernetes.io/<role> format",
-			nodes: []*v1.Node{
+			nodes: []*corev1.Node{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   "node-1",
@@ -101,7 +99,7 @@ func TestHasControlPlaneNodes(t *testing.T) {
 		},
 		{
 			name: "Nodes found, including a control-plane role in kubernetes.io/node-role=<role> format",
-			nodes: []*v1.Node{
+			nodes: []*corev1.Node{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   "node-1",
@@ -122,7 +120,7 @@ func TestHasControlPlaneNodes(t *testing.T) {
 		},
 		{
 			name: "Nodes found, including a master role in kubernetes.io/node-role=<role> format",
-			nodes: []*v1.Node{
+			nodes: []*corev1.Node{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   "node-1",

--- a/internal/controller/apicerts/apiservice_updater_test.go
+++ b/internal/controller/apicerts/apiservice_updater_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package apicerts
@@ -15,7 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	kubeinformers "k8s.io/client-go/informers"
+	k8sinformers "k8s.io/client-go/informers"
 	kubernetesfake "k8s.io/client-go/kubernetes/fake"
 	coretesting "k8s.io/client-go/testing"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
@@ -38,7 +38,7 @@ func TestAPIServiceUpdaterControllerOptions(t *testing.T) {
 		it.Before(func() {
 			r = require.New(t)
 			observableWithInformerOption = testutil.NewObservableWithInformerOption()
-			secretsInformer := kubeinformers.NewSharedInformerFactory(nil, 0).Core().V1().Secrets()
+			secretsInformer := k8sinformers.NewSharedInformerFactory(nil, 0).Core().V1().Secrets()
 			_ = NewAPIServiceUpdaterController(
 				installedInNamespace,
 				certsSecretResourceName,
@@ -110,7 +110,7 @@ func TestAPIServiceUpdaterControllerSync(t *testing.T) {
 		var subject controllerlib.Controller
 		var aggregatorAPIClient *aggregatorfake.Clientset
 		var kubeInformerClient *kubernetesfake.Clientset
-		var kubeInformers kubeinformers.SharedInformerFactory
+		var kubeInformers k8sinformers.SharedInformerFactory
 		var cancelContext context.Context
 		var cancelContextCancelFunc context.CancelFunc
 		var syncContext *controllerlib.Context
@@ -149,7 +149,7 @@ func TestAPIServiceUpdaterControllerSync(t *testing.T) {
 			cancelContext, cancelContextCancelFunc = context.WithCancel(context.Background())
 
 			kubeInformerClient = kubernetesfake.NewSimpleClientset()
-			kubeInformers = kubeinformers.NewSharedInformerFactory(kubeInformerClient, 0)
+			kubeInformers = k8sinformers.NewSharedInformerFactory(kubeInformerClient, 0)
 			aggregatorAPIClient = aggregatorfake.NewSimpleClientset()
 		})
 

--- a/internal/controller/apicerts/certs_expirer_test.go
+++ b/internal/controller/apicerts/certs_expirer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package apicerts
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	kubeinformers "k8s.io/client-go/informers"
+	k8sinformers "k8s.io/client-go/informers"
 	kubernetesfake "k8s.io/client-go/kubernetes/fake"
 	kubetesting "k8s.io/client-go/testing"
 
@@ -92,7 +92,7 @@ func TestExpirerControllerFilters(t *testing.T) {
 		t.Run(test.name+"-"+test.namespace, func(t *testing.T) {
 			t.Parallel()
 
-			secretsInformer := kubeinformers.NewSharedInformerFactory(
+			secretsInformer := k8sinformers.NewSharedInformerFactory(
 				kubernetesfake.NewSimpleClientset(),
 				0,
 			).Core().V1().Secrets()
@@ -253,7 +253,7 @@ func TestExpirerControllerSync(t *testing.T) {
 				require.NoError(t, kubeInformerClient.Tracker().Add(secret))
 			}
 
-			kubeInformers := kubeinformers.NewSharedInformerFactory(
+			kubeInformers := k8sinformers.NewSharedInformerFactory(
 				kubeInformerClient,
 				0,
 			)

--- a/internal/controller/apicerts/certs_manager_test.go
+++ b/internal/controller/apicerts/certs_manager_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package apicerts
@@ -16,7 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	kubeinformers "k8s.io/client-go/informers"
+	k8sinformers "k8s.io/client-go/informers"
 	kubernetesfake "k8s.io/client-go/kubernetes/fake"
 	coretesting "k8s.io/client-go/testing"
 
@@ -38,7 +38,7 @@ func TestManagerControllerOptions(t *testing.T) {
 			r = require.New(t)
 			observableWithInformerOption = testutil.NewObservableWithInformerOption()
 			observableWithInitialEventOption = testutil.NewObservableWithInitialEventOption()
-			secretsInformer := kubeinformers.NewSharedInformerFactory(nil, 0).Core().V1().Secrets()
+			secretsInformer := k8sinformers.NewSharedInformerFactory(nil, 0).Core().V1().Secrets()
 			_ = NewCertsManagerController(
 				installedInNamespace,
 				certsSecretResourceName,
@@ -125,7 +125,7 @@ func TestManagerControllerSync(t *testing.T) {
 		var subject controllerlib.Controller
 		var kubeAPIClient *kubernetesfake.Clientset
 		var kubeInformerClient *kubernetesfake.Clientset
-		var kubeInformers kubeinformers.SharedInformerFactory
+		var kubeInformers k8sinformers.SharedInformerFactory
 		var cancelContext context.Context
 		var cancelContextCancelFunc context.CancelFunc
 		var syncContext *controllerlib.Context
@@ -171,7 +171,7 @@ func TestManagerControllerSync(t *testing.T) {
 			cancelContext, cancelContextCancelFunc = context.WithCancel(context.Background())
 
 			kubeInformerClient = kubernetesfake.NewSimpleClientset()
-			kubeInformers = kubeinformers.NewSharedInformerFactory(kubeInformerClient, 0)
+			kubeInformers = k8sinformers.NewSharedInformerFactory(kubeInformerClient, 0)
 			kubeAPIClient = kubernetesfake.NewSimpleClientset()
 		})
 

--- a/internal/controller/apicerts/certs_observer_test.go
+++ b/internal/controller/apicerts/certs_observer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package apicerts
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kubeinformers "k8s.io/client-go/informers"
+	k8sinformers "k8s.io/client-go/informers"
 	kubernetesfake "k8s.io/client-go/kubernetes/fake"
 
 	"go.pinniped.dev/internal/certauthority"
@@ -35,7 +35,7 @@ func TestObserverControllerInformerFilters(t *testing.T) {
 		it.Before(func() {
 			r = require.New(t)
 			observableWithInformerOption = testutil.NewObservableWithInformerOption()
-			secretsInformer := kubeinformers.NewSharedInformerFactory(nil, 0).Core().V1().Secrets()
+			secretsInformer := k8sinformers.NewSharedInformerFactory(nil, 0).Core().V1().Secrets()
 			_ = NewCertsObserverController(
 				installedInNamespace,
 				certsSecretResourceName,
@@ -106,7 +106,7 @@ func TestObserverControllerSync(t *testing.T) {
 
 		var subject controllerlib.Controller
 		var kubeInformerClient *kubernetesfake.Clientset
-		var kubeInformers kubeinformers.SharedInformerFactory
+		var kubeInformers k8sinformers.SharedInformerFactory
 		var cancelContext context.Context
 		var cancelContextCancelFunc context.CancelFunc
 		var syncContext *controllerlib.Context
@@ -145,7 +145,7 @@ func TestObserverControllerSync(t *testing.T) {
 			cancelContext, cancelContextCancelFunc = context.WithCancel(context.Background())
 
 			kubeInformerClient = kubernetesfake.NewSimpleClientset()
-			kubeInformers = kubeinformers.NewSharedInformerFactory(kubeInformerClient, 0)
+			kubeInformers = k8sinformers.NewSharedInformerFactory(kubeInformerClient, 0)
 			dynamicCertProvider = dynamiccert.NewServingCert(name)
 		})
 

--- a/internal/controller/conditionsutil/conditions_util.go
+++ b/internal/controller/conditionsutil/conditions_util.go
@@ -7,22 +7,22 @@ import (
 	"sort"
 
 	"k8s.io/apimachinery/pkg/api/equality"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"go.pinniped.dev/internal/plog"
 )
 
 // MergeIDPConditions merges conditions into conditionsToUpdate. If returns true if it merged any error conditions.
-func MergeIDPConditions(conditions []*v1.Condition, observedGeneration int64, conditionsToUpdate *[]v1.Condition, log plog.MinLogger) bool {
+func MergeIDPConditions(conditions []*metav1.Condition, observedGeneration int64, conditionsToUpdate *[]metav1.Condition, log plog.MinLogger) bool {
 	hadErrorCondition := false
 	for i := range conditions {
 		cond := conditions[i].DeepCopy()
-		cond.LastTransitionTime = v1.Now()
+		cond.LastTransitionTime = metav1.Now()
 		cond.ObservedGeneration = observedGeneration
 		if mergeIDPCondition(conditionsToUpdate, cond) {
 			log.Info("updated condition", "type", cond.Type, "status", cond.Status, "reason", cond.Reason, "message", cond.Message)
 		}
-		if cond.Status == v1.ConditionFalse {
+		if cond.Status == metav1.ConditionFalse {
 			hadErrorCondition = true
 		}
 	}
@@ -32,11 +32,11 @@ func MergeIDPConditions(conditions []*v1.Condition, observedGeneration int64, co
 	return hadErrorCondition
 }
 
-// mergeIDPCondition merges a new v1.Condition into a slice of existing conditions. It returns true
+// mergeIDPCondition merges a new metav1.Condition into a slice of existing conditions. It returns true
 // if the condition has meaningfully changed.
-func mergeIDPCondition(existing *[]v1.Condition, new *v1.Condition) bool {
+func mergeIDPCondition(existing *[]metav1.Condition, new *metav1.Condition) bool {
 	// Find any existing condition with a matching type.
-	var old *v1.Condition
+	var old *metav1.Condition
 	for i := range *existing {
 		if (*existing)[i].Type == new.Type {
 			old = &(*existing)[i]
@@ -67,7 +67,7 @@ func mergeIDPCondition(existing *[]v1.Condition, new *v1.Condition) bool {
 }
 
 // MergeConfigConditions merges conditions into conditionsToUpdate. If returns true if it merged any error conditions.
-func MergeConfigConditions(conditions []*v1.Condition, observedGeneration int64, conditionsToUpdate *[]v1.Condition, log plog.MinLogger, now v1.Time) bool {
+func MergeConfigConditions(conditions []*metav1.Condition, observedGeneration int64, conditionsToUpdate *[]metav1.Condition, log plog.MinLogger, now metav1.Time) bool {
 	hadErrorCondition := false
 	for i := range conditions {
 		cond := conditions[i].DeepCopy()
@@ -76,7 +76,7 @@ func MergeConfigConditions(conditions []*v1.Condition, observedGeneration int64,
 		if mergeConfigCondition(conditionsToUpdate, cond) {
 			log.Info("updated condition", "type", cond.Type, "status", cond.Status, "reason", cond.Reason, "message", cond.Message)
 		}
-		if cond.Status == v1.ConditionFalse {
+		if cond.Status == metav1.ConditionFalse {
 			hadErrorCondition = true
 		}
 	}
@@ -86,11 +86,11 @@ func MergeConfigConditions(conditions []*v1.Condition, observedGeneration int64,
 	return hadErrorCondition
 }
 
-// mergeConfigCondition merges a new v1.Condition into a slice of existing conditions. It returns true
+// mergeConfigCondition merges a new metav1.Condition into a slice of existing conditions. It returns true
 // if the condition has meaningfully changed.
-func mergeConfigCondition(existing *[]v1.Condition, new *v1.Condition) bool {
+func mergeConfigCondition(existing *[]metav1.Condition, new *metav1.Condition) bool {
 	// Find any existing condition with a matching type.
-	var old *v1.Condition
+	var old *metav1.Condition
 	for i := range *existing {
 		if (*existing)[i].Type == new.Type {
 			old = &(*existing)[i]

--- a/internal/controller/impersonatorconfig/impersonator_config_test.go
+++ b/internal/controller/impersonatorconfig/impersonator_config_test.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	kubeinformers "k8s.io/client-go/informers"
+	k8sinformers "k8s.io/client-go/informers"
 	kubernetesfake "k8s.io/client-go/kubernetes/fake"
 	coretesting "k8s.io/client-go/testing"
 	clocktesting "k8s.io/utils/clock/testing"
@@ -68,7 +68,7 @@ func TestImpersonatorConfigControllerOptions(t *testing.T) {
 			r = require.New(t)
 			observableWithInformerOption = testutil.NewObservableWithInformerOption()
 			pinnipedInformerFactory := pinnipedinformers.NewSharedInformerFactory(nil, 0)
-			sharedInformerFactory := kubeinformers.NewSharedInformerFactory(nil, 0)
+			sharedInformerFactory := k8sinformers.NewSharedInformerFactory(nil, 0)
 			credIssuerInformer := pinnipedInformerFactory.Config().V1alpha1().CredentialIssuers()
 			servicesInformer := sharedInformerFactory.Core().V1().Services()
 			secretsInformer := sharedInformerFactory.Core().V1().Secrets()
@@ -282,7 +282,7 @@ func TestImpersonatorConfigControllerSync(t *testing.T) {
 		var pinnipedInformerClient *pinnipedfake.Clientset
 		var pinnipedInformers pinnipedinformers.SharedInformerFactory
 		var kubeInformerClient *kubernetesfake.Clientset
-		var kubeInformers kubeinformers.SharedInformerFactory
+		var kubeInformers k8sinformers.SharedInformerFactory
 		var cancelContext context.Context
 		var cancelContextCancelFunc context.CancelFunc
 		var syncContext *controllerlib.Context
@@ -1121,8 +1121,8 @@ func TestImpersonatorConfigControllerSync(t *testing.T) {
 			pinnipedInformers = pinnipedinformers.NewSharedInformerFactoryWithOptions(pinnipedInformerClient, 0)
 
 			kubeInformerClient = kubernetesfake.NewSimpleClientset()
-			kubeInformers = kubeinformers.NewSharedInformerFactoryWithOptions(kubeInformerClient, 0,
-				kubeinformers.WithNamespace(installedInNamespace),
+			kubeInformers = k8sinformers.NewSharedInformerFactoryWithOptions(kubeInformerClient, 0,
+				k8sinformers.WithNamespace(installedInNamespace),
 			)
 			kubeAPIClient = kubernetesfake.NewSimpleClientset()
 			pinnipedAPIClient = pinnipedfake.NewSimpleClientset()

--- a/internal/controller/kubecertagent/pod_command_executor.go
+++ b/internal/controller/kubecertagent/pod_command_executor.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"context"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	restclient "k8s.io/client-go/rest"
@@ -41,7 +41,7 @@ func (s *kubeClientPodCommandExecutor) Exec(ctx context.Context, podNamespace st
 		Resource("pods").
 		Name(podName).
 		SubResource("exec").
-		VersionedParams(&v1.PodExecOptions{
+		VersionedParams(&corev1.PodExecOptions{
 			Stdin:     false,
 			Stdout:    true,
 			Stderr:    false,

--- a/internal/controller/supervisorconfig/activedirectoryupstreamwatcher/active_directory_upstream_watcher.go
+++ b/internal/controller/supervisorconfig/activedirectoryupstreamwatcher/active_directory_upstream_watcher.go
@@ -20,7 +20,7 @@ import (
 	corev1informers "k8s.io/client-go/informers/core/v1"
 
 	"go.pinniped.dev/generated/latest/apis/supervisor/idp/v1alpha1"
-	pinnipedclientset "go.pinniped.dev/generated/latest/client/supervisor/clientset/versioned"
+	supervisorclientset "go.pinniped.dev/generated/latest/client/supervisor/clientset/versioned"
 	idpinformers "go.pinniped.dev/generated/latest/client/supervisor/informers/externalversions/idp/v1alpha1"
 	pinnipedcontroller "go.pinniped.dev/internal/controller"
 	"go.pinniped.dev/internal/controller/conditionsutil"
@@ -232,7 +232,7 @@ type activeDirectoryWatcherController struct {
 	cache                                   UpstreamActiveDirectoryIdentityProviderICache
 	validatedSettingsCache                  upstreamwatchers.ValidatedSettingsCacheI
 	ldapDialer                              upstreamldap.LDAPDialer
-	client                                  pinnipedclientset.Interface
+	client                                  supervisorclientset.Interface
 	activeDirectoryIdentityProviderInformer idpinformers.ActiveDirectoryIdentityProviderInformer
 	secretInformer                          corev1informers.SecretInformer
 }
@@ -240,7 +240,7 @@ type activeDirectoryWatcherController struct {
 // New instantiates a new controllerlib.Controller which will populate the provided UpstreamActiveDirectoryIdentityProviderICache.
 func New(
 	idpCache UpstreamActiveDirectoryIdentityProviderICache,
-	client pinnipedclientset.Interface,
+	client supervisorclientset.Interface,
 	activeDirectoryIdentityProviderInformer idpinformers.ActiveDirectoryIdentityProviderInformer,
 	secretInformer corev1informers.SecretInformer,
 	withInformer pinnipedcontroller.WithInformerOptionFunc,
@@ -263,7 +263,7 @@ func newInternal(
 	idpCache UpstreamActiveDirectoryIdentityProviderICache,
 	validatedSettingsCache upstreamwatchers.ValidatedSettingsCacheI,
 	ldapDialer upstreamldap.LDAPDialer,
-	client pinnipedclientset.Interface,
+	client supervisorclientset.Interface,
 	activeDirectoryIdentityProviderInformer idpinformers.ActiveDirectoryIdentityProviderInformer,
 	secretInformer corev1informers.SecretInformer,
 	withInformer pinnipedcontroller.WithInformerOptionFunc,

--- a/internal/controller/supervisorconfig/federation_domain_watcher.go
+++ b/internal/controller/supervisorconfig/federation_domain_watcher.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/utils/clock"
 
 	configv1alpha1 "go.pinniped.dev/generated/latest/apis/supervisor/config/v1alpha1"
-	pinnipedclientset "go.pinniped.dev/generated/latest/client/supervisor/clientset/versioned"
+	supervisorclientset "go.pinniped.dev/generated/latest/client/supervisor/clientset/versioned"
 	configinformers "go.pinniped.dev/generated/latest/client/supervisor/informers/externalversions/config/v1alpha1"
 	idpinformers "go.pinniped.dev/generated/latest/client/supervisor/informers/externalversions/idp/v1alpha1"
 	"go.pinniped.dev/internal/celtransformer"
@@ -82,7 +82,7 @@ type federationDomainWatcherController struct {
 	federationDomainsSetter FederationDomainsSetter
 	apiGroup                string
 	clock                   clock.Clock
-	client                  pinnipedclientset.Interface
+	client                  supervisorclientset.Interface
 
 	federationDomainInformer                configinformers.FederationDomainInformer
 	oidcIdentityProviderInformer            idpinformers.OIDCIdentityProviderInformer
@@ -99,7 +99,7 @@ func NewFederationDomainWatcherController(
 	federationDomainsSetter FederationDomainsSetter,
 	apiGroupSuffix string,
 	clock clock.Clock,
-	client pinnipedclientset.Interface,
+	client supervisorclientset.Interface,
 	federationDomainInformer configinformers.FederationDomainInformer,
 	oidcIdentityProviderInformer idpinformers.OIDCIdentityProviderInformer,
 	ldapIdentityProviderInformer idpinformers.LDAPIdentityProviderInformer,

--- a/internal/controller/supervisorconfig/generator/federation_domain_secrets.go
+++ b/internal/controller/supervisorconfig/generator/federation_domain_secrets.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package generator
@@ -17,7 +17,7 @@ import (
 	"k8s.io/klog/v2"
 
 	configv1alpha1 "go.pinniped.dev/generated/latest/apis/supervisor/config/v1alpha1"
-	pinnipedclientset "go.pinniped.dev/generated/latest/client/supervisor/clientset/versioned"
+	supervisorclientset "go.pinniped.dev/generated/latest/client/supervisor/clientset/versioned"
 	configinformers "go.pinniped.dev/generated/latest/client/supervisor/informers/externalversions/config/v1alpha1"
 	pinnipedcontroller "go.pinniped.dev/internal/controller"
 	"go.pinniped.dev/internal/controllerlib"
@@ -28,7 +28,7 @@ type federationDomainSecretsController struct {
 	secretHelper             SecretHelper
 	secretRefFunc            func(domain *configv1alpha1.FederationDomainStatus) *corev1.LocalObjectReference
 	kubeClient               kubernetes.Interface
-	pinnipedClient           pinnipedclientset.Interface
+	pinnipedClient           supervisorclientset.Interface
 	federationDomainInformer configinformers.FederationDomainInformer
 	secretInformer           corev1informers.SecretInformer
 }
@@ -40,7 +40,7 @@ func NewFederationDomainSecretsController(
 	secretHelper SecretHelper,
 	secretRefFunc func(domain *configv1alpha1.FederationDomainStatus) *corev1.LocalObjectReference,
 	kubeClient kubernetes.Interface,
-	pinnipedClient pinnipedclientset.Interface,
+	pinnipedClient supervisorclientset.Interface,
 	secretInformer corev1informers.SecretInformer,
 	federationDomainInformer configinformers.FederationDomainInformer,
 	withInformer pinnipedcontroller.WithInformerOptionFunc,

--- a/internal/controller/supervisorconfig/generator/federation_domain_secrets_test.go
+++ b/internal/controller/supervisorconfig/generator/federation_domain_secrets_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package generator
@@ -18,7 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	kubeinformers "k8s.io/client-go/informers"
+	k8sinformers "k8s.io/client-go/informers"
 	kubernetesfake "k8s.io/client-go/kubernetes/fake"
 	kubetesting "k8s.io/client-go/testing"
 
@@ -180,7 +180,7 @@ func TestFederationDomainControllerFilterSecret(t *testing.T) {
 				func(cacheKey string, cacheValue []byte) {},
 			)
 
-			secretInformer := kubeinformers.NewSharedInformerFactory(
+			secretInformer := k8sinformers.NewSharedInformerFactory(
 				kubernetesfake.NewSimpleClientset(),
 				0,
 			).Core().V1().Secrets()
@@ -243,7 +243,7 @@ func TestNewFederationDomainSecretsControllerFilterFederationDomain(t *testing.T
 				func(cacheKey string, cacheValue []byte) {},
 			)
 
-			secretInformer := kubeinformers.NewSharedInformerFactory(
+			secretInformer := k8sinformers.NewSharedInformerFactory(
 				kubernetesfake.NewSimpleClientset(),
 				0,
 			).Core().V1().Secrets()
@@ -656,7 +656,7 @@ func TestFederationDomainSecretsControllerSync(t *testing.T) {
 				test.client(pinnipedAPIClient, kubeAPIClient)
 			}
 
-			kubeInformers := kubeinformers.NewSharedInformerFactory(
+			kubeInformers := k8sinformers.NewSharedInformerFactory(
 				kubeInformerClient,
 				0,
 			)

--- a/internal/controller/supervisorconfig/generator/supervisor_secrets_test.go
+++ b/internal/controller/supervisorconfig/generator/supervisor_secrets_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package generator
@@ -16,7 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	kubeinformers "k8s.io/client-go/informers"
+	k8sinformers "k8s.io/client-go/informers"
 	kubernetesfake "k8s.io/client-go/kubernetes/fake"
 	kubetesting "k8s.io/client-go/testing"
 
@@ -104,7 +104,7 @@ func TestSupervisorSecretsControllerFilterSecret(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			secretInformer := kubeinformers.NewSharedInformerFactory(
+			secretInformer := k8sinformers.NewSharedInformerFactory(
 				kubernetesfake.NewSimpleClientset(),
 				0,
 			).Core().V1().Secrets()
@@ -131,7 +131,7 @@ func TestSupervisorSecretsControllerFilterSecret(t *testing.T) {
 
 func TestSupervisorSecretsControllerInitialEvent(t *testing.T) {
 	initialEventOption := testutil.NewObservableWithInitialEventOption()
-	secretInformer := kubeinformers.NewSharedInformerFactory(
+	secretInformer := k8sinformers.NewSharedInformerFactory(
 		kubernetesfake.NewSimpleClientset(),
 		0,
 	).Core().V1().Secrets()
@@ -437,7 +437,7 @@ func TestSupervisorSecretsControllerSync(t *testing.T) {
 				require.NoError(t, informerClient.Tracker().Add(storedSecret))
 			}
 
-			informers := kubeinformers.NewSharedInformerFactory(informerClient, 0)
+			informers := k8sinformers.NewSharedInformerFactory(informerClient, 0)
 			secrets := informers.Core().V1().Secrets()
 
 			var callbackSecret []byte

--- a/internal/controller/supervisorconfig/jwks_observer_test.go
+++ b/internal/controller/supervisorconfig/jwks_observer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package supervisorconfig
@@ -14,7 +14,7 @@ import (
 	"gopkg.in/square/go-jose.v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kubeinformers "k8s.io/client-go/informers"
+	k8sinformers "k8s.io/client-go/informers"
 	kubernetesfake "k8s.io/client-go/kubernetes/fake"
 
 	"go.pinniped.dev/generated/latest/apis/supervisor/config/v1alpha1"
@@ -36,7 +36,7 @@ func TestJWKSObserverControllerInformerFilters(t *testing.T) {
 		it.Before(func() {
 			r = require.New(t)
 			observableWithInformerOption = testutil.NewObservableWithInformerOption()
-			secretsInformer := kubeinformers.NewSharedInformerFactory(nil, 0).Core().V1().Secrets()
+			secretsInformer := k8sinformers.NewSharedInformerFactory(nil, 0).Core().V1().Secrets()
 			federationDomainInformer := pinnipedinformers.NewSharedInformerFactory(nil, 0).Config().V1alpha1().FederationDomains()
 			_ = NewJWKSObserverController(
 				nil,
@@ -128,7 +128,7 @@ func TestJWKSObserverControllerSync(t *testing.T) {
 			pinnipedInformerClient  *pinnipedfake.Clientset
 			kubeInformerClient      *kubernetesfake.Clientset
 			pinnipedInformers       pinnipedinformers.SharedInformerFactory
-			kubeInformers           kubeinformers.SharedInformerFactory
+			kubeInformers           k8sinformers.SharedInformerFactory
 			cancelContext           context.Context
 			cancelContextCancelFunc context.CancelFunc
 			syncContext             *controllerlib.Context
@@ -168,7 +168,7 @@ func TestJWKSObserverControllerSync(t *testing.T) {
 			cancelContext, cancelContextCancelFunc = context.WithCancel(context.Background())
 
 			kubeInformerClient = kubernetesfake.NewSimpleClientset()
-			kubeInformers = kubeinformers.NewSharedInformerFactory(kubeInformerClient, 0)
+			kubeInformers = k8sinformers.NewSharedInformerFactory(kubeInformerClient, 0)
 			pinnipedInformerClient = pinnipedfake.NewSimpleClientset()
 			pinnipedInformers = pinnipedinformers.NewSharedInformerFactory(pinnipedInformerClient, 0)
 			issuerToJWKSSetter = &fakeIssuerToJWKSMapSetter{}

--- a/internal/controller/supervisorconfig/jwks_writer.go
+++ b/internal/controller/supervisorconfig/jwks_writer.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package supervisorconfig
@@ -23,7 +23,7 @@ import (
 	"k8s.io/klog/v2"
 
 	configv1alpha1 "go.pinniped.dev/generated/latest/apis/supervisor/config/v1alpha1"
-	pinnipedclientset "go.pinniped.dev/generated/latest/client/supervisor/clientset/versioned"
+	supervisorclientset "go.pinniped.dev/generated/latest/client/supervisor/clientset/versioned"
 	configinformers "go.pinniped.dev/generated/latest/client/supervisor/informers/externalversions/config/v1alpha1"
 	pinnipedcontroller "go.pinniped.dev/internal/controller"
 	"go.pinniped.dev/internal/controller/supervisorconfig/generator"
@@ -60,7 +60,7 @@ func generateECKey(r io.Reader) (interface{}, error) {
 // secrets, both via a cache and via the API.
 type jwksWriterController struct {
 	jwksSecretLabels         map[string]string
-	pinnipedClient           pinnipedclientset.Interface
+	pinnipedClient           supervisorclientset.Interface
 	kubeClient               kubernetes.Interface
 	federationDomainInformer configinformers.FederationDomainInformer
 	secretInformer           corev1informers.SecretInformer
@@ -71,7 +71,7 @@ type jwksWriterController struct {
 func NewJWKSWriterController(
 	jwksSecretLabels map[string]string,
 	kubeClient kubernetes.Interface,
-	pinnipedClient pinnipedclientset.Interface,
+	pinnipedClient supervisorclientset.Interface,
 	secretInformer corev1informers.SecretInformer,
 	federationDomainInformer configinformers.FederationDomainInformer,
 	withInformer pinnipedcontroller.WithInformerOptionFunc,

--- a/internal/controller/supervisorconfig/jwks_writer_test.go
+++ b/internal/controller/supervisorconfig/jwks_writer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package supervisorconfig
@@ -18,7 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	kubeinformers "k8s.io/client-go/informers"
+	k8sinformers "k8s.io/client-go/informers"
 	kubernetesfake "k8s.io/client-go/kubernetes/fake"
 	kubetesting "k8s.io/client-go/testing"
 
@@ -171,7 +171,7 @@ func TestJWKSWriterControllerFilterSecret(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			secretInformer := kubeinformers.NewSharedInformerFactory(
+			secretInformer := k8sinformers.NewSharedInformerFactory(
 				kubernetesfake.NewSimpleClientset(),
 				0,
 			).Core().V1().Secrets()
@@ -225,7 +225,7 @@ func TestJWKSWriterControllerFilterFederationDomain(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			secretInformer := kubeinformers.NewSharedInformerFactory(
+			secretInformer := k8sinformers.NewSharedInformerFactory(
 				kubernetesfake.NewSimpleClientset(),
 				0,
 			).Core().V1().Secrets()
@@ -696,7 +696,7 @@ func TestJWKSWriterControllerSync(t *testing.T) {
 				test.configPinnipedClient(pinnipedAPIClient)
 			}
 
-			kubeInformers := kubeinformers.NewSharedInformerFactory(
+			kubeInformers := k8sinformers.NewSharedInformerFactory(
 				kubeInformerClient,
 				0,
 			)

--- a/internal/controller/supervisorconfig/ldapupstreamwatcher/ldap_upstream_watcher.go
+++ b/internal/controller/supervisorconfig/ldapupstreamwatcher/ldap_upstream_watcher.go
@@ -14,7 +14,7 @@ import (
 	corev1informers "k8s.io/client-go/informers/core/v1"
 
 	"go.pinniped.dev/generated/latest/apis/supervisor/idp/v1alpha1"
-	pinnipedclientset "go.pinniped.dev/generated/latest/client/supervisor/clientset/versioned"
+	supervisorclientset "go.pinniped.dev/generated/latest/client/supervisor/clientset/versioned"
 	idpinformers "go.pinniped.dev/generated/latest/client/supervisor/informers/externalversions/idp/v1alpha1"
 	pinnipedcontroller "go.pinniped.dev/internal/controller"
 	"go.pinniped.dev/internal/controller/conditionsutil"
@@ -140,7 +140,7 @@ type ldapWatcherController struct {
 	cache                        UpstreamLDAPIdentityProviderICache
 	validatedSettingsCache       upstreamwatchers.ValidatedSettingsCacheI
 	ldapDialer                   upstreamldap.LDAPDialer
-	client                       pinnipedclientset.Interface
+	client                       supervisorclientset.Interface
 	ldapIdentityProviderInformer idpinformers.LDAPIdentityProviderInformer
 	secretInformer               corev1informers.SecretInformer
 }
@@ -148,7 +148,7 @@ type ldapWatcherController struct {
 // New instantiates a new controllerlib.Controller which will populate the provided UpstreamLDAPIdentityProviderICache.
 func New(
 	idpCache UpstreamLDAPIdentityProviderICache,
-	client pinnipedclientset.Interface,
+	client supervisorclientset.Interface,
 	ldapIdentityProviderInformer idpinformers.LDAPIdentityProviderInformer,
 	secretInformer corev1informers.SecretInformer,
 	withInformer pinnipedcontroller.WithInformerOptionFunc,
@@ -171,7 +171,7 @@ func newInternal(
 	idpCache UpstreamLDAPIdentityProviderICache,
 	validatedSettingsCache upstreamwatchers.ValidatedSettingsCacheI,
 	ldapDialer upstreamldap.LDAPDialer,
-	client pinnipedclientset.Interface,
+	client supervisorclientset.Interface,
 	ldapIdentityProviderInformer idpinformers.LDAPIdentityProviderInformer,
 	secretInformer corev1informers.SecretInformer,
 	withInformer pinnipedcontroller.WithInformerOptionFunc,

--- a/internal/controller/supervisorconfig/oidcclientwatcher/oidc_client_watcher.go
+++ b/internal/controller/supervisorconfig/oidcclientwatcher/oidc_client_watcher.go
@@ -16,7 +16,7 @@ import (
 
 	"go.pinniped.dev/generated/latest/apis/supervisor/config/v1alpha1"
 	oidcapi "go.pinniped.dev/generated/latest/apis/supervisor/oidc"
-	pinnipedclientset "go.pinniped.dev/generated/latest/client/supervisor/clientset/versioned"
+	supervisorclientset "go.pinniped.dev/generated/latest/client/supervisor/clientset/versioned"
 	configInformers "go.pinniped.dev/generated/latest/client/supervisor/informers/externalversions/config/v1alpha1"
 	pinnipedcontroller "go.pinniped.dev/internal/controller"
 	"go.pinniped.dev/internal/controller/conditionsutil"
@@ -32,7 +32,7 @@ const (
 )
 
 type oidcClientWatcherController struct {
-	pinnipedClient     pinnipedclientset.Interface
+	pinnipedClient     supervisorclientset.Interface
 	oidcClientInformer configInformers.OIDCClientInformer
 	secretInformer     corev1informers.SecretInformer
 }
@@ -40,7 +40,7 @@ type oidcClientWatcherController struct {
 // NewOIDCClientWatcherController returns a controllerlib.Controller that watches OIDCClients and updates
 // their status with validation errors.
 func NewOIDCClientWatcherController(
-	pinnipedClient pinnipedclientset.Interface,
+	pinnipedClient supervisorclientset.Interface,
 	secretInformer corev1informers.SecretInformer,
 	oidcClientInformer configInformers.OIDCClientInformer,
 	withInformer pinnipedcontroller.WithInformerOptionFunc,

--- a/internal/controller/supervisorconfig/oidcclientwatcher/oidc_client_watcher_test.go
+++ b/internal/controller/supervisorconfig/oidcclientwatcher/oidc_client_watcher_test.go
@@ -13,7 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	kubeinformers "k8s.io/client-go/informers"
+	k8sinformers "k8s.io/client-go/informers"
 	kubernetesfake "k8s.io/client-go/kubernetes/fake"
 
 	configv1alpha1 "go.pinniped.dev/generated/latest/apis/supervisor/config/v1alpha1"
@@ -62,7 +62,7 @@ func TestOIDCClientWatcherControllerFilterSecret(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			secretInformer := kubeinformers.NewSharedInformerFactory(
+			secretInformer := k8sinformers.NewSharedInformerFactory(
 				kubernetesfake.NewSimpleClientset(),
 				0,
 			).Core().V1().Secrets()
@@ -131,7 +131,7 @@ func TestOIDCClientWatcherControllerFilterOIDCClient(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			secretInformer := kubeinformers.NewSharedInformerFactory(
+			secretInformer := k8sinformers.NewSharedInformerFactory(
 				kubernetesfake.NewSimpleClientset(),
 				0,
 			).Core().V1().Secrets()
@@ -961,7 +961,7 @@ func TestOIDCClientWatcherControllerSync(t *testing.T) {
 			fakePinnipedClientForInformers := pinnipedfake.NewSimpleClientset(tt.inputObjects...)
 			pinnipedInformers := pinnipedinformers.NewSharedInformerFactory(fakePinnipedClientForInformers, 0)
 			fakeKubeClient := kubernetesfake.NewSimpleClientset(tt.inputSecrets...)
-			kubeInformers := kubeinformers.NewSharedInformerFactoryWithOptions(fakeKubeClient, 0)
+			kubeInformers := k8sinformers.NewSharedInformerFactoryWithOptions(fakeKubeClient, 0)
 
 			controller := NewOIDCClientWatcherController(
 				fakePinnipedClient,

--- a/internal/controller/supervisorconfig/oidcupstreamwatcher/oidc_upstream_watcher.go
+++ b/internal/controller/supervisorconfig/oidcupstreamwatcher/oidc_upstream_watcher.go
@@ -27,7 +27,7 @@ import (
 
 	"go.pinniped.dev/generated/latest/apis/supervisor/idp/v1alpha1"
 	oidcapi "go.pinniped.dev/generated/latest/apis/supervisor/oidc"
-	pinnipedclientset "go.pinniped.dev/generated/latest/client/supervisor/clientset/versioned"
+	supervisorclientset "go.pinniped.dev/generated/latest/client/supervisor/clientset/versioned"
 	idpinformers "go.pinniped.dev/generated/latest/client/supervisor/informers/externalversions/idp/v1alpha1"
 	"go.pinniped.dev/internal/constable"
 	pinnipedcontroller "go.pinniped.dev/internal/controller"
@@ -126,7 +126,7 @@ func (c *lruValidatorCache) cacheKey(spec *v1alpha1.OIDCIdentityProviderSpec) in
 type oidcWatcherController struct {
 	cache                        UpstreamOIDCIdentityProviderICache
 	log                          logr.Logger
-	client                       pinnipedclientset.Interface
+	client                       supervisorclientset.Interface
 	oidcIdentityProviderInformer idpinformers.OIDCIdentityProviderInformer
 	secretInformer               corev1informers.SecretInformer
 	validatorCache               interface {
@@ -138,7 +138,7 @@ type oidcWatcherController struct {
 // New instantiates a new controllerlib.Controller which will populate the provided UpstreamOIDCIdentityProviderICache.
 func New(
 	idpCache UpstreamOIDCIdentityProviderICache,
-	client pinnipedclientset.Interface,
+	client supervisorclientset.Interface,
 	oidcIdentityProviderInformer idpinformers.OIDCIdentityProviderInformer,
 	secretInformer corev1informers.SecretInformer,
 	log logr.Logger,

--- a/internal/controller/supervisorconfig/tls_cert_observer.go
+++ b/internal/controller/supervisorconfig/tls_cert_observer.go
@@ -9,7 +9,7 @@ import (
 	"net/url"
 	"strings"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	corev1informers "k8s.io/client-go/informers/core/v1"
@@ -51,7 +51,7 @@ func NewTLSCertObserverController(
 		},
 		withInformer(
 			secretInformer,
-			pinnipedcontroller.MatchAnySecretOfTypeFilter(v1.SecretTypeTLS, nil),
+			pinnipedcontroller.MatchAnySecretOfTypeFilter(corev1.SecretTypeTLS, nil),
 			controllerlib.InformerOption{},
 		),
 		withInformer(

--- a/internal/controller/supervisorconfig/tls_cert_observer_test.go
+++ b/internal/controller/supervisorconfig/tls_cert_observer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package supervisorconfig
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kubeinformers "k8s.io/client-go/informers"
+	k8sinformers "k8s.io/client-go/informers"
 	kubernetesfake "k8s.io/client-go/kubernetes/fake"
 
 	"go.pinniped.dev/generated/latest/apis/supervisor/config/v1alpha1"
@@ -37,7 +37,7 @@ func TestTLSCertObserverControllerInformerFilters(t *testing.T) {
 		it.Before(func() {
 			r = require.New(t)
 			observableWithInformerOption = testutil.NewObservableWithInformerOption()
-			secretsInformer := kubeinformers.NewSharedInformerFactory(nil, 0).Core().V1().Secrets()
+			secretsInformer := k8sinformers.NewSharedInformerFactory(nil, 0).Core().V1().Secrets()
 			federationDomainInformer := pinnipedinformers.NewSharedInformerFactory(nil, 0).Config().V1alpha1().FederationDomains()
 			_ = NewTLSCertObserverController(
 				nil,
@@ -134,7 +134,7 @@ func TestTLSCertObserverControllerSync(t *testing.T) {
 			pinnipedInformerClient  *pinnipedfake.Clientset
 			kubeInformerClient      *kubernetesfake.Clientset
 			pinnipedInformers       pinnipedinformers.SharedInformerFactory
-			kubeInformers           kubeinformers.SharedInformerFactory
+			kubeInformers           k8sinformers.SharedInformerFactory
 			cancelContext           context.Context
 			cancelContextCancelFunc context.CancelFunc
 			syncContext             *controllerlib.Context
@@ -181,7 +181,7 @@ func TestTLSCertObserverControllerSync(t *testing.T) {
 			cancelContext, cancelContextCancelFunc = context.WithCancel(context.Background())
 
 			kubeInformerClient = kubernetesfake.NewSimpleClientset()
-			kubeInformers = kubeinformers.NewSharedInformerFactory(kubeInformerClient, 0)
+			kubeInformers = k8sinformers.NewSharedInformerFactory(kubeInformerClient, 0)
 			pinnipedInformerClient = pinnipedfake.NewSimpleClientset()
 			pinnipedInformers = pinnipedinformers.NewSharedInformerFactory(pinnipedInformerClient, 0)
 			issuerTLSCertSetter = &fakeIssuerTLSCertSetter{}

--- a/internal/controller/supervisorstorage/garbage_collector.go
+++ b/internal/controller/supervisorstorage/garbage_collector.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	corev1informers "k8s.io/client-go/informers/core/v1"
@@ -55,7 +55,7 @@ func GarbageCollectorController(
 	withInformer pinnipedcontroller.WithInformerOptionFunc,
 ) controllerlib.Controller {
 	isSecretWithGCAnnotation := func(obj metav1.Object) bool {
-		secret, ok := obj.(*v1.Secret)
+		secret, ok := obj.(*corev1.Secret)
 		if !ok {
 			return false
 		}
@@ -169,7 +169,7 @@ func (c *garbageCollectorController) Sync(ctx controllerlib.Context) error {
 	return nil
 }
 
-func (c *garbageCollectorController) maybeRevokeUpstreamOIDCToken(ctx context.Context, storageType string, secret *v1.Secret) error {
+func (c *garbageCollectorController) maybeRevokeUpstreamOIDCToken(ctx context.Context, storageType string, secret *corev1.Secret) error {
 	// All downstream session storage types hold upstream tokens when the upstream IDP is an OIDC provider.
 	// However, some of them will be outdated because they are not updated by fosite after creation.
 	// Our goal below is to always revoke the latest upstream refresh token that we are holding for the
@@ -238,7 +238,7 @@ func (c *garbageCollectorController) maybeRevokeUpstreamOIDCToken(ctx context.Co
 	}
 }
 
-func (c *garbageCollectorController) tryRevokeUpstreamOIDCToken(ctx context.Context, customSessionData *psession.CustomSessionData, secret *v1.Secret) error {
+func (c *garbageCollectorController) tryRevokeUpstreamOIDCToken(ctx context.Context, customSessionData *psession.CustomSessionData, secret *corev1.Secret) error {
 	// When session was for another upstream IDP type, e.g. LDAP, there is no upstream OIDC token involved.
 	if customSessionData.ProviderType != psession.ProviderTypeOIDC {
 		return nil
@@ -279,7 +279,7 @@ func (c *garbageCollectorController) tryRevokeUpstreamOIDCToken(ctx context.Cont
 	return nil
 }
 
-func logKV(secret *v1.Secret) []interface{} {
+func logKV(secret *corev1.Secret) []interface{} {
 	return []interface{}{
 		"secretName", secret.Name,
 		"secretNamespace", secret.Namespace,

--- a/internal/controller/supervisorstorage/garbage_collector_test.go
+++ b/internal/controller/supervisorstorage/garbage_collector_test.go
@@ -18,7 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	kubeinformers "k8s.io/client-go/informers"
+	k8sinformers "k8s.io/client-go/informers"
 	kubernetesfake "k8s.io/client-go/kubernetes/fake"
 	kubetesting "k8s.io/client-go/testing"
 	"k8s.io/utils/clock"
@@ -47,7 +47,7 @@ func TestGarbageCollectorControllerInformerFilters(t *testing.T) {
 		it.Before(func() {
 			r = require.New(t)
 			observableWithInformerOption = testutil.NewObservableWithInformerOption()
-			secretsInformer := kubeinformers.NewSharedInformerFactory(nil, 0).Core().V1().Secrets()
+			secretsInformer := k8sinformers.NewSharedInformerFactory(nil, 0).Core().V1().Secrets()
 			_ = GarbageCollectorController(
 				nil,
 				clock.RealClock{},
@@ -128,7 +128,7 @@ func TestGarbageCollectorControllerSync(t *testing.T) {
 			subject                 controllerlib.Controller
 			kubeInformerClient      *kubernetesfake.Clientset
 			kubeClient              *kubernetesfake.Clientset
-			kubeInformers           kubeinformers.SharedInformerFactory
+			kubeInformers           k8sinformers.SharedInformerFactory
 			cancelContext           context.Context
 			cancelContextCancelFunc context.CancelFunc
 			syncContext             *controllerlib.Context
@@ -171,7 +171,7 @@ func TestGarbageCollectorControllerSync(t *testing.T) {
 
 			kubeInformerClient = kubernetesfake.NewSimpleClientset()
 			kubeClient = kubernetesfake.NewSimpleClientset()
-			kubeInformers = kubeinformers.NewSharedInformerFactory(kubeInformerClient, 0)
+			kubeInformers = k8sinformers.NewSharedInformerFactory(kubeInformerClient, 0)
 			frozenNow = time.Now().UTC()
 			fakeClock = clocktesting.NewFakeClock(frozenNow)
 

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -4,7 +4,7 @@
 package controller
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"go.pinniped.dev/internal/controllerlib"
@@ -43,9 +43,9 @@ func SimpleFilter(match func(metav1.Object) bool, parentFunc controllerlib.Paren
 	}
 }
 
-func MatchAnySecretOfTypeFilter(secretType v1.SecretType, parentFunc controllerlib.ParentFunc) controllerlib.Filter {
+func MatchAnySecretOfTypeFilter(secretType corev1.SecretType, parentFunc controllerlib.ParentFunc) controllerlib.Filter {
 	isSecretOfType := func(obj metav1.Object) bool {
-		secret, ok := obj.(*v1.Secret)
+		secret, ok := obj.(*corev1.Secret)
 		if !ok {
 			return false
 		}

--- a/internal/controllermanager/prepare_controllers.go
+++ b/internal/controllermanager/prepare_controllers.go
@@ -13,8 +13,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/clock"
 
-	pinnipedclientset "go.pinniped.dev/generated/latest/client/concierge/clientset/versioned"
-	pinnipedinformers "go.pinniped.dev/generated/latest/client/concierge/informers/externalversions"
+	conciergeclientset "go.pinniped.dev/generated/latest/client/concierge/clientset/versioned"
+	conciergeinformers "go.pinniped.dev/generated/latest/client/concierge/informers/externalversions"
 	"go.pinniped.dev/internal/apiserviceref"
 	"go.pinniped.dev/internal/concierge/impersonator"
 	"go.pinniped.dev/internal/config/concierge"
@@ -320,14 +320,14 @@ type informers struct {
 	kubePublicNamespaceK8s   k8sinformers.SharedInformerFactory
 	kubeSystemNamespaceK8s   k8sinformers.SharedInformerFactory
 	installationNamespaceK8s k8sinformers.SharedInformerFactory
-	pinniped                 pinnipedinformers.SharedInformerFactory
+	pinniped                 conciergeinformers.SharedInformerFactory
 }
 
 // Create the informers that will be used by the controllers.
 func createInformers(
 	serverInstallationNamespace string,
 	k8sClient kubernetes.Interface,
-	pinnipedClient pinnipedclientset.Interface,
+	pinnipedClient conciergeclientset.Interface,
 ) *informers {
 	return &informers{
 		kubePublicNamespaceK8s: k8sinformers.NewSharedInformerFactoryWithOptions(
@@ -345,7 +345,7 @@ func createInformers(
 			defaultResyncInterval,
 			k8sinformers.WithNamespace(serverInstallationNamespace),
 		),
-		pinniped: pinnipedinformers.NewSharedInformerFactoryWithOptions(
+		pinniped: conciergeinformers.NewSharedInformerFactoryWithOptions(
 			pinnipedClient,
 			defaultResyncInterval,
 		),

--- a/internal/crypto/ptls/ptls.go
+++ b/internal/crypto/ptls/ptls.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2022 the Pinniped contributors. All Rights Reserved.
+// Copyright 2021-2023 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package ptls
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/options"
-	kubeinformers "k8s.io/client-go/informers"
+	k8sinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/transport"
@@ -104,7 +104,7 @@ func secureClient(opts *options.RecommendedOptions, f RestConfigFunc) error {
 	opts.ExtraAdmissionInitializers = func(c *genericapiserver.RecommendedConfig) ([]admission.PluginInitializer, error) {
 		// abuse this closure to rewrite how we load admission plugins
 		c.ClientConfig = inClusterConfig
-		c.SharedInformerFactory = kubeinformers.NewSharedInformerFactory(inClusterClient, 0)
+		c.SharedInformerFactory = k8sinformers.NewSharedInformerFactory(inClusterClient, 0)
 
 		// abuse this closure to rewrite our loopback config
 		// this is mostly future proofing for post start hooks

--- a/internal/federationdomain/clientregistry/clientregistry.go
+++ b/internal/federationdomain/clientregistry/clientregistry.go
@@ -13,7 +13,7 @@ import (
 	coreosoidc "github.com/coreos/go-oidc/v3/oidc"
 	"github.com/ory/fosite"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	configv1alpha1 "go.pinniped.dev/generated/latest/apis/supervisor/config/v1alpha1"
 	oidcapi "go.pinniped.dev/generated/latest/apis/supervisor/oidc"
@@ -84,7 +84,7 @@ func (m *ClientManager) GetClient(ctx context.Context, id string) (fosite.Client
 	}
 
 	// Try to look up an OIDCClient with the given client ID (which will be the Name of the OIDCClient).
-	oidcClient, err := m.oidcClientsClient.Get(ctx, id, v1.GetOptions{})
+	oidcClient, err := m.oidcClientsClient.Get(ctx, id, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		return nil, fosite.ErrNotFound.WithDescription("no such client")
 	}

--- a/internal/federationdomain/oidcclientvalidator/oidcclientvalidator.go
+++ b/internal/federationdomain/oidcclientvalidator/oidcclientvalidator.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"golang.org/x/crypto/bcrypt"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"go.pinniped.dev/generated/latest/apis/supervisor/config/v1alpha1"
@@ -37,7 +37,7 @@ const (
 // get the validation error for that case. It returns a bool to indicate if the client is valid,
 // along with a slice of conditions containing more details, and the list of client secrets in the
 // case that the client was valid.
-func Validate(oidcClient *v1alpha1.OIDCClient, secret *v1.Secret, minBcryptCost int) (bool, []*metav1.Condition, []string) {
+func Validate(oidcClient *v1alpha1.OIDCClient, secret *corev1.Secret, minBcryptCost int) (bool, []*metav1.Condition, []string) {
 	conds := make([]*metav1.Condition, 0, 3)
 
 	conds, clientSecrets := validateSecret(secret, conds, minBcryptCost)
@@ -132,7 +132,7 @@ func validateAllowedGrantTypes(oidcClient *v1alpha1.OIDCClient, conditions []*me
 
 // validateSecret checks if the client secret storage Secret is valid and contains at least one client secret.
 // It returns the updated conditions slice along with the client secrets found in that case that it is valid.
-func validateSecret(secret *v1.Secret, conditions []*metav1.Condition, minBcryptCost int) ([]*metav1.Condition, []string) {
+func validateSecret(secret *corev1.Secret, conditions []*metav1.Condition, minBcryptCost int) ([]*metav1.Condition, []string) {
 	emptyList := []string{}
 
 	if secret == nil {

--- a/internal/fositestorage/accesstoken/accesstoken.go
+++ b/internal/fositestorage/accesstoken/accesstoken.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/handler/oauth2"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 
@@ -56,7 +56,7 @@ func New(secrets corev1client.SecretInterface, clock func() time.Time, sessionSt
 }
 
 // ReadFromSecret reads the contents of a Secret as a Session.
-func ReadFromSecret(secret *v1.Secret) (*Session, error) {
+func ReadFromSecret(secret *corev1.Secret) (*Session, error) {
 	session := newValidEmptyAccessTokenSession()
 	err := crud.FromSecret(TypeLabelValue, secret, session)
 	if err != nil {

--- a/internal/fositestorage/authorizationcode/authorizationcode.go
+++ b/internal/fositestorage/authorizationcode/authorizationcode.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/handler/oauth2"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 
@@ -53,7 +53,7 @@ func New(secrets corev1client.SecretInterface, clock func() time.Time, sessionSt
 }
 
 // ReadFromSecret reads the contents of a Secret as a Session.
-func ReadFromSecret(secret *v1.Secret) (*Session, error) {
+func ReadFromSecret(secret *corev1.Secret) (*Session, error) {
 	session := NewValidEmptyAuthorizeCodeSession()
 	err := crud.FromSecret(TypeLabelValue, secret, session)
 	if err != nil {

--- a/internal/fositestorage/refreshtoken/refreshtoken.go
+++ b/internal/fositestorage/refreshtoken/refreshtoken.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/handler/oauth2"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 
@@ -57,7 +57,7 @@ func New(secrets corev1client.SecretInterface, clock func() time.Time, sessionSt
 }
 
 // ReadFromSecret reads the contents of a Secret as a Session.
-func ReadFromSecret(secret *v1.Secret) (*Session, error) {
+func ReadFromSecret(secret *corev1.Secret) (*Session, error) {
 	session := newValidEmptyRefreshTokenSession()
 	err := crud.FromSecret(TypeLabelValue, secret, session)
 	if err != nil {

--- a/internal/localuserauthenticator/localuserauthenticator.go
+++ b/internal/localuserauthenticator/localuserauthenticator.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package localuserauthenticator provides a authentication webhook program.
@@ -29,7 +29,7 @@ import (
 	authenticationv1beta1 "k8s.io/api/authentication/v1beta1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kubeinformers "k8s.io/client-go/informers"
+	k8sinformers "k8s.io/client-go/informers"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -283,7 +283,7 @@ func startControllers(
 	ctx context.Context,
 	dynamicCertProvider dynamiccert.Private,
 	kubeClient kubernetes.Interface,
-	kubeInformers kubeinformers.SharedInformerFactory,
+	kubeInformers k8sinformers.SharedInformerFactory,
 ) {
 	aVeryLongTime := time.Hour * 24 * 365 * 100
 
@@ -346,10 +346,10 @@ func run(ctx context.Context) error {
 		return fmt.Errorf("cannot create k8s client: %w", err)
 	}
 
-	kubeInformers := kubeinformers.NewSharedInformerFactoryWithOptions(
+	kubeInformers := k8sinformers.NewSharedInformerFactoryWithOptions(
 		client.Kubernetes,
 		defaultResyncInterval,
-		kubeinformers.WithNamespace(namespace),
+		k8sinformers.WithNamespace(namespace),
 	)
 
 	dynamicCertProvider := dynamiccert.NewServingCert("local-user-authenticator-tls-serving-certificate")

--- a/internal/localuserauthenticator/localuserauthenticator_test.go
+++ b/internal/localuserauthenticator/localuserauthenticator_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package localuserauthenticator
@@ -24,7 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
-	kubeinformers "k8s.io/client-go/informers"
+	k8sinformers "k8s.io/client-go/informers"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	kubernetesfake "k8s.io/client-go/kubernetes/fake"
@@ -433,7 +433,7 @@ func TestWebhook(t *testing.T) {
 func createSecretInformer(ctx context.Context, t *testing.T, kubeClient kubernetes.Interface) corev1informers.SecretInformer {
 	t.Helper()
 
-	kubeInformers := kubeinformers.NewSharedInformerFactory(kubeClient, 0)
+	kubeInformers := k8sinformers.NewSharedInformerFactory(kubeClient, 0)
 
 	secretInformer := kubeInformers.Core().V1().Secrets()
 

--- a/internal/supervisor/server/server.go
+++ b/internal/supervisor/server/server.go
@@ -30,7 +30,7 @@ import (
 	openapinamer "k8s.io/apiserver/pkg/endpoints/openapi"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
-	kubeinformers "k8s.io/client-go/informers"
+	k8sinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
@@ -38,9 +38,9 @@ import (
 	"k8s.io/utils/clock"
 
 	configv1alpha1 "go.pinniped.dev/generated/latest/apis/supervisor/config/v1alpha1"
-	pinnipedclientset "go.pinniped.dev/generated/latest/client/supervisor/clientset/versioned"
+	supervisorclientset "go.pinniped.dev/generated/latest/client/supervisor/clientset/versioned"
 	"go.pinniped.dev/generated/latest/client/supervisor/clientset/versioned/typed/config/v1alpha1"
-	pinnipedinformers "go.pinniped.dev/generated/latest/client/supervisor/informers/externalversions"
+	supervisorinformers "go.pinniped.dev/generated/latest/client/supervisor/informers/externalversions"
 	supervisoropenapi "go.pinniped.dev/generated/latest/client/supervisor/openapi"
 	"go.pinniped.dev/internal/apiserviceref"
 	"go.pinniped.dev/internal/config/supervisor"
@@ -138,10 +138,10 @@ func prepareControllers(
 	secretCache *secret.Cache,
 	supervisorDeployment *appsv1.Deployment,
 	kubeClient kubernetes.Interface,
-	pinnipedClient pinnipedclientset.Interface,
+	pinnipedClient supervisorclientset.Interface,
 	aggregatorClient aggregatorclient.Interface,
-	kubeInformers kubeinformers.SharedInformerFactory,
-	pinnipedInformers pinnipedinformers.SharedInformerFactory,
+	kubeInformers k8sinformers.SharedInformerFactory,
+	pinnipedInformers supervisorinformers.SharedInformerFactory,
 	leaderElector controllerinit.RunnerWrapper,
 	podInfo *downward.PodInfo,
 ) controllerinit.RunnerBuilder {
@@ -419,16 +419,16 @@ func runSupervisor(ctx context.Context, podInfo *downward.PodInfo, cfg *supervis
 		return fmt.Errorf("cannot create k8s client without leader election: %w", err)
 	}
 
-	kubeInformers := kubeinformers.NewSharedInformerFactoryWithOptions(
+	kubeInformers := k8sinformers.NewSharedInformerFactoryWithOptions(
 		client.Kubernetes,
 		defaultResyncInterval,
-		kubeinformers.WithNamespace(serverInstallationNamespace),
+		k8sinformers.WithNamespace(serverInstallationNamespace),
 	)
 
-	pinnipedInformers := pinnipedinformers.NewSharedInformerFactoryWithOptions(
+	pinnipedInformers := supervisorinformers.NewSharedInformerFactoryWithOptions(
 		client.PinnipedSupervisor,
 		defaultResyncInterval,
-		pinnipedinformers.WithNamespace(serverInstallationNamespace),
+		supervisorinformers.WithNamespace(serverInstallationNamespace),
 	)
 
 	// Serve the /healthz endpoint and make all other paths result in 404.

--- a/internal/testutil/psession.go
+++ b/internal/testutil/psession.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/ory/fosite/handler/openid"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	testing2 "k8s.io/client-go/testing"
 
@@ -40,9 +40,9 @@ func NewFakePinnipedSession() *psession.PinnipedSession {
 }
 
 func LogActualJSONFromCreateAction(t *testing.T, client *fake.Clientset, actionIndex int) {
-	t.Log("actual value of CreateAction secret data", string(client.Actions()[actionIndex].(testing2.CreateActionImpl).Object.(*v1.Secret).Data["pinniped-storage-data"]))
+	t.Log("actual value of CreateAction secret data", string(client.Actions()[actionIndex].(testing2.CreateActionImpl).Object.(*corev1.Secret).Data["pinniped-storage-data"]))
 }
 
 func LogActualJSONFromUpdateAction(t *testing.T, client *fake.Clientset, actionIndex int) {
-	t.Log("actual value of UpdateAction secret data", string(client.Actions()[actionIndex].(testing2.UpdateActionImpl).Object.(*v1.Secret).Data["pinniped-storage-data"]))
+	t.Log("actual value of UpdateAction secret data", string(client.Actions()[actionIndex].(testing2.UpdateActionImpl).Object.(*corev1.Secret).Data["pinniped-storage-data"]))
 }

--- a/pkg/oidcclient/oidctypes/oidctypes.go
+++ b/pkg/oidcclient/oidctypes/oidctypes.go
@@ -1,10 +1,10 @@
-// Copyright 2020 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package oidctypes provides core data types for OIDC token structures.
 package oidctypes
 
-import v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // AccessToken is an OAuth2 access token.
 type AccessToken struct {
@@ -15,7 +15,7 @@ type AccessToken struct {
 	Type string `json:"type,omitempty"`
 
 	// Expiry is the optional expiration time of the access token.
-	Expiry v1.Time `json:"expiryTimestamp,omitempty"`
+	Expiry metav1.Time `json:"expiryTimestamp,omitempty"`
 }
 
 // RefreshToken is an OAuth2 refresh token.
@@ -30,7 +30,7 @@ type IDToken struct {
 	Token string `json:"token"`
 
 	// Expiry is the optional expiration time of the ID token.
-	Expiry v1.Time `json:"expiryTimestamp,omitempty"`
+	Expiry metav1.Time `json:"expiryTimestamp,omitempty"`
 
 	// Claims are the claims expressed by the Token.
 	Claims map[string]interface{} `json:"claims,omitempty"`

--- a/test/integration/concierge_impersonation_proxy_test.go
+++ b/test/integration/concierge_impersonation_proxy_test.go
@@ -37,7 +37,6 @@ import (
 	certificatesv1 "k8s.io/api/certificates/v1"
 	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -1795,9 +1794,9 @@ func TestImpersonationProxy(t *testing.T) { //nolint:gocyclo // yeah, it's compl
 			"external-tls-cert-secret-name",
 			corev1.SecretTypeTLS,
 			map[string]string{
-				"ca.crt":            string(externallyProvidedCA.Bundle()),
-				v1.TLSCertKey:       string(externallyProvidedTLSServingCertPEM),
-				v1.TLSPrivateKeyKey: string(externallyProvidedTLSServingKeyPEM),
+				"ca.crt":                string(externallyProvidedCA.Bundle()),
+				corev1.TLSCertKey:       string(externallyProvidedTLSServingCertPEM),
+				corev1.TLSPrivateKeyKey: string(externallyProvidedTLSServingKeyPEM),
 			})
 
 		_, originalInternallyGeneratedCAPEM := performImpersonatorDiscoveryURL(ctx, t, env, adminConciergeClient)
@@ -1867,9 +1866,9 @@ func TestImpersonationProxy(t *testing.T) { //nolint:gocyclo // yeah, it's compl
 			"external-tls-cert-secret-name-integration-tests",
 			corev1.SecretTypeTLS,
 			map[string][]byte{
-				"ca.crt":            externallyProvidedCA.Bundle(),
-				v1.TLSCertKey:       externallyProvidedTLSServingCertPEM,
-				v1.TLSPrivateKeyKey: externallyProvidedTLSServingKeyPEM,
+				"ca.crt":                externallyProvidedCA.Bundle(),
+				corev1.TLSCertKey:       externallyProvidedTLSServingCertPEM,
+				corev1.TLSPrivateKeyKey: externallyProvidedTLSServingKeyPEM,
 			})
 
 		_, originalInternallyGeneratedCAPEM := performImpersonatorDiscoveryURL(ctx, t, env, adminConciergeClient)

--- a/test/integration/controllerinit_test.go
+++ b/test/integration/controllerinit_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2021-2023 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package integration
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	kubeinformers "k8s.io/client-go/informers"
+	k8sinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
@@ -62,7 +62,7 @@ func TestControllerInitPrepare_Parallel(t *testing.T) {
 	})
 }
 
-func buildBrokenInformer(t *testing.T) kubeinformers.SharedInformerFactory {
+func buildBrokenInformer(t *testing.T) k8sinformers.SharedInformerFactory {
 	t.Helper()
 
 	config := testlib.NewClientConfig(t)
@@ -71,7 +71,7 @@ func buildBrokenInformer(t *testing.T) kubeinformers.SharedInformerFactory {
 
 	client := kubernetes.NewForConfigOrDie(config)
 
-	informers := kubeinformers.NewSharedInformerFactoryWithOptions(client, 0)
+	informers := k8sinformers.NewSharedInformerFactoryWithOptions(client, 0)
 
 	// make sure some informers gets lazily loaded
 	_ = informers.Core().V1().Nodes().Informer()

--- a/test/integration/supervisor_discovery_test.go
+++ b/test/integration/supervisor_discovery_test.go
@@ -27,7 +27,7 @@ import (
 
 	"go.pinniped.dev/generated/latest/apis/supervisor/config/v1alpha1"
 	idpv1alpha1 "go.pinniped.dev/generated/latest/apis/supervisor/idp/v1alpha1"
-	pinnipedclientset "go.pinniped.dev/generated/latest/client/supervisor/clientset/versioned"
+	supervisorclientset "go.pinniped.dev/generated/latest/client/supervisor/clientset/versioned"
 	"go.pinniped.dev/internal/certauthority"
 	"go.pinniped.dev/internal/crypto/ptls"
 	"go.pinniped.dev/internal/here"
@@ -364,7 +364,7 @@ func temporarilyRemoveAllFederationDomainsAndDefaultTLSCertSecret(
 	t *testing.T,
 	ns string,
 	defaultTLSCertSecretName string,
-	pinnipedClient pinnipedclientset.Interface,
+	pinnipedClient supervisorclientset.Interface,
 	kubeClient kubernetes.Interface,
 ) {
 	// Temporarily remove any existing FederationDomains from the cluster so we can test from a clean slate.
@@ -485,7 +485,7 @@ func requireCreatingFederationDomainCausesDiscoveryEndpointsToAppear(
 	t *testing.T,
 	supervisorScheme, supervisorAddress, supervisorCABundle string,
 	issuerName string,
-	client pinnipedclientset.Interface,
+	client supervisorclientset.Interface,
 ) (*v1alpha1.FederationDomain, *ExpectedJWKSResponseFormat) {
 	t.Helper()
 	newFederationDomain := testlib.CreateTestFederationDomain(ctx, t, v1alpha1.FederationDomainSpec{Issuer: issuerName}, v1alpha1.FederationDomainPhaseReady)
@@ -503,7 +503,7 @@ func requireDiscoveryEndpointsAreWorking(t *testing.T, supervisorScheme, supervi
 func requireDeletingFederationDomainCausesDiscoveryEndpointsToDisappear(
 	t *testing.T,
 	existingFederationDomain *v1alpha1.FederationDomain,
-	client pinnipedclientset.Interface,
+	client supervisorclientset.Interface,
 	ns string,
 	supervisorScheme, supervisorAddress, supervisorCABundle string,
 	issuerName string,
@@ -628,7 +628,7 @@ func requireSuccessEndpointResponse(t *testing.T, endpointURL, issuer, caBundle 
 func editFederationDomainIssuerName(
 	t *testing.T,
 	existingFederationDomain *v1alpha1.FederationDomain,
-	client pinnipedclientset.Interface,
+	client supervisorclientset.Interface,
 	ns string,
 	newIssuerName string,
 ) *v1alpha1.FederationDomain {
@@ -649,7 +649,7 @@ func editFederationDomainIssuerName(
 	return updated
 }
 
-func requireDelete(t *testing.T, client pinnipedclientset.Interface, ns, name string) {
+func requireDelete(t *testing.T, client supervisorclientset.Interface, ns, name string) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
@@ -685,7 +685,7 @@ func withFalseConditions(falseConditionTypes []string) map[string]metav1.Conditi
 	return c
 }
 
-func requireStatus(t *testing.T, client pinnipedclientset.Interface, ns, name string, wantPhase v1alpha1.FederationDomainPhase, wantConditionTypeToStatus map[string]metav1.ConditionStatus) {
+func requireStatus(t *testing.T, client supervisorclientset.Interface, ns, name string, wantPhase v1alpha1.FederationDomainPhase, wantConditionTypeToStatus map[string]metav1.ConditionStatus) {
 	t.Helper()
 
 	testlib.RequireEventually(t, func(requireEventually *require.Assertions) {

--- a/test/integration/supervisor_login_test.go
+++ b/test/integration/supervisor_login_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"k8s.io/utils/strings/slices"
@@ -73,13 +73,13 @@ func TestSupervisorLogin_Browser(t *testing.T) {
 		}
 	}
 
-	createActiveDirectoryIdentityProvider := func(t *testing.T, edit func(spec *idpv1alpha1.ActiveDirectoryIdentityProviderSpec)) (*idpv1alpha1.ActiveDirectoryIdentityProvider, *v1.Secret) {
+	createActiveDirectoryIdentityProvider := func(t *testing.T, edit func(spec *idpv1alpha1.ActiveDirectoryIdentityProviderSpec)) (*idpv1alpha1.ActiveDirectoryIdentityProvider, *corev1.Secret) {
 		t.Helper()
 
-		secret := testlib.CreateTestSecret(t, env.SupervisorNamespace, "ad-service-account", v1.SecretTypeBasicAuth,
+		secret := testlib.CreateTestSecret(t, env.SupervisorNamespace, "ad-service-account", corev1.SecretTypeBasicAuth,
 			map[string]string{
-				v1.BasicAuthUsernameKey: env.SupervisorUpstreamActiveDirectory.BindUsername,
-				v1.BasicAuthPasswordKey: env.SupervisorUpstreamActiveDirectory.BindPassword,
+				corev1.BasicAuthUsernameKey: env.SupervisorUpstreamActiveDirectory.BindUsername,
+				corev1.BasicAuthPasswordKey: env.SupervisorUpstreamActiveDirectory.BindPassword,
 			},
 		)
 
@@ -109,13 +109,13 @@ func TestSupervisorLogin_Browser(t *testing.T) {
 		return adIDP, secret
 	}
 
-	createLDAPIdentityProvider := func(t *testing.T, edit func(spec *idpv1alpha1.LDAPIdentityProviderSpec)) (*idpv1alpha1.LDAPIdentityProvider, *v1.Secret) {
+	createLDAPIdentityProvider := func(t *testing.T, edit func(spec *idpv1alpha1.LDAPIdentityProviderSpec)) (*idpv1alpha1.LDAPIdentityProvider, *corev1.Secret) {
 		t.Helper()
 
-		secret := testlib.CreateTestSecret(t, env.SupervisorNamespace, "ldap-service-account", v1.SecretTypeBasicAuth,
+		secret := testlib.CreateTestSecret(t, env.SupervisorNamespace, "ldap-service-account", corev1.SecretTypeBasicAuth,
 			map[string]string{
-				v1.BasicAuthUsernameKey: env.SupervisorUpstreamLDAP.BindUsername,
-				v1.BasicAuthPasswordKey: env.SupervisorUpstreamLDAP.BindPassword,
+				corev1.BasicAuthUsernameKey: env.SupervisorUpstreamLDAP.BindUsername,
+				corev1.BasicAuthPasswordKey: env.SupervisorUpstreamLDAP.BindPassword,
 			},
 		)
 
@@ -875,15 +875,15 @@ func TestSupervisorLogin_Browser(t *testing.T) {
 				// create the secret again
 				recreateCtx, recreateCancel := context.WithTimeout(context.Background(), time.Minute)
 				defer recreateCancel()
-				recreatedSecret, err := client.CoreV1().Secrets(env.SupervisorNamespace).Create(recreateCtx, &v1.Secret{
+				recreatedSecret, err := client.CoreV1().Secrets(env.SupervisorNamespace).Create(recreateCtx, &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      secret.Name,
 						Namespace: env.SupervisorNamespace,
 					},
-					Type: v1.SecretTypeBasicAuth,
+					Type: corev1.SecretTypeBasicAuth,
 					StringData: map[string]string{
-						v1.BasicAuthUsernameKey: env.SupervisorUpstreamLDAP.BindUsername,
-						v1.BasicAuthPasswordKey: env.SupervisorUpstreamLDAP.BindPassword,
+						corev1.BasicAuthUsernameKey: env.SupervisorUpstreamLDAP.BindUsername,
+						corev1.BasicAuthPasswordKey: env.SupervisorUpstreamLDAP.BindPassword,
 					},
 				}, metav1.CreateOptions{})
 				require.NoError(t, err)
@@ -1110,15 +1110,15 @@ func TestSupervisorLogin_Browser(t *testing.T) {
 				// create the secret again
 				recreateCtx, recreateCancel := context.WithTimeout(context.Background(), time.Minute)
 				defer recreateCancel()
-				recreatedSecret, err := client.CoreV1().Secrets(env.SupervisorNamespace).Create(recreateCtx, &v1.Secret{
+				recreatedSecret, err := client.CoreV1().Secrets(env.SupervisorNamespace).Create(recreateCtx, &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      secret.Name,
 						Namespace: env.SupervisorNamespace,
 					},
-					Type: v1.SecretTypeBasicAuth,
+					Type: corev1.SecretTypeBasicAuth,
 					StringData: map[string]string{
-						v1.BasicAuthUsernameKey: env.SupervisorUpstreamActiveDirectory.BindUsername,
-						v1.BasicAuthPasswordKey: env.SupervisorUpstreamActiveDirectory.BindPassword,
+						corev1.BasicAuthUsernameKey: env.SupervisorUpstreamActiveDirectory.BindUsername,
+						corev1.BasicAuthPasswordKey: env.SupervisorUpstreamActiveDirectory.BindPassword,
 					},
 				}, metav1.CreateOptions{})
 				require.NoError(t, err)
@@ -1449,7 +1449,7 @@ func TestSupervisorLogin_Browser(t *testing.T) {
 				return []configv1alpha1.FederationDomainIdentityProvider{
 						{
 							DisplayName: displayName,
-							ObjectRef: v1.TypedLocalObjectReference{
+							ObjectRef: corev1.TypedLocalObjectReference{
 								APIGroup: ptr.To("idp.supervisor." + env.APIGroupSuffix),
 								Kind:     "OIDCIdentityProvider",
 								Name:     idpName,
@@ -1823,7 +1823,7 @@ func TestSupervisorLogin_Browser(t *testing.T) {
 				return []configv1alpha1.FederationDomainIdentityProvider{
 					{
 						DisplayName: displayName,
-						ObjectRef: v1.TypedLocalObjectReference{
+						ObjectRef: corev1.TypedLocalObjectReference{
 							APIGroup: ptr.To("idp.supervisor." + env.APIGroupSuffix),
 							Kind:     "OIDCIdentityProvider",
 							Name:     idpName,
@@ -1884,7 +1884,7 @@ func TestSupervisorLogin_Browser(t *testing.T) {
 				return []configv1alpha1.FederationDomainIdentityProvider{
 					{
 						DisplayName: displayName,
-						ObjectRef: v1.TypedLocalObjectReference{
+						ObjectRef: corev1.TypedLocalObjectReference{
 							APIGroup: ptr.To("idp.supervisor." + env.APIGroupSuffix),
 							Kind:     "LDAPIdentityProvider",
 							Name:     idpName,
@@ -1951,7 +1951,7 @@ func TestSupervisorLogin_Browser(t *testing.T) {
 				return []configv1alpha1.FederationDomainIdentityProvider{
 					{
 						DisplayName: displayName,
-						ObjectRef: v1.TypedLocalObjectReference{
+						ObjectRef: corev1.TypedLocalObjectReference{
 							APIGroup: ptr.To("idp.supervisor." + env.APIGroupSuffix),
 							Kind:     "LDAPIdentityProvider",
 							Name:     idpName,
@@ -2015,7 +2015,7 @@ func TestSupervisorLogin_Browser(t *testing.T) {
 				return []configv1alpha1.FederationDomainIdentityProvider{
 					{
 						DisplayName: displayName,
-						ObjectRef: v1.TypedLocalObjectReference{
+						ObjectRef: corev1.TypedLocalObjectReference{
 							APIGroup: ptr.To("idp.supervisor." + env.APIGroupSuffix),
 							Kind:     "ActiveDirectoryIdentityProvider",
 							Name:     idpName,
@@ -2084,7 +2084,7 @@ func TestSupervisorLogin_Browser(t *testing.T) {
 				return []configv1alpha1.FederationDomainIdentityProvider{
 					{
 						DisplayName: displayName,
-						ObjectRef: v1.TypedLocalObjectReference{
+						ObjectRef: corev1.TypedLocalObjectReference{
 							APIGroup: ptr.To("idp.supervisor." + env.APIGroupSuffix),
 							Kind:     "ActiveDirectoryIdentityProvider",
 							Name:     idpName,
@@ -2376,7 +2376,7 @@ func testSupervisorLogin(
 	certSecret := testlib.CreateTestSecret(t,
 		env.SupervisorNamespace,
 		"oidc-provider-tls",
-		v1.SecretTypeTLS,
+		corev1.SecretTypeTLS,
 		map[string]string{"tls.crt": string(certPEM), "tls.key": string(keyPEM)},
 	)
 

--- a/test/integration/supervisor_storage_garbage_collection_test.go
+++ b/test/integration/supervisor_storage_garbage_collection_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package integration
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -67,7 +67,7 @@ func TestStorageGarbageCollection_Parallel(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func updateSecretEveryTwoSeconds(stopCh chan struct{}, errCh chan error, secrets corev1client.SecretInterface, secret *v1.Secret) {
+func updateSecretEveryTwoSeconds(stopCh chan struct{}, errCh chan error, secrets corev1client.SecretInterface, secret *corev1.Secret) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
@@ -112,7 +112,7 @@ func updateSecretEveryTwoSeconds(stopCh chan struct{}, errCh chan error, secrets
 	}
 }
 
-func createSecret(ctx context.Context, t *testing.T, secrets corev1client.SecretInterface, name string, expiresAt time.Time) *v1.Secret {
+func createSecret(ctx context.Context, t *testing.T, secrets corev1client.SecretInterface, name string, expiresAt time.Time) *corev1.Secret {
 	secret, err := secrets.Create(ctx, newSecret("pinniped-storage-gc-integration-test-"+name+"-", expiresAt), metav1.CreateOptions{})
 	require.NoError(t, err)
 
@@ -131,13 +131,13 @@ func createSecret(ctx context.Context, t *testing.T, secrets corev1client.Secret
 	return secret
 }
 
-func newSecret(namePrefix string, expiresAt time.Time) *v1.Secret {
+func newSecret(namePrefix string, expiresAt time.Time) *corev1.Secret {
 	annotations := map[string]string{}
 	if !expiresAt.Equal(time.Time{}) {
 		// Mark the secret for garbage collection.
 		annotations[crud.SecretLifetimeAnnotationKey] = expiresAt.UTC().Format(time.RFC3339)
 	}
-	return &v1.Secret{
+	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: namePrefix,
 			Annotations:  annotations,

--- a/test/integration/supervisor_storage_test.go
+++ b/test/integration/supervisor_storage_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/compose"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -107,7 +107,7 @@ func TestAuthorizeCodeStorage(t *testing.T) {
 	require.Equal(t, map[string]string{"storage.pinniped.dev/type": "authcode"}, initialSecret.Labels)
 
 	// check that the Secret got the right type
-	require.Equal(t, v1.SecretType("storage.pinniped.dev/authcode"), initialSecret.Type)
+	require.Equal(t, corev1.SecretType("storage.pinniped.dev/authcode"), initialSecret.Type)
 
 	// we should be able to get the session now and the request should be the same as what we put in
 	request, err := storage.GetAuthorizeCodeSession(ctx, signature, nil)


### PR DESCRIPTION
Taking some inspiration from [cluster-api](https://github.com/kubernetes-sigs/cluster-api/blob/9f7c446652f6b507a8f7e4e046f5c67c76f86cbd/.golangci.yml#L98-L166) and [cluster-api-provider-vsphere](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/ea2041de40783878d192260604cece5b8ea67a14/.golangci.yml#L92-L133), we should standardize our imports.

I found that it's not easy to retrofit the `golangci-lint` rule into a large existing codebase, since it seems to require that ALL import aliases are called out in the `.golangci.yaml` configuration.