### PR TITLE
Add PINNIPED_SKIP_PRINT_LOGIN_URL env var to CLI

### DIFF
--- a/cmd/pinniped/cmd/login_oidc_test.go
+++ b/cmd/pinniped/cmd/login_oidc_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package cmd
@@ -185,6 +185,18 @@ func TestLoginOIDCCommand(t *testing.T) {
 				"--credential-cache", "", // must specify --credential-cache or else the cache file on disk causes test pollution
 			},
 			wantOptionsCount: 4,
+			wantStdout:       `{"kind":"ExecCredential","apiVersion":"client.authentication.k8s.io/v1beta1","spec":{"interactive":false},"status":{"expirationTimestamp":"3020-10-12T13:14:15Z","token":"test-id-token"}}` + "\n",
+		},
+		{
+			name: "PINNIPED_SKIP_PRINT_LOGIN_URL adds an option",
+			args: []string{
+				"--issuer", "test-issuer",
+				"--client-id", "test-client-id",
+				"--upstream-identity-provider-type", "oidc",
+				"--credential-cache", "", // must specify --credential-cache or else the cache file on disk causes test pollution
+			},
+			env:              map[string]string{"PINNIPED_SKIP_PRINT_LOGIN_URL": "true"},
+			wantOptionsCount: 5,
 			wantStdout:       `{"kind":"ExecCredential","apiVersion":"client.authentication.k8s.io/v1beta1","spec":{"interactive":false},"status":{"expirationTimestamp":"3020-10-12T13:14:15Z","token":"test-id-token"}}` + "\n",
 		},
 		{
@@ -489,8 +501,8 @@ func TestLoginOIDCCommand(t *testing.T) {
 			wantOptionsCount: 4,
 			wantStdout:       `{"kind":"ExecCredential","apiVersion":"client.authentication.k8s.io/v1beta1","spec":{"interactive":false},"status":{"expirationTimestamp":"3020-10-12T13:14:15Z","token":"test-id-token"}}` + "\n",
 			wantLogs: []string{
-				nowStr + `  pinniped-login  cmd/login_oidc.go:243  Performing OIDC login  {"issuer": "test-issuer", "client id": "test-client-id"}`,
-				nowStr + `  pinniped-login  cmd/login_oidc.go:263  No concierge configured, skipping token credential exchange`,
+				nowStr + `  pinniped-login  cmd/login_oidc.go:260  Performing OIDC login  {"issuer": "test-issuer", "client id": "test-client-id"}`,
+				nowStr + `  pinniped-login  cmd/login_oidc.go:280  No concierge configured, skipping token credential exchange`,
 			},
 		},
 		{
@@ -515,14 +527,14 @@ func TestLoginOIDCCommand(t *testing.T) {
 				"--upstream-identity-provider-name", "some-upstream-name",
 				"--upstream-identity-provider-type", "ldap",
 			},
-			env:              map[string]string{"PINNIPED_DEBUG": "true"},
-			wantOptionsCount: 11,
+			env:              map[string]string{"PINNIPED_DEBUG": "true", "PINNIPED_SKIP_PRINT_LOGIN_URL": "true"},
+			wantOptionsCount: 12,
 			wantStdout:       `{"kind":"ExecCredential","apiVersion":"client.authentication.k8s.io/v1beta1","spec":{"interactive":false},"status":{"token":"exchanged-token"}}` + "\n",
 			wantLogs: []string{
-				nowStr + `  pinniped-login  cmd/login_oidc.go:243  Performing OIDC login  {"issuer": "test-issuer", "client id": "test-client-id"}`,
-				nowStr + `  pinniped-login  cmd/login_oidc.go:253  Exchanging token for cluster credential  {"endpoint": "https://127.0.0.1:1234/", "authenticator type": "webhook", "authenticator name": "test-authenticator"}`,
-				nowStr + `  pinniped-login  cmd/login_oidc.go:261  Successfully exchanged token for cluster credential.`,
-				nowStr + `  pinniped-login  cmd/login_oidc.go:268  caching cluster credential for future use.`,
+				nowStr + `  pinniped-login  cmd/login_oidc.go:260  Performing OIDC login  {"issuer": "test-issuer", "client id": "test-client-id"}`,
+				nowStr + `  pinniped-login  cmd/login_oidc.go:270  Exchanging token for cluster credential  {"endpoint": "https://127.0.0.1:1234/", "authenticator type": "webhook", "authenticator name": "test-authenticator"}`,
+				nowStr + `  pinniped-login  cmd/login_oidc.go:278  Successfully exchanged token for cluster credential.`,
+				nowStr + `  pinniped-login  cmd/login_oidc.go:285  caching cluster credential for future use.`,
 			},
 		},
 	}

--- a/pkg/oidcclient/login_test.go
+++ b/pkg/oidcclient/login_test.go
@@ -622,7 +622,6 @@ func TestLogin(t *testing.T) { //nolint:gocyclo
 
 					h.listen = func(string, string) (net.Listener, error) { return nil, fmt.Errorf("some listen error") }
 					h.stdinIsTTY = func() bool { return false }
-					h.stderrIsTTY = func() bool { return true }
 					return nil
 				}
 			},
@@ -694,7 +693,6 @@ func TestLogin(t *testing.T) { //nolint:gocyclo
 						return nil, fmt.Errorf("some listen error")
 					}
 					h.stdinIsTTY = func() bool { return false }
-					h.stderrIsTTY = func() bool { return true }
 					return nil
 				}
 			},
@@ -713,7 +711,6 @@ func TestLogin(t *testing.T) { //nolint:gocyclo
 					h.generatePKCE = func() (pkce.Code, error) { return "test-pkce", nil }
 					h.generateNonce = func() (nonce.Nonce, error) { return "test-nonce", nil }
 					h.stdinIsTTY = func() bool { return true }
-					h.stderrIsTTY = func() bool { return true }
 					require.NoError(t, WithClient(newClientForServer(formPostSuccessServer))(h))
 					require.NoError(t, WithSkipListen()(h))
 					h.openURL = func(authorizeURL string) error {
@@ -753,7 +750,6 @@ func TestLogin(t *testing.T) { //nolint:gocyclo
 					h.generatePKCE = func() (pkce.Code, error) { return "test-pkce", nil }
 					h.generateNonce = func() (nonce.Nonce, error) { return "test-nonce", nil }
 					h.stdinIsTTY = func() bool { return true }
-					h.stderrIsTTY = func() bool { return true }
 					require.NoError(t, WithClient(newClientForServer(formPostSuccessServer))(h))
 					h.listen = func(string, string) (net.Listener, error) { return nil, fmt.Errorf("some listen error") }
 					h.openURL = func(authorizeURL string) error {
@@ -793,7 +789,6 @@ func TestLogin(t *testing.T) { //nolint:gocyclo
 					h.generatePKCE = func() (pkce.Code, error) { return "test-pkce", nil }
 					h.generateNonce = func() (nonce.Nonce, error) { return "test-nonce", nil }
 					h.stdinIsTTY = func() bool { return true }
-					h.stderrIsTTY = func() bool { return true }
 
 					require.NoError(t, WithClient(newClientForServer(successServer))(h))
 
@@ -829,7 +824,6 @@ func TestLogin(t *testing.T) { //nolint:gocyclo
 					h.generatePKCE = func() (pkce.Code, error) { return "test-pkce", nil }
 					h.generateNonce = func() (nonce.Nonce, error) { return "test-nonce", nil }
 					h.stdinIsTTY = func() bool { return true }
-					h.stderrIsTTY = func() bool { return true }
 					require.NoError(t, WithClient(newClientForServer(successServer))(h))
 					h.openURL = func(_ string) error {
 						go func() {
@@ -864,7 +858,6 @@ func TestLogin(t *testing.T) { //nolint:gocyclo
 					h.generateNonce = func() (nonce.Nonce, error) { return "test-nonce", nil }
 
 					h.stdinIsTTY = func() bool { return true }
-					h.stderrIsTTY = func() bool { return true }
 
 					cache := &mockSessionCache{t: t, getReturnsToken: nil}
 					cacheKey := SessionCacheKey{
@@ -929,7 +922,7 @@ func TestLogin(t *testing.T) { //nolint:gocyclo
 			wantToken: &testToken,
 		},
 		{
-			name:     "callback returns success, without stderr tty and with opening the browser, did not show authorize URL on stderr",
+			name:     "callback returns success, with skipPrintLoginURL and with opening the browser, did not show authorize URL on stderr",
 			clientID: "test-client-id",
 			opt: func(t *testing.T) Option {
 				return func(h *handlerState) error {
@@ -938,7 +931,7 @@ func TestLogin(t *testing.T) { //nolint:gocyclo
 					h.generateNonce = func() (nonce.Nonce, error) { return "test-nonce", nil }
 
 					h.stdinIsTTY = func() bool { return true }
-					h.stderrIsTTY = func() bool { return false } // stderr is not a tty
+					h.skipPrintLoginURL = true
 
 					cache := &mockSessionCache{t: t, getReturnsToken: nil}
 					cacheKey := SessionCacheKey{
@@ -995,7 +988,7 @@ func TestLogin(t *testing.T) { //nolint:gocyclo
 			wantToken:  &testToken,
 		},
 		{
-			name:     "callback returns success, without stderr tty but there was an error when opening the browser, did show authorize URL on stderr",
+			name:     "callback returns success, with skipPrintLoginURL but there was an error when opening the browser, did show authorize URL on stderr",
 			clientID: "test-client-id",
 			opt: func(t *testing.T) Option {
 				return func(h *handlerState) error {
@@ -1004,7 +997,7 @@ func TestLogin(t *testing.T) { //nolint:gocyclo
 					h.generateNonce = func() (nonce.Nonce, error) { return "test-nonce", nil }
 
 					h.stdinIsTTY = func() bool { return true }
-					h.stderrIsTTY = func() bool { return false } // stderr is not a tty
+					h.skipPrintLoginURL = true
 
 					cache := &mockSessionCache{t: t, getReturnsToken: nil}
 					cacheKey := SessionCacheKey{
@@ -1073,7 +1066,7 @@ func TestLogin(t *testing.T) { //nolint:gocyclo
 			wantToken: &testToken,
 		},
 		{
-			name:     "callback returns success, without stderr tty and with skipping the browser, did show authorize URL on stderr",
+			name:     "callback returns success, with skipPrintLoginURL and with skipping the browser, did show authorize URL on stderr",
 			clientID: "test-client-id",
 			opt: func(t *testing.T) Option {
 				return func(h *handlerState) error {
@@ -1082,7 +1075,7 @@ func TestLogin(t *testing.T) { //nolint:gocyclo
 					h.generateNonce = func() (nonce.Nonce, error) { return "test-nonce", nil }
 
 					h.stdinIsTTY = func() bool { return true }
-					h.stderrIsTTY = func() bool { return false } // stderr is not a tty
+					h.skipPrintLoginURL = true
 
 					cache := &mockSessionCache{t: t, getReturnsToken: nil}
 					cacheKey := SessionCacheKey{
@@ -1157,7 +1150,6 @@ func TestLogin(t *testing.T) { //nolint:gocyclo
 					h.generateNonce = func() (nonce.Nonce, error) { return "test-nonce", nil }
 
 					h.stdinIsTTY = func() bool { return true }
-					h.stderrIsTTY = func() bool { return true }
 
 					// Because response_mode=form_post, the Login function is going to prompt the user
 					// to paste their authcode. This test needs to handle that prompt.
@@ -1249,7 +1241,6 @@ func TestLogin(t *testing.T) { //nolint:gocyclo
 					h.generateNonce = func() (nonce.Nonce, error) { return "test-nonce", nil }
 
 					h.stdinIsTTY = func() bool { return true }
-					h.stderrIsTTY = func() bool { return true }
 
 					cache := &mockSessionCache{t: t, getReturnsToken: nil}
 					cacheKey := SessionCacheKey{


### PR DESCRIPTION
The approach taken in #1874 to attempt to solve #1868 did not work as well as I had hoped.

This PR removes some of the code from #1874 and replaces it with a new env var used by the CLI called `PINNIPED_SKIP_PRINT_LOGIN_URL`, which causes the CLI to skip printing the login URL to stderr when the env car is set to `true` and when the browser was opened to the login URL.

For example, you could use `PINNIPED_SKIP_PRINT_LOGIN_URL=true k9s --kubeconfig pinniped-browser-flow-kubeconfig.yaml` to start k9s.

**Release note**:

```release-note
The `pinniped login oidc` CLI command will skip printing the login URL to stderr if the browser has successfully opened and if the `PINNIPED_SKIP_PRINT_LOGIN_URL` env var is set to `true`. This new env var can be used to avoid having the URL output on stdout confuse console UIs like k9s.
```
