### PR TITLE
Upgrade fosite to latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@
 # Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG BUILD_IMAGE=golang:1.22.0@sha256:ef61a20960397f4d44b0e729298bf02327ca94f1519239ddc6d91689615b1367
-ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:112a87f19e83c83711cc81ce8ed0b4d79acd65789682a6a272df57c4a0858534
+ARG BUILD_IMAGE=golang:1.22.0@sha256:4a3e85e88ca4edb571679a3e8b86aaef16ad65134d3aba68760741a850d69f41
+ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:6a3500b086c2856fbc189f5d11351bdbcf7c4dc5673c2b6070aac9d607da90d7
 
 # Prepare to cross-compile by always running the build stage in the build platform, not the target platform.
 FROM --platform=$BUILDPLATFORM $BUILD_IMAGE as build-env

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/gorilla/websocket v1.5.1
 	github.com/joshlf/go-acl v0.0.0-20200411065538-eae00ae38531
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
-	github.com/ory/fosite v0.45.1-0.20240103162202-f4114878826c
+	github.com/ory/fosite v0.46.1-0.20240213131620-c16a2d159d6d
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pkg/errors v0.9.1
 	github.com/sclevine/spec v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -458,8 +458,8 @@ github.com/openzipkin/zipkin-go v0.4.1 h1:kNd/ST2yLLWhaWrkgchya40TJabe8Hioj9udfP
 github.com/openzipkin/zipkin-go v0.4.1/go.mod h1:qY0VqDSN1pOBN94dBc6w2GJlWLiovAyg7Qt6/I9HecM=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde h1:x0TT0RDC7UhAVbbWWBzr41ElhJx5tXPWkIHA2HWPRuw=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
-github.com/ory/fosite v0.45.1-0.20240103162202-f4114878826c h1:l2O0QFfznFYWpCSc8rsNosv9qb6eYBCdK5uFLQIDmQc=
-github.com/ory/fosite v0.45.1-0.20240103162202-f4114878826c/go.mod h1:fkMPsnm/UjiefE9dE9CdZQGOH48TWJLIzUcdGIXg8Kk=
+github.com/ory/fosite v0.46.1-0.20240213131620-c16a2d159d6d h1:Kw5dYrxKmY28QOds1q9gJdPEdMOcQQQt/RG/4Yb6vXA=
+github.com/ory/fosite v0.46.1-0.20240213131620-c16a2d159d6d/go.mod h1:fkMPsnm/UjiefE9dE9CdZQGOH48TWJLIzUcdGIXg8Kk=
 github.com/ory/go-acc v0.2.9-0.20230103102148-6b1c9a70dbbe h1:rvu4obdvqR0fkSIJ8IfgzKOWwZ5kOT2UNfLq81Qk7rc=
 github.com/ory/go-acc v0.2.9-0.20230103102148-6b1c9a70dbbe/go.mod h1:z4n3u6as84LbV4YmgjHhnwtccQqzf4cZlSk9f1FhygI=
 github.com/ory/go-convenience v0.1.0 h1:zouLKfF2GoSGnJwGq+PE/nJAE6dj2Zj5QlTgmMTsTS8=

--- a/hack/Dockerfile_fips
+++ b/hack/Dockerfile_fips
@@ -16,8 +16,8 @@
 # See https://go.googlesource.com/go/+/dev.boringcrypto/README.boringcrypto.md
 # and https://kupczynski.info/posts/fips-golang/ for details.
 
-ARG BUILD_IMAGE=golang:1.22.0@sha256:ef61a20960397f4d44b0e729298bf02327ca94f1519239ddc6d91689615b1367
-ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:112a87f19e83c83711cc81ce8ed0b4d79acd65789682a6a272df57c4a0858534
+ARG BUILD_IMAGE=golang:1.22.0@sha256:4a3e85e88ca4edb571679a3e8b86aaef16ad65134d3aba68760741a850d69f41
+ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:6a3500b086c2856fbc189f5d11351bdbcf7c4dc5673c2b6070aac9d607da90d7
 
 # This is not currently using --platform to prepare to cross-compile because we use gcc below to build
 # platform-specific GCO code. This makes multi-arch builds slow due to target platform emulation.

--- a/internal/controller/supervisorstorage/garbage_collector.go
+++ b/internal/controller/supervisorstorage/garbage_collector.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package supervisorstorage
@@ -227,8 +227,7 @@ func (c *garbageCollectorController) maybeRevokeUpstreamOIDCToken(ctx context.Co
 
 	case openidconnect.TypeLabelValue:
 		// For OIDC storage, there is no need to do anything for reasons similar to the PKCE storage.
-		// These are not deleted during downstream authcode exchange, probably due to a bug in fosite, even
-		// though it will never be read or updated again. However, the upstream token contained inside will
+		// These are deleted during downstream authcode exchange. The upstream token contained inside will
 		// be revoked by one of the other cases above.
 		return nil
 

--- a/internal/federationdomain/endpointsmanager/manager_test.go
+++ b/internal/federationdomain/endpointsmanager/manager_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package endpointsmanager
@@ -211,8 +211,8 @@ func TestManager(t *testing.T) {
 			r.Equal("some-state", actualLocationQueryParams.Get("state"))
 
 			// Make sure that we wired up the callback endpoint to use kube storage for fosite sessions.
-			r.Equal(len(kubeClient.Actions()), numberOfKubeActionsBeforeThisRequest+3,
-				"did not perform any kube actions during the callback request, but should have")
+			r.Equal(numberOfKubeActionsBeforeThisRequest+3, len(kubeClient.Actions()),
+				"did not perform expected number of kube actions during the callback request")
 
 			// Return the important parts of the response so we can use them in our next request to the token endpoint.
 			return actualLocationQueryParams.Get("code")
@@ -253,8 +253,8 @@ func TestManager(t *testing.T) {
 			oidctestutil.VerifyECDSAIDToken(t, jwkIssuer, downstreamClientID, privateKey, idToken)
 
 			// Make sure that we wired up the callback endpoint to use kube storage for fosite sessions.
-			r.Equal(len(kubeClient.Actions()), numberOfKubeActionsBeforeThisRequest+9,
-				"did not perform any kube actions during the callback request, but should have")
+			r.Equal(numberOfKubeActionsBeforeThisRequest+10, len(kubeClient.Actions()),
+				"did not perform expected number of kube actions during the callback request")
 		}
 
 		requireJWKSRequestToBeHandled := func(requestIssuer, requestURLSuffix, expectedJWKKeyID string) *jose.JSONWebKeySet {

--- a/internal/federationdomain/oidc/oidc.go
+++ b/internal/federationdomain/oidc/oidc.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package oidc contains common OIDC functionality needed by FederationDomains to implement
@@ -6,11 +6,9 @@
 package oidc
 
 import (
-	"context"
 	"crypto/subtle"
 	"fmt"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/felixge/httpsnoop"
@@ -131,10 +129,6 @@ func FositeOauth2Helper(
 	jwksProvider jwks.DynamicJWKSProvider,
 	timeoutsConfiguration timeouts.Configuration,
 ) fosite.OAuth2Provider {
-	isRedirectURISecureStrict := func(_ context.Context, uri *url.URL) bool {
-		return fosite.IsRedirectURISecureStrict(uri)
-	}
-
 	oauthConfig := &fosite.Config{
 		IDTokenIssuer: issuer,
 
@@ -157,7 +151,7 @@ func FositeOauth2Helper(
 		MinParameterEntropy: fosite.MinParameterEntropy,
 
 		// do not allow custom scheme redirects, only https and http (on loopback)
-		RedirectSecureChecker: isRedirectURISecureStrict,
+		RedirectSecureChecker: fosite.IsRedirectURISecureStrict,
 
 		// html template for rendering the authorization response when the request has response_mode=form_post
 		FormPostHTMLTemplate: formposthtml.Template(),

--- a/internal/federationdomain/storage/kube_storage.go
+++ b/internal/federationdomain/storage/kube_storage.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package storage
@@ -107,10 +107,7 @@ func (k KubeStorage) DeletePKCERequestSession(ctx context.Context, signatureOfAu
 // Fosite will create these in the authorize endpoint when it creates an authcode, but only if the user
 // requested the openid scope.
 //
-// Fosite will never delete these, which is likely a bug in fosite. Although there is a delete method below, fosite
-// never calls it. Used during authcode redemption, they will never be accessed again after a successful authcode
-// redemption. Although that implies that they should probably follow a lifecycle similar the the PKCE storage, they
-// are, in fact, not deleted.
+// Used during authcode redemption, and will be deleted during a successful authcode redemption.
 //
 
 func (k KubeStorage) CreateOpenIDConnectSession(ctx context.Context, fullAuthcode string, requester fosite.Requester) error {
@@ -122,7 +119,7 @@ func (k KubeStorage) GetOpenIDConnectSession(ctx context.Context, fullAuthcode s
 }
 
 func (k KubeStorage) DeleteOpenIDConnectSession(ctx context.Context, fullAuthcode string) error {
-	return k.oidcStorage.DeleteOpenIDConnectSession(ctx, fullAuthcode) //nolint:staticcheck  // we know this is deprecated and never called.  our GC controller cleans these up.
+	return k.oidcStorage.DeleteOpenIDConnectSession(ctx, fullAuthcode)
 }
 
 //

--- a/internal/federationdomain/timeouts/timeouts_configuration.go
+++ b/internal/federationdomain/timeouts/timeouts_configuration.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package timeouts
@@ -51,8 +51,8 @@ type Configuration struct {
 	PKCESessionStorageLifetime time.Duration
 
 	// OIDCSessionStorageLifetime is the length of time after which the OIDC session data related to an authcode
-	// is allowed to be garbage collected from storage. Due to a bug in an underlying library, these are not explicitly
-	// deleted. Similar to the PKCE session, they are not needed anymore after the corresponding authcode has expired.
+	// is allowed to be garbage collected from storage. After the authcode is successfully redeemed, the OIDC session is
+	// explicitly deleted. Similar to the PKCE session, they are not needed anymore after the corresponding authcode has expired.
 	// Therefore, this can be just slightly longer than the AuthorizeCodeLifespan. We'll avoid making it exactly the same
 	// as AuthorizeCodeLifespan to avoid any chance of the garbage collector deleting it while it is being used.
 	OIDCSessionStorageLifetime time.Duration

--- a/internal/fositestorage/openidconnect/openidconnect_test.go
+++ b/internal/fositestorage/openidconnect/openidconnect_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package openidconnect
@@ -100,7 +100,7 @@ func TestOpenIdConnectStorage(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, request, newRequest)
 
-	err = storage.DeleteOpenIDConnectSession(ctx, "fancy-code.fancy-signature") //nolint:staticcheck  // we know this is deprecated and never called.  our GC controller cleans these up.
+	err = storage.DeleteOpenIDConnectSession(ctx, "fancy-code.fancy-signature")
 	require.NoError(t, err)
 
 	testutil.LogActualJSONFromCreateAction(t, client, 0) // makes it easier to update expected values when needed

--- a/site/content/docs/howto/configure-auth-for-webapps.md
+++ b/site/content/docs/howto/configure-auth-for-webapps.md
@@ -277,9 +277,8 @@ The ID token returned at the end of the authorization code flow will contain the
 - `nonce`: a string value used to associate a Client session with an ID Token, and to mitigate replay attacks
 
 Refreshed ID tokens will contain the same claims, except that a refreshed ID token will also contain an `at_hash` claim,
-and will not contain a `nonce` claim. (The original ID token should also contain an `at_hash` claim, but it is excluded
-due to a bug in one of Pinniped's dependencies. The Pinniped maintainers have submitted a PR to that library to fix
-the bug and are waiting for the next release of that library to incorporate the fix into Pinniped.)
+and will not contain a `nonce` claim. The original ID token should also contain an `at_hash` claim, but it was excluded
+in older versions of Pinniped due to a bug in one of Pinniped's dependencies, which has since been fixed.
 
 Additionally, the following custom claims may be included in the ID tokens, if the client requested
 the `username` and/or `groups` scopes in the original authorization request, and if the client is allowed to request those scopes:


### PR DESCRIPTION
Upgrade fosite to the latest version, which includes this bug fix https://github.com/ory/fosite/pull/793 from me.

As a result, the Pinniped Supervisor will be able to remove oidc session storage Secrets more efficiently.

It also included some other unrelated changes, and our tests needed to be updated to account for those changes as well.

**Release note**:

```release-note
None.
```
