### PR TITLE
revert the disabling of http2 for the Supervisor OIDC endpoints

### DIFF
--- a/internal/supervisor/server/server.go
+++ b/internal/supervisor/server/server.go
@@ -531,10 +531,6 @@ func runSupervisor(ctx context.Context, podInfo *downward.PodInfo, cfg *supervis
 		}
 
 		c := ptls.Default(nil)
-		// Remove "h2" from the list for now, until we have a better idea of how to mitigate
-		// potential http2 rapid reset vulnerabilities. This disables serving requests using http2.
-		c.NextProtos = []string{"http/1.1"}
-
 		c.GetCertificate = func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
 			cert := dynamicTLSCertProvider.GetTLSCert(strings.ToLower(info.ServerName))
 			foundServerNameCert := cert != nil


### PR DESCRIPTION
This reverts a small part of #1789 due to the unintended consequence of potentially breaking Ingresses which were configured to use http2 on their backends.

See more details in comment: https://github.com/vmware-tanzu/pinniped/pull/1789#discussion_r1417976580

**Release note**:

None. This is reverting a change that was never included in a release.

```release-note
NONE
```
