### PR TITLE
Add more output on failure of TokenCredentialRequest integration tests

### DIFF
--- a/test/integration/concierge_credentialrequest_test.go
+++ b/test/integration/concierge_credentialrequest_test.go
@@ -39,7 +39,7 @@ func TestUnsuccessfulCredentialRequest_Parallel(t *testing.T) {
 			},
 		},
 	)
-	require.NoError(t, err)
+	require.NoError(t, err, testlib.Sdump(err))
 	require.Nil(t, response.Status.Credential)
 	require.NotNil(t, response.Status.Message)
 	require.Equal(t, "authentication failed", *response.Status.Message)
@@ -147,7 +147,7 @@ func TestFailedCredentialRequestWhenTheRequestIsValidButTheTokenDoesNotAuthentic
 		loginv1alpha1.TokenCredentialRequestSpec{Token: "not a good token", Authenticator: testWebhook},
 	)
 
-	require.NoError(t, err)
+	require.NoError(t, err, testlib.Sdump(err))
 
 	require.Empty(t, response.Spec)
 	require.Nil(t, response.Status.Credential)
@@ -170,7 +170,7 @@ func TestCredentialRequest_ShouldFailWhenRequestDoesNotIncludeToken_Parallel(t *
 
 	require.Error(t, err)
 	statusError, isStatus := err.(*errors.StatusError)
-	require.True(t, isStatus)
+	require.True(t, isStatus, testlib.Sdump(err))
 
 	require.Equal(t, 1, len(statusError.ErrStatus.Details.Causes))
 	cause := statusError.ErrStatus.Details.Causes[0]

--- a/test/integration/concierge_impersonation_proxy_test.go
+++ b/test/integration/concierge_impersonation_proxy_test.go
@@ -644,7 +644,7 @@ func TestImpersonationProxy(t *testing.T) { //nolint:gocyclo // yeah, it's compl
 				clusterAdminCredentials, impersonationProxyURL, impersonationProxyCACertPEM, nil).
 				PinnipedConcierge.IdentityV1alpha1().WhoAmIRequests().
 				Create(ctx, &identityv1alpha1.WhoAmIRequest{}, metav1.CreateOptions{})
-			require.NoError(t, err)
+			require.NoError(t, err, testlib.Sdump(err))
 
 			// The WhoAmI API is lossy:
 			// - It drops UID
@@ -695,7 +695,7 @@ func TestImpersonationProxy(t *testing.T) { //nolint:gocyclo // yeah, it's compl
 			// check that we impersonated the correct user and that the original user is retained in the extra
 			whoAmI, err := nestedImpersonationClient.PinnipedConcierge.IdentityV1alpha1().WhoAmIRequests().
 				Create(ctx, &identityv1alpha1.WhoAmIRequest{}, metav1.CreateOptions{})
-			require.NoError(t, err)
+			require.NoError(t, err, testlib.Sdump(err))
 			require.Equal(t,
 				expectedWhoAmIRequestResponse(
 					"other-user-to-impersonate",
@@ -851,7 +851,7 @@ func TestImpersonationProxy(t *testing.T) { //nolint:gocyclo // yeah, it's compl
 
 			whoAmI, err := nestedImpersonationClient.IdentityV1alpha1().WhoAmIRequests().
 				Create(ctx, &identityv1alpha1.WhoAmIRequest{}, metav1.CreateOptions{})
-			require.NoError(t, err)
+			require.NoError(t, err, testlib.Sdump(err))
 			require.Equal(t,
 				expectedWhoAmIRequestResponse(
 					"system:serviceaccount:kube-system:root-ca-cert-publisher",
@@ -875,7 +875,7 @@ func TestImpersonationProxy(t *testing.T) { //nolint:gocyclo // yeah, it's compl
 			).PinnipedConcierge
 			whoAmI, err := impersonationProxyPinnipedConciergeClient.IdentityV1alpha1().WhoAmIRequests().
 				Create(ctx, &identityv1alpha1.WhoAmIRequest{}, metav1.CreateOptions{})
-			require.NoError(t, err)
+			require.NoError(t, err, testlib.Sdump(err))
 			expectedGroups := make([]string, 0, len(env.TestUser.ExpectedGroups)+1) // make sure we do not mutate env.TestUser.ExpectedGroups
 			expectedGroups = append(expectedGroups, env.TestUser.ExpectedGroups...)
 			expectedGroups = append(expectedGroups, "system:authenticated")
@@ -897,7 +897,7 @@ func TestImpersonationProxy(t *testing.T) { //nolint:gocyclo // yeah, it's compl
 
 			// we expect the impersonation proxy to match the behavior of KAS in regards to anonymous requests
 			if env.HasCapability(testlib.AnonymousAuthenticationSupported) {
-				require.NoError(t, err)
+				require.NoError(t, err, testlib.Sdump(err))
 				require.Equal(t,
 					expectedWhoAmIRequestResponse(
 						"system:anonymous",
@@ -918,7 +918,7 @@ func TestImpersonationProxy(t *testing.T) { //nolint:gocyclo // yeah, it's compl
 				impersonationProxyURL, impersonationProxyCACertPEM, nil).PinnipedConcierge
 			whoAmI, err = impersonationProxyServiceAccountPinnipedConciergeClient.IdentityV1alpha1().WhoAmIRequests().
 				Create(ctx, &identityv1alpha1.WhoAmIRequest{}, metav1.CreateOptions{})
-			require.NoError(t, err)
+			require.NoError(t, err, testlib.Sdump(err))
 			require.Equal(t,
 				expectedWhoAmIRequestResponse(
 					serviceaccount.MakeUsername(namespaceName, saName),
@@ -997,7 +997,7 @@ func TestImpersonationProxy(t *testing.T) { //nolint:gocyclo // yeah, it's compl
 
 			whoAmITokenReq, err := impersonationProxySAClient.PinnipedConcierge.IdentityV1alpha1().WhoAmIRequests().
 				Create(ctx, &identityv1alpha1.WhoAmIRequest{}, metav1.CreateOptions{})
-			require.NoError(t, err)
+			require.NoError(t, err, testlib.Sdump(err))
 
 			// new service account tokens include the pod info in the extra fields
 			require.Equal(t,
@@ -1444,7 +1444,7 @@ func TestImpersonationProxy(t *testing.T) { //nolint:gocyclo // yeah, it's compl
 
 					whoAmI, err := impersonationProxyAnonymousClient.PinnipedConcierge.IdentityV1alpha1().WhoAmIRequests().
 						Create(ctx, &identityv1alpha1.WhoAmIRequest{}, metav1.CreateOptions{})
-					require.NoError(t, err)
+					require.NoError(t, err, testlib.Sdump(err))
 					require.Equal(t,
 						expectedWhoAmIRequestResponse(
 							"system:anonymous",
@@ -1978,7 +1978,7 @@ func TestImpersonationProxy(t *testing.T) { //nolint:gocyclo // yeah, it's compl
 			// Note that library.CreateTokenCredentialRequest makes an unauthenticated request, so we can't meaningfully
 			// perform this part of the test on a cluster which does not allow anonymous authentication.
 			tokenCredentialRequestResponse, err := testlib.CreateTokenCredentialRequest(ctx, t, credentialRequestSpecWithWorkingCredentials)
-			require.NoError(t, err)
+			require.NoError(t, err, testlib.Sdump(err))
 
 			require.NotNil(t, tokenCredentialRequestResponse.Status.Message, "expected an error message but got nil")
 			require.Equal(t, "authentication failed", *tokenCredentialRequestResponse.Status.Message)


### PR DESCRIPTION
In addition to adding more verbose test failure output to some assertions, this PR also updates a test's expectations to also work with pre-releases of future versions of Kubernetes which will include https://github.com/kubernetes/enhancements/issues/4214.

**Release note**:

None, changing test output and assertions only.

```release-note
NONE
```
