### PR TITLE
Don't skip upstream group memberships when groups scope is not granted

### DIFF
--- a/internal/authenticators/authenticators.go
+++ b/internal/authenticators/authenticators.go
@@ -31,7 +31,7 @@ import (
 // See k8s.io/apiserver/pkg/authentication/authenticator/interfaces.go for the token authenticator
 // interface, as well as the Response type.
 type UserAuthenticator interface {
-	AuthenticateUser(ctx context.Context, username, password string, skipGroups bool) (*Response, bool, error)
+	AuthenticateUser(ctx context.Context, username, password string) (*Response, bool, error)
 }
 
 type Response struct {

--- a/internal/federationdomain/endpoints/auth/auth_handler.go
+++ b/internal/federationdomain/endpoints/auth/auth_handler.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/handler/openid"
 	"github.com/ory/fosite/token/jwt"
-	"k8s.io/utils/strings/slices"
 
 	oidcapi "go.pinniped.dev/generated/latest/apis/supervisor/oidc"
 	"go.pinniped.dev/internal/federationdomain/csrftoken"
@@ -202,9 +201,7 @@ func (h *authorizeHandler) authorizeWithoutBrowser(
 		return err
 	}
 
-	groupsWillBeIgnored := !slices.Contains(authorizeRequester.GetGrantedScopes(), oidcapi.ScopeGroups)
-
-	identity, loginExtras, err := idp.Login(r.Context(), submittedUsername, submittedPassword, groupsWillBeIgnored)
+	identity, loginExtras, err := idp.Login(r.Context(), submittedUsername, submittedPassword)
 	if err != nil {
 		return err
 	}

--- a/internal/federationdomain/endpoints/login/post_login_handler.go
+++ b/internal/federationdomain/endpoints/login/post_login_handler.go
@@ -9,9 +9,7 @@ import (
 	"net/url"
 
 	"github.com/ory/fosite"
-	"k8s.io/utils/strings/slices"
 
-	oidcapi "go.pinniped.dev/generated/latest/apis/supervisor/oidc"
 	"go.pinniped.dev/internal/federationdomain/downstreamsession"
 	"go.pinniped.dev/internal/federationdomain/endpoints/loginurl"
 	"go.pinniped.dev/internal/federationdomain/federationdomainproviders"
@@ -67,10 +65,8 @@ func NewPostHandler(issuerURL string, upstreamIDPs federationdomainproviders.Fed
 			return redirectToLoginPage(r, w, issuerURL, encodedState, loginurl.ShowBadUserPassErr)
 		}
 
-		skipGroups := !slices.Contains(authorizeRequester.GetGrantedScopes(), oidcapi.ScopeGroups)
-
 		// Attempt to authenticate the user with the upstream IDP.
-		identity, loginExtras, err := idp.Login(r.Context(), submittedUsername, submittedPassword, skipGroups)
+		identity, loginExtras, err := idp.Login(r.Context(), submittedUsername, submittedPassword)
 		if err != nil {
 			switch {
 			case errors.Is(err, resolvedldap.ErrUnexpectedUpstreamLDAPError):

--- a/internal/federationdomain/endpoints/token/token_handler.go
+++ b/internal/federationdomain/endpoints/token/token_handler.go
@@ -147,7 +147,7 @@ func upstreamRefresh(
 	oldUntransformedGroups := session.Custom.UpstreamGroups
 	oldTransformedUsername := session.Custom.Username
 
-	previousIdentity := resolvedprovider.Identity{
+	previousIdentity := &resolvedprovider.Identity{
 		UpstreamUsername:       oldUntransformedUsername,
 		UpstreamGroups:         oldUntransformedGroups,
 		DownstreamSubject:      session.Fosite.Claims.Subject,
@@ -155,7 +155,7 @@ func upstreamRefresh(
 	}
 
 	// Perform the upstream refresh.
-	refreshedIdentity, err := idp.UpstreamRefresh(ctx, &previousIdentity, skipGroups)
+	refreshedIdentity, err := idp.UpstreamRefresh(ctx, previousIdentity)
 	if err != nil {
 		return err
 	}

--- a/internal/federationdomain/resolvedprovider/resolved_provider.go
+++ b/internal/federationdomain/resolvedprovider/resolved_provider.go
@@ -141,20 +141,16 @@ type FederationDomainResolvedIdentityProvider interface {
 	// Login performs auth using a username and password that was submitted by the client, without a web browser.
 	// This function should authenticate the user with the upstream identity provider, extract their upstream
 	// identity, and transform it into their downstream identity.
-	// The groupsWillBeIgnored parameter will be true when the returned groups are going to be ignored by the caller,
-	// in which case this function may be able to save some effort by avoiding getting the user's upstream groups.
 	// Returned errors should be of type fosite.RFC6749Error.
-	Login(ctx context.Context, submittedUsername string, submittedPassword string, groupsWillBeIgnored bool) (*Identity, *IdentityLoginExtras, error)
+	Login(ctx context.Context, submittedUsername string, submittedPassword string) (*Identity, *IdentityLoginExtras, error)
 
 	// UpstreamRefresh performs a refresh with the upstream provider.
 	// The user's previous identity information is provided as a parameter.
 	// Implementations may use this information to assist in refreshes, but mutations to this argument will be ignored.
 	// If possible, implementations should update the user's upstream group memberships by fetching them from the
 	// upstream provider during the refresh, and returning them.
-	// The groupsWillBeIgnored parameter will be true when the returned groups are going to be ignored by the caller,
-	// in which case this function may be able to save some effort by avoiding getting the user's upstream groups.
 	// Returned errors should be of type fosite.RFC6749Error.
-	UpstreamRefresh(ctx context.Context, identity *Identity, groupsWillBeIgnored bool) (refreshedIdentity *RefreshedIdentity, err error)
+	UpstreamRefresh(ctx context.Context, identity *Identity) (refreshedIdentity *RefreshedIdentity, err error)
 }
 
 // ErrMissingUpstreamSessionInternalError returns a common type of error that can happen during a login or refresh.

--- a/internal/federationdomain/resolvedprovider/resolvedldap/resolved_ldap_provider.go
+++ b/internal/federationdomain/resolvedprovider/resolvedldap/resolved_ldap_provider.go
@@ -125,9 +125,8 @@ func (p *FederationDomainResolvedLDAPIdentityProvider) Login(
 	ctx context.Context,
 	submittedUsername string,
 	submittedPassword string,
-	groupsWillBeIgnored bool,
 ) (*resolvedprovider.Identity, *resolvedprovider.IdentityLoginExtras, error) {
-	authenticateResponse, authenticated, err := p.Provider.AuthenticateUser(ctx, submittedUsername, submittedPassword, groupsWillBeIgnored)
+	authenticateResponse, authenticated, err := p.Provider.AuthenticateUser(ctx, submittedUsername, submittedPassword)
 	if err != nil {
 		plog.WarningErr("unexpected error during upstream LDAP authentication", err, "upstreamName", p.Provider.GetName())
 		return nil, nil, ErrUnexpectedUpstreamLDAPError.WithWrap(err)
@@ -185,7 +184,6 @@ func (p *FederationDomainResolvedLDAPIdentityProvider) LoginFromCallback(
 func (p *FederationDomainResolvedLDAPIdentityProvider) UpstreamRefresh(
 	ctx context.Context,
 	identity *resolvedprovider.Identity,
-	groupsWillBeIgnored bool,
 ) (refreshedIdentity *resolvedprovider.RefreshedIdentity, err error) {
 	var dn string
 	var additionalAttributes map[string]string
@@ -229,7 +227,6 @@ func (p *FederationDomainResolvedLDAPIdentityProvider) UpstreamRefresh(
 		DN:                   dn,
 		Groups:               identity.UpstreamGroups,
 		AdditionalAttributes: additionalAttributes,
-		SkipGroups:           groupsWillBeIgnored,
 	}, p.GetDisplayName())
 	if err != nil {
 		return nil, resolvedprovider.ErrUpstreamRefreshError().WithHint(

--- a/internal/federationdomain/upstreamprovider/upsteam_provider.go
+++ b/internal/federationdomain/upstreamprovider/upsteam_provider.go
@@ -32,10 +32,6 @@ type RefreshAttributes struct {
 	DN                   string
 	Groups               []string
 	AdditionalAttributes map[string]string
-	// Skip group search for this particular session refresh.
-	// E.g. This could be set to true when the user was not granted the downstream groups scope.
-	// There is no reason to spend the cost of an LDAP group search unless we are going to use the results.
-	SkipGroups bool
 }
 
 // UpstreamIdentityProviderI includes the interface functions that are common to all upstream identity provider types.

--- a/internal/testutil/oidctestutil/testldapprovider.go
+++ b/internal/testutil/oidctestutil/testldapprovider.go
@@ -115,7 +115,7 @@ func (u *TestUpstreamLDAPIdentityProvider) GetName() string {
 	return u.Name
 }
 
-func (u *TestUpstreamLDAPIdentityProvider) AuthenticateUser(ctx context.Context, username, password string, _skipGroups bool) (*authenticators.Response, bool, error) {
+func (u *TestUpstreamLDAPIdentityProvider) AuthenticateUser(ctx context.Context, username, password string) (*authenticators.Response, bool, error) {
 	return u.AuthenticateFunc(ctx, username, password)
 }
 

--- a/internal/testutil/transformtestutil/transformtestutil.go
+++ b/internal/testutil/transformtestutil/transformtestutil.go
@@ -1,4 +1,4 @@
-// Copyright 2023 the Pinniped contributors. All Rights Reserved.
+// Copyright 2023-2024 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package transformtestutil
@@ -53,6 +53,23 @@ func NewRejectAllAuthPipeline(t *testing.T) *idtransform.TransformationPipeline 
 	)
 	require.NoError(t, err)
 	p.AppendTransformation(compiledTransform)
+
+	return p
+}
+
+func NewPipeline(t *testing.T, transforms []celtransformer.CELTransformation) *idtransform.TransformationPipeline {
+	t.Helper()
+
+	transformer, err := celtransformer.NewCELTransformer(5 * time.Second)
+	require.NoError(t, err)
+
+	p := idtransform.NewTransformationPipeline()
+
+	for _, transform := range transforms {
+		compiledTransform, err := transformer.CompileTransformation(transform, nil)
+		require.NoError(t, err)
+		p.AppendTransformation(compiledTransform)
+	}
 
 	return p
 }

--- a/test/integration/ldap_client_test.go
+++ b/test/integration/ldap_client_test.go
@@ -73,7 +73,6 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 		name                string
 		username            string
 		password            string
-		skipGroups          bool
 		provider            *upstreamldap.Provider
 		wantError           testutil.RequireErrorStringFunc
 		wantAuthResponse    *authenticators.Response
@@ -111,18 +110,6 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 			provider: upstreamldap.New(*providerConfig(func(p *upstreamldap.ProviderConfig) { p.UserSearch.Base = "dc=pinniped,dc=dev" })),
 			wantAuthResponse: &authenticators.Response{
 				User:                   &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: []string{"ball-game-players", "seals"}},
-				DN:                     "cn=pinny,ou=users,dc=pinniped,dc=dev",
-				ExtraRefreshAttributes: map[string]string{},
-			},
-		},
-		{
-			name:       "skip groups",
-			username:   "pinny",
-			password:   pinnyPassword,
-			skipGroups: true,
-			provider:   upstreamldap.New(*providerConfig(nil)),
-			wantAuthResponse: &authenticators.Response{
-				User:                   &user.DefaultInfo{Name: "pinny", UID: b64("1000"), Groups: nil},
 				DN:                     "cn=pinny,ou=users,dc=pinniped,dc=dev",
 				ExtraRefreshAttributes: map[string]string{},
 			},
@@ -741,7 +728,7 @@ func TestLDAPSearch_Parallel(t *testing.T) {
 	for _, test := range tests {
 		tt := test
 		t.Run(tt.name, func(t *testing.T) {
-			authResponse, authenticated, err := tt.provider.AuthenticateUser(ctx, tt.username, tt.password, tt.skipGroups)
+			authResponse, authenticated, err := tt.provider.AuthenticateUser(ctx, tt.username, tt.password)
 
 			switch {
 			case tt.wantError != nil:
@@ -799,7 +786,7 @@ func TestSimultaneousLDAPRequestsOnSingleProvider(t *testing.T) {
 			authUserCtx, authUserCtxCancelFunc := context.WithTimeout(context.Background(), 2*time.Minute)
 			defer authUserCtxCancelFunc()
 
-			authResponse, authenticated, err := provider.AuthenticateUser(authUserCtx, env.SupervisorUpstreamLDAP.TestUserCN, env.SupervisorUpstreamLDAP.TestUserPassword, false)
+			authResponse, authenticated, err := provider.AuthenticateUser(authUserCtx, env.SupervisorUpstreamLDAP.TestUserCN, env.SupervisorUpstreamLDAP.TestUserPassword)
 			resultCh <- authUserResult{
 				response:      authResponse,
 				authenticated: authenticated,


### PR DESCRIPTION
Background: For dynamic clients, the groups scope is not always allowed and/or requested by the client, so it will not always be granted by the Supervisor for an authorization request.

Previously, when the groups scope was not granted, we would skip searching for upstream groups in some scenarios.

This commit changes the behavior of authorization flows so that even when the groups scope is not granted we still search for the upstream group memberships as configured, and we pass the upstream group memberships into any configured identity transformations. The identity transformations could potentially reject the user's authentication based on their upstream group membership.

When the groups scope is not granted, we don't include the groups in the final Supervisor-issued ID token. This behavior is not changed.

**Release note**:

```release-note
For OIDCClients that are configured to not be allowed to request the groups scope,
or those which choose not to request the groups scope in an authorization flow,
query the external identity provider for the user's groups anyway.
Include those external groups into the inputs for the configured FederationDomain
identity transformations, even though the final groups list will not be included in
the Supervisor-issued ID tokens, because they might matter for the transformations.
```
