### PR TITLE
Update CI URL, increase lint timeout, disable some dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,11 +2,6 @@
 
 version: 2
 updates:
-  - package-ecosystem: "gomod"
-    open-pull-requests-limit: 100
-    directory: "/"
-    schedule:
-      interval: "daily"
 
   - package-ecosystem: "gomod"
     open-pull-requests-limit: 2
@@ -14,12 +9,21 @@ updates:
     schedule:
       interval: "daily"
 
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "daily"
+# Our own CI job is responsible for updating this go.mod file now.
+#  - package-ecosystem: "gomod"
+#    open-pull-requests-limit: 100
+#    directory: "/"
+#    schedule:
+#      interval: "daily"
 
-  - package-ecosystem: "docker"
-    directory: "/hack"  # this should keep the FIPS dockerfile updated per https://github.com/dependabot/feedback/issues/145#issuecomment-414738498
-    schedule:
-      interval: "daily"
+# Our own CI job is responsible for updating this Docker file now.
+#  - package-ecosystem: "docker"
+#    directory: "/"
+#    schedule:
+#      interval: "daily"
+
+# Our own CI job is responsible for updating this Docker file now.
+#  - package-ecosystem: "docker"
+#    directory: "/hack"  # this should keep the FIPS dockerfile updated per https://github.com/dependabot/feedback/issues/145#issuecomment-414738498
+#    schedule:
+#      interval: "daily"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@ To destroy the local Kubernetes cluster, run `./hack/kind-down.sh`.
 
 ### Observing Tests on the Continuous Integration Environment
 
-[CI](https://hush-house.pivotal.io/teams/tanzu-user-auth/pipelines/pinniped-pull-requests)
+[CI](https://ci.pinniped.dev/teams/main/pipelines/pull-requests)
 will not be triggered on a pull request until the pull request is reviewed and
 approved for CI by a project [maintainer](MAINTAINERS.md). Once CI is triggered,
 the progress and results will appear on the Github page for that

--- a/hack/module.sh
+++ b/hack/module.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
+# Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -13,7 +13,7 @@ function tidy_cmd() {
 }
 
 function lint_cmd() {
-  echo "golangci-lint run --modules-download-mode=readonly --timeout=20m"
+  echo "golangci-lint run --modules-download-mode=readonly --timeout=30m"
 }
 
 function test_cmd() {


### PR DESCRIPTION
- Update the URL of the CI system in `CONTRIBUTING.md`
- Increase the lint timeout for when CI workers get slow
- Disable dependabot watching some files in favor of using our own tooling and avoiding the additional load that lots of simultaneous separate dependabot PRs puts onto the CI workers, e.g. whenever there is a new version of the kube libs

**Release note**:

```release-note
NONE
```
