### PR TITLE
Remove deprecated deploy options

### DIFF
--- a/deploy/concierge/deployment.yaml
+++ b/deploy/concierge/deployment.yaml
@@ -98,9 +98,7 @@ data:
       (@ end @)
     (@ if data.values.log_level: @)
     log:
-      (@ if data.values.log_level: @)
       level: (@= getAndValidateLogLevel() @)
-      (@ end @)
     (@ end @)
 ---
 #@ if data.values.image_pull_dockerconfigjson and data.values.image_pull_dockerconfigjson != "":

--- a/deploy/concierge/deployment.yaml
+++ b/deploy/concierge/deployment.yaml
@@ -1,4 +1,4 @@
-#! Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
+#! Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
 #! SPDX-License-Identifier: Apache-2.0
 
 #@ load("@ytt:data", "data")
@@ -96,13 +96,10 @@ data:
       imagePullSecrets:
         - image-pull-secret
       (@ end @)
-    (@ if data.values.log_level or data.values.deprecated_log_format: @)
+    (@ if data.values.log_level: @)
     log:
       (@ if data.values.log_level: @)
       level: (@= getAndValidateLogLevel() @)
-      (@ end @)
-      (@ if data.values.deprecated_log_format: @)
-      format: (@= data.values.deprecated_log_format @)
       (@ end @)
     (@ end @)
 ---

--- a/deploy/concierge/values.yaml
+++ b/deploy/concierge/values.yaml
@@ -124,17 +124,6 @@ api_serving_certificate_renew_before_seconds: 2160000
 #@schema/validation one_of=["info", "debug", "trace", "all"]
 log_level: ""
 
-#@schema/title "Log format"
-#@ deprecated_log_format_desc = "Specify the format of logging: json (for machine parsable logs) and text (for legacy klog formatted logs). \
-#@ By default, when this value is left unset, logs are formatted in json. \
-#@ This configuration is deprecated and will be removed in a future release at which point logs will always be formatted as json."
-#@schema/desc deprecated_log_format_desc
-#@schema/examples ("Set logs to JSON format","json")
-#@schema/nullable
-#@schema/validation one_of=["json", "text"]
-#@schema/deprecated "This configuration is deprecated and will be removed in a future release at which point logs will always be formatted as json."
-deprecated_log_format: ""
-
 #@schema/title "Run as user"
 #@schema/desc "The user ID that will own the process."
 #! See the Dockerfile for the reasoning behind this default value.

--- a/deploy/supervisor/helpers.lib.yaml
+++ b/deploy/supervisor/helpers.lib.yaml
@@ -1,4 +1,4 @@
-#! Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
+#! Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
 #! SPDX-License-Identifier: Apache-2.0
 
 #@ load("@ytt:data", "data")
@@ -53,16 +53,10 @@ _: #@ template.replace(data.values.custom_labels)
 #@       "apiService": defaultResourceNameWithSuffix("api"),
 #@     },
 #@     "labels": labels(),
-#@     "insecureAcceptExternalUnencryptedHttpRequests": data.values.deprecated_insecure_accept_external_unencrypted_http_requests
 #@   }
-#@   if data.values.log_level or data.values.deprecated_log_format:
-#@     config["log"] = {}
-#@   end
 #@   if data.values.log_level:
+#@     config["log"] = {}
 #@     config["log"]["level"] = getAndValidateLogLevel()
-#@   end
-#@   if data.values.deprecated_log_format:
-#@     config["log"]["format"] = data.values.deprecated_log_format
 #@   end
 #@   if data.values.endpoints:
 #@     config["endpoints"] = data.values.endpoints

--- a/deploy/supervisor/service.yaml
+++ b/deploy/supervisor/service.yaml
@@ -1,24 +1,10 @@
-#! Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
+#! Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
 #! SPDX-License-Identifier: Apache-2.0
 
 #@ load("@ytt:data", "data")
-#@ load("@ytt:assert", "assert")
 #@ load("helpers.lib.yaml", "labels", "deploymentPodLabel", "namespace", "defaultResourceName", "defaultResourceNameWithSuffix")
 
-#@ if hasattr(data.values, "service_http_nodeport_port"):
-#@   assert.fail('value "service_http_nodeport_port" has been renamed to "deprecated_service_http_nodeport_port" and will be removed in a future release')
-#@ end
-#@ if hasattr(data.values, "service_http_nodeport_nodeport"):
-#@   assert.fail('value "service_http_nodeport_nodeport" has been renamed to "deprecated_service_http_nodeport_nodeport" and will be removed in a future release')
-#@ end
-#@ if hasattr(data.values, "service_http_loadbalancer_port"):
-#@   assert.fail('value "service_http_loadbalancer_port" has been renamed to "deprecated_service_http_loadbalancer_port" and will be removed in a future release')
-#@ end
-#@ if hasattr(data.values, "service_http_clusterip_port"):
-#@   assert.fail('value "service_http_clusterip_port" has been renamed to "deprecated_service_http_clusterip_port" and will be removed in a future release')
-#@ end
-
-#@ if data.values.deprecated_service_http_nodeport_port or data.values.service_https_nodeport_port:
+#@ if data.values.service_https_nodeport_port:
 ---
 apiVersion: v1
 kind: Service
@@ -33,15 +19,6 @@ spec:
   type: NodePort
   selector: #@ deploymentPodLabel()
   ports:
-    #@ if data.values.deprecated_service_http_nodeport_port:
-    - name: http
-      protocol: TCP
-      port: #@ data.values.deprecated_service_http_nodeport_port
-      targetPort: 8080
-      #@ if data.values.deprecated_service_http_nodeport_nodeport:
-      nodePort: #@ data.values.deprecated_service_http_nodeport_nodeport
-      #@ end
-    #@ end
     #@ if data.values.service_https_nodeport_port:
     - name: https
       protocol: TCP
@@ -53,7 +30,7 @@ spec:
     #@ end
 #@ end
 
-#@ if data.values.deprecated_service_http_clusterip_port or data.values.service_https_clusterip_port:
+#@ if data.values.service_https_clusterip_port:
 ---
 apiVersion: v1
 kind: Service
@@ -68,12 +45,6 @@ spec:
   type: ClusterIP
   selector: #@ deploymentPodLabel()
   ports:
-    #@ if data.values.deprecated_service_http_clusterip_port:
-    - name: http
-      protocol: TCP
-      port: #@ data.values.deprecated_service_http_clusterip_port
-      targetPort: 8080
-    #@ end
     #@ if data.values.service_https_clusterip_port:
     - name: https
       protocol: TCP
@@ -82,7 +53,7 @@ spec:
     #@ end
 #@ end
 
-#@ if data.values.deprecated_service_http_loadbalancer_port or data.values.service_https_loadbalancer_port:
+#@ if data.values.service_https_loadbalancer_port:
 ---
 apiVersion: v1
 kind: Service
@@ -100,12 +71,6 @@ spec:
   loadBalancerIP: #@ data.values.service_loadbalancer_ip
   #@ end
   ports:
-    #@ if data.values.deprecated_service_http_loadbalancer_port:
-    - name: http
-      protocol: TCP
-      port: #@ data.values.deprecated_service_http_loadbalancer_port
-      targetPort: 8080
-    #@ end
     #@ if data.values.service_https_loadbalancer_port:
     - name: https
       protocol: TCP

--- a/deploy/supervisor/values.yaml
+++ b/deploy/supervisor/values.yaml
@@ -156,28 +156,39 @@ https_proxy: ""
 no_proxy: "$(KUBERNETES_SERVICE_HOST),169.254.169.254,127.0.0.1,localhost,.svc,.cluster.local"
 
 #@schema/title "Endpoints"
-#@ endpoints_desc = "Control the HTTPS listener of the Supervisor.  The current defaults are: \
-#@ {\"https\":{\"network\":\"tcp\",\"address\":\":8443\"}}. \
-#@ These defaults mean: Tor HTTPS listening, bind to all interfaces using TCP on port 8443. \
+#@ endpoints_desc = "Control the HTTP and HTTPS listeners of the Supervisor.  The current defaults are: \
+#@ {\"https\":{\"network\":\"tcp\",\"address\":\":8443\"},\"http\":\"disabled\"}. \
+#@ These defaults mean: 1.) for HTTPS listening, bind to all interfaces using TCP on port 8443 and \
+#@ 2.) disable HTTP listening by default. \
 #@ The schema of this config is as follows: \
-#@ {\"https\":{\"network\":\"tcp\",\"address\":\"{host}:{port}\"}} \
-#@ The HTTPS listener must be used to accept all traffic from outside the pod. \
-#@ Ingresses and load balancers that terminate TLS connections must re-encrypt the data and route traffic \
-#@ to the HTTPS listener, or provide TLS passthrough. \
+#@ {\"https\":{\"network\":\"tcp | unix | disabled\",\"address\":\"host:port when network=tcp or /pinniped_socket/socketfile.sock when network=unix\"},\"http\":{\"network\":\"tcp | unix | disabled\",\"address\":\"same as https, except that when network=tcp then the address is only allowed to bind to loopback interfaces\"}} \
+#@ The HTTP listener can only be bound to loopback interfaces. This allows the listener to accept \
+#@ traffic from within the pod, e.g. from a service mesh sidecar. The HTTP listener should not be \
+#@ used to accept traffic from outside the pod, since that would mean that the network traffic could be \
+#@ transmitted unencrypted. The HTTPS listener should be used instead to accept traffic from outside the pod. \
+#@ Ingresses and load balancers that terminate TLS connections should re-encrypt the data and route traffic \
+#@ to the HTTPS listener. Unix domain sockets may also be used for integrations with service meshes. \
 #@ Changing the HTTPS port number must be accompanied by matching changes to the service and deployment \
 #@ manifests. Changes to the HTTPS listener must be coordinated with the deployment health checks."
 #@schema/desc endpoints_desc
-#@schema/examples ("Example matching default settings", '{"https":{"network":"tcp","address":":8443"}}')
+#@schema/examples ("Example matching default settings", '{"https":{"network":"tcp","address":":8443"},"http":"disabled"}')
 #@schema/type any=True
 #@ def validate_endpoint(endpoint):
-#@   if (type(endpoint) != "yamlfragment"):
+#@   if(type(endpoint) not in ["yamlfragment", "string"]):
 #@     return False
 #@   end
-#@   if (endpoint["network"] != "tcp"):
-#@      return False
+#@   if(type(endpoint) in ["string"]):
+#@     if (endpoint != "disabled"):
+#@        return False
+#@     end
 #@   end
-#@   if (type(endpoint["address"]) != "string"):
-#@      return False
+#@   if(type(endpoint) in ["yamlfragment"]):
+#@     if (endpoint["network"] not in ["tcp", "unix", "disabled"]):
+#@        return False
+#@     end
+#@     if (type(endpoint["address"]) not in ["string"]):
+#@        return False
+#@     end
 #@   end
 #@   return True
 #@ end
@@ -185,11 +196,10 @@ no_proxy: "$(KUBERNETES_SERVICE_HOST),169.254.169.254,127.0.0.1,localhost,.svc,.
 #@   """
 #@   Returns True if endpoints fulfill the expected structure
 #@   """
-#@   if (type(endpoints) != "yamlfragment"):
-#@     return False
-#@   end
-#@   return validate_endpoint(endpoints["https"])
+#@   http_val = endpoints["http"]
+#@   https_val = endpoints["https"]
+#@   return validate_endpoint(http_val) and validate_endpoint(https_val)
 #@ end
 #@schema/nullable
-#@schema/validation ("a map with key 'https', whose values are either the string 'disabled' or a map having keys 'network' and 'address', and the value of 'network' must be one of the allowed values", validate_endpoints)
+#@schema/validation ("a map with keys 'http' and 'https', whose values are either the string 'disabled' or a map having keys 'network' and 'address', and the value of 'network' must be one of the allowed values", validate_endpoints)
 endpoints: { }

--- a/deploy/supervisor/values.yaml
+++ b/deploy/supervisor/values.yaml
@@ -79,34 +79,6 @@ image_tag: latest
 #@schema/validation min_len=1
 image_pull_dockerconfigjson: ""
 
-#@schema/title "Deprecated service HTTP nodeport port"
-#@schema/desc "When specified, creates a NodePort Service with this `port` value, with port 8080 as its `targetPort`"
-#@schema/examples ("Specify port",31234)
-#@schema/nullable
-#@schema/deprecated "This data value will be removed in a future release"
-deprecated_service_http_nodeport_port: 0
-
-#@schema/title "Deprecated service http nodeport nodeport"
-#@schema/desc "The `nodePort` value of the NodePort Service, optional when `deprecated_service_http_nodeport_port` is specified"
-#@schema/examples ("Specify port",31234)
-#@schema/nullable
-#@schema/deprecated "This data value will be removed in a future release"
-deprecated_service_http_nodeport_nodeport: 0
-
-#@schema/title "Deprecated service http loadbalancer port"
-#@schema/desc "When specified, creates a LoadBalancer Service with this `port` value, with port 8080 as its `targetPort`"
-#@schema/examples ("Specify port",8443)
-#@schema/nullable
-#@schema/deprecated "This data value will be removed in a future release"
-deprecated_service_http_loadbalancer_port: 0
-
-#@schema/title "Deprecated service http clusterip port"
-#@schema/desc "Creates a ClusterIP Service with this `port` value, with port 8080 as its `targetPort`"
-#@schema/examples ("Specify port",8443)
-#@schema/nullable
-#@schema/deprecated "This data value will be removed in a future release"
-deprecated_service_http_clusterip_port: 0
-
 #@schema/title "Service https nodeport port"
 #@schema/desc "When specified, creates a NodePort Service with this `port` value, with port 8443 as its `targetPort`"
 #@schema/examples ("Specify port",31243)
@@ -147,17 +119,6 @@ service_loadbalancer_ip: ""
 #@schema/validation one_of=["info", "debug", "trace", "all"]
 log_level: ""
 
-#@schema/title "Log format"
-#@ deprecated_log_format_desc = "Specify the format of logging: json (for machine parsable logs) and text (for legacy klog formatted logs). \
-#@ By default, when this value is left unset, logs are formatted in json. \
-#@ This configuration is deprecated and will be removed in a future release at which point logs will always be formatted as json."
-#@schema/desc deprecated_log_format_desc
-#@schema/examples ("Set logs to JSON format","json")
-#@schema/nullable
-#@schema/validation one_of=["json", "text"]
-#@schema/deprecated "This configuration is deprecated and will be removed in a future release at which point logs will always be formatted as json."
-deprecated_log_format: ""
-
 #@schema/title "Run as user"
 #@schema/desc "The user ID that will own the process."
 #! See the Dockerfile for the reasoning behind this default value.
@@ -195,39 +156,28 @@ https_proxy: ""
 no_proxy: "$(KUBERNETES_SERVICE_HOST),169.254.169.254,127.0.0.1,localhost,.svc,.cluster.local"
 
 #@schema/title "Endpoints"
-#@ endpoints_desc = "Control the HTTP and HTTPS listeners of the Supervisor.  The current defaults are: \
-#@ {\"https\":{\"network\":\"tcp\",\"address\":\":8443\"},\"http\":\"disabled\"}. \
-#@ These defaults mean: 1.) for HTTPS listening, bind to all interfaces using TCP on port 8443 and \
-#@ 2.) disable HTTP listening by default. \
+#@ endpoints_desc = "Control the HTTPS listener of the Supervisor.  The current defaults are: \
+#@ {\"https\":{\"network\":\"tcp\",\"address\":\":8443\"}}. \
+#@ These defaults mean: Tor HTTPS listening, bind to all interfaces using TCP on port 8443. \
 #@ The schema of this config is as follows: \
-#@ {\"https\":{\"network\":\"tcp | unix | disabled\",\"address\":\"host:port when network=tcp or /pinniped_socket/socketfile.sock when network=unix\"},\"http\":{\"network\":\"tcp | unix | disabled\",\"address\":\"same as https, except that when network=tcp then the address is only allowed to bind to loopback interfaces\"}} \
-#@ The HTTP listener can only be bound to loopback interfaces. This allows the listener to accept \
-#@ traffic from within the pod, e.g. from a service mesh sidecar. The HTTP listener should not be \
-#@ used to accept traffic from outside the pod, since that would mean that the network traffic could be \
-#@ transmitted unencrypted. The HTTPS listener should be used instead to accept traffic from outside the pod. \
-#@ Ingresses and load balancers that terminate TLS connections should re-encrypt the data and route traffic \
-#@ to the HTTPS listener. Unix domain sockets may also be used for integrations with service meshes. \
+#@ {\"https\":{\"network\":\"tcp\",\"address\":\"{host}:{port}\"}} \
+#@ The HTTPS listener must be used to accept all traffic from outside the pod. \
+#@ Ingresses and load balancers that terminate TLS connections must re-encrypt the data and route traffic \
+#@ to the HTTPS listener, or provide TLS passthrough. \
 #@ Changing the HTTPS port number must be accompanied by matching changes to the service and deployment \
 #@ manifests. Changes to the HTTPS listener must be coordinated with the deployment health checks."
 #@schema/desc endpoints_desc
-#@schema/examples ("Example matching default settings", '{"https":{"network":"tcp","address":":8443"},"http":"disabled"}')
+#@schema/examples ("Example matching default settings", '{"https":{"network":"tcp","address":":8443"}}')
 #@schema/type any=True
 #@ def validate_endpoint(endpoint):
-#@   if(type(endpoint) not in ["yamlfragment", "string"]):
+#@   if (type(endpoint) != "yamlfragment"):
 #@     return False
 #@   end
-#@   if(type(endpoint) in ["string"]):
-#@     if (endpoint != "disabled"):
-#@        return False
-#@     end
+#@   if (endpoint["network"] != "tcp"):
+#@      return False
 #@   end
-#@   if(type(endpoint) in ["yamlfragment"]):
-#@     if (endpoint["network"] not in ["tcp", "unix", "disabled"]):
-#@        return False
-#@     end
-#@     if (type(endpoint["address"]) not in ["string"]):
-#@        return False
-#@     end
+#@   if (type(endpoint["address"]) != "string"):
+#@      return False
 #@   end
 #@   return True
 #@ end
@@ -235,26 +185,11 @@ no_proxy: "$(KUBERNETES_SERVICE_HOST),169.254.169.254,127.0.0.1,localhost,.svc,.
 #@   """
 #@   Returns True if endpoints fulfill the expected structure
 #@   """
-#@   http_val = endpoints["http"]
-#@   https_val = endpoints["https"]
-#@   return validate_endpoint(http_val) and validate_endpoint(https_val)
+#@   if (type(endpoints) != "yamlfragment"):
+#@     return False
+#@   end
+#@   return validate_endpoint(endpoints["https"])
 #@ end
 #@schema/nullable
-#@schema/validation ("a map with keys 'http' and 'https', whose values are either the string 'disabled' or a map having keys 'network' and 'address', and the value of 'network' must be one of the allowed values", validate_endpoints)
+#@schema/validation ("a map with key 'https', whose values are either the string 'disabled' or a map having keys 'network' and 'address', and the value of 'network' must be one of the allowed values", validate_endpoints)
 endpoints: { }
-
-#@ deprecated_insecure_accept_external_unencrypted_http_requests_desc = "Optionally override the validation on the endpoints.http \
-#@ value which checks that only loopback interfaces are used. \
-#@ When deprecated_insecure_accept_external_unencrypted_http_requests is true, the HTTP listener is allowed to bind to any \
-#@ interface, including interfaces that are listening for traffic from outside the pod. This value is being introduced \
-#@ to ease the transition to the new loopback interface validation for the HTTP port for any users who need more time \
-#@ to change their ingress strategy to avoid using plain HTTP into the Supervisor pods. \
-#@ This value is immediately deprecated upon its introduction. It will be removed in some future release, at which time \
-#@ traffic from outside the pod will need to be sent to the HTTPS listener instead, with no simple workaround available. \
-#@ Allowed values are true (boolean), 'true' (string), false (boolean), and 'false' (string). The default is false."
-#@schema/desc deprecated_insecure_accept_external_unencrypted_http_requests_desc
-#@schema/type any=True
-#@schema/validation ("a boolean or string version of boolean", lambda v: type(v) in ["string", "boolean"])
-#@schema/validation one_of=["true", "false", True, False]
-#@schema/deprecated "This data value will be removed in a future release"
-deprecated_insecure_accept_external_unencrypted_http_requests: false

--- a/internal/config/concierge/config.go
+++ b/internal/config/concierge/config.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package concierge contains functionality to load/store Config's from/to
@@ -79,7 +79,6 @@ func FromPath(ctx context.Context, path string) (*Config, error) {
 		return nil, fmt.Errorf("validate names: %w", err)
 	}
 
-	plog.MaybeSetDeprecatedLogLevel(config.LogLevel, &config.Log)
 	if err := plog.ValidateAndSetLogLevelAndFormatGlobally(ctx, config.Log); err != nil {
 		return nil, fmt.Errorf("validate log level: %w", err)
 	}

--- a/internal/config/concierge/config_test.go
+++ b/internal/config/concierge/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package concierge
@@ -57,7 +57,8 @@ func TestFromPath(t *testing.T) {
 				  namePrefix: kube-cert-agent-name-prefix-
 				  image: kube-cert-agent-image
 				  imagePullSecrets: [kube-cert-agent-image-pull-secret]
-				logLevel: debug
+				log:
+				  level: debug
 			`),
 			wantConfig: &Config{
 				DiscoveryInfo: DiscoveryInfoSpec{
@@ -94,7 +95,6 @@ func TestFromPath(t *testing.T) {
 					Image:            ptr.To("kube-cert-agent-image"),
 					ImagePullSecrets: []string{"kube-cert-agent-image-pull-secret"},
 				},
-				LogLevel: func(level plog.LogLevel) *plog.LogLevel { return &level }(plog.LevelDebug),
 				Log: plog.LogSpec{
 					Level: plog.LevelDebug,
 				},
@@ -215,7 +215,6 @@ func TestFromPath(t *testing.T) {
 				  namePrefix: kube-cert-agent-name-prefix-
 				  image: kube-cert-agent-image
 				  imagePullSecrets: [kube-cert-agent-image-pull-secret]
-				logLevel: debug
 				log:
 				  level: all
 				  format: json
@@ -255,9 +254,8 @@ func TestFromPath(t *testing.T) {
 					Image:            ptr.To("kube-cert-agent-image"),
 					ImagePullSecrets: []string{"kube-cert-agent-image-pull-secret"},
 				},
-				LogLevel: func(level plog.LogLevel) *plog.LogLevel { return &level }(plog.LevelDebug),
 				Log: plog.LogSpec{
-					Level:  plog.LevelDebug,
+					Level:  plog.LevelAll,
 					Format: plog.FormatJSON,
 				},
 			},

--- a/internal/config/concierge/config_test.go
+++ b/internal/config/concierge/config_test.go
@@ -101,87 +101,7 @@ func TestFromPath(t *testing.T) {
 			},
 		},
 		{
-			name: "Fully filled out new log struct",
-			yaml: here.Doc(`
-				---
-				discovery:
-				  url: https://some.discovery/url
-				api:
-				  servingCertificate:
-					durationSeconds: 3600
-					renewBeforeSeconds: 2400
-				apiGroupSuffix: some.suffix.com
-				aggregatedAPIServerPort: 12345
-				impersonationProxyServerPort: 4242
-				names:
-				  servingCertificateSecret: pinniped-concierge-api-tls-serving-certificate
-				  credentialIssuer: pinniped-config
-				  apiService: pinniped-api
-				  kubeCertAgentPrefix: kube-cert-agent-prefix
-				  impersonationLoadBalancerService: impersonationLoadBalancerService-value
-				  impersonationClusterIPService: impersonationClusterIPService-value
-				  impersonationTLSCertificateSecret: impersonationTLSCertificateSecret-value
-				  impersonationCACertificateSecret: impersonationCACertificateSecret-value
-				  impersonationSignerSecret: impersonationSignerSecret-value
-				  impersonationSignerSecret: impersonationSignerSecret-value
-				  agentServiceAccount: agentServiceAccount-value
-				  impersonationProxyServiceAccount: impersonationProxyServiceAccount-value
-				  impersonationProxyLegacySecret: impersonationProxyLegacySecret-value
-				  extraName: extraName-value
-				labels:
-				  myLabelKey1: myLabelValue1
-				  myLabelKey2: myLabelValue2
-				kubeCertAgent:
-				  namePrefix: kube-cert-agent-name-prefix-
-				  image: kube-cert-agent-image
-				  imagePullSecrets: [kube-cert-agent-image-pull-secret]
-				log:
-				  level: all
-				  format: json
-			`),
-			wantConfig: &Config{
-				DiscoveryInfo: DiscoveryInfoSpec{
-					URL: ptr.To("https://some.discovery/url"),
-				},
-				APIConfig: APIConfigSpec{
-					ServingCertificateConfig: ServingCertificateConfigSpec{
-						DurationSeconds:    ptr.To[int64](3600),
-						RenewBeforeSeconds: ptr.To[int64](2400),
-					},
-				},
-				APIGroupSuffix:               ptr.To("some.suffix.com"),
-				AggregatedAPIServerPort:      ptr.To[int64](12345),
-				ImpersonationProxyServerPort: ptr.To[int64](4242),
-				NamesConfig: NamesConfigSpec{
-					ServingCertificateSecret:          "pinniped-concierge-api-tls-serving-certificate",
-					CredentialIssuer:                  "pinniped-config",
-					APIService:                        "pinniped-api",
-					ImpersonationLoadBalancerService:  "impersonationLoadBalancerService-value",
-					ImpersonationClusterIPService:     "impersonationClusterIPService-value",
-					ImpersonationTLSCertificateSecret: "impersonationTLSCertificateSecret-value",
-					ImpersonationCACertificateSecret:  "impersonationCACertificateSecret-value",
-					ImpersonationSignerSecret:         "impersonationSignerSecret-value",
-					AgentServiceAccount:               "agentServiceAccount-value",
-					ImpersonationProxyServiceAccount:  "impersonationProxyServiceAccount-value",
-					ImpersonationProxyLegacySecret:    "impersonationProxyLegacySecret-value",
-				},
-				Labels: map[string]string{
-					"myLabelKey1": "myLabelValue1",
-					"myLabelKey2": "myLabelValue2",
-				},
-				KubeCertAgentConfig: KubeCertAgentSpec{
-					NamePrefix:       ptr.To("kube-cert-agent-name-prefix-"),
-					Image:            ptr.To("kube-cert-agent-image"),
-					ImagePullSecrets: []string{"kube-cert-agent-image-pull-secret"},
-				},
-				Log: plog.LogSpec{
-					Level:  plog.LevelAll,
-					Format: plog.FormatJSON,
-				},
-			},
-		},
-		{
-			name: "Fully filled out old log and new log struct",
+			name: "fully filled out including log format",
 			yaml: here.Doc(`
 				---
 				discovery:
@@ -279,7 +199,28 @@ func TestFromPath(t *testing.T) {
 				  level: all
 				  format: snorlax
 			`),
-			wantError: "decode yaml: error unmarshaling JSON: while decoding JSON: invalid log format, valid choices are the empty string, json and text",
+			wantError: "decode yaml: error unmarshaling JSON: while decoding JSON: invalid log format, valid choices are the empty string or 'json'",
+		},
+		{
+			name: "cli is a bad log format when configured by the user",
+			yaml: here.Doc(`
+				---
+				names:
+				  servingCertificateSecret: pinniped-concierge-api-tls-serving-certificate
+				  credentialIssuer: pinniped-config
+				  apiService: pinniped-api
+				  impersonationLoadBalancerService: impersonationLoadBalancerService-value
+				  impersonationClusterIPService: impersonationClusterIPService-value
+				  impersonationTLSCertificateSecret: impersonationTLSCertificateSecret-value
+				  impersonationCACertificateSecret: impersonationCACertificateSecret-value
+				  impersonationSignerSecret: impersonationSignerSecret-value
+				  agentServiceAccount: agentServiceAccount-value
+				  impersonationProxyServiceAccount: impersonationProxyServiceAccount-value
+				log:
+				  level: all
+				  format: cli
+			`),
+			wantError: "decode yaml: error unmarshaling JSON: while decoding JSON: invalid log format, valid choices are the empty string or 'json'",
 		},
 		{
 			name: "When only the required fields are present, causes other fields to be defaulted",

--- a/internal/config/concierge/types.go
+++ b/internal/config/concierge/types.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package concierge
@@ -15,9 +15,7 @@ type Config struct {
 	NamesConfig                  NamesConfigSpec   `json:"names"`
 	KubeCertAgentConfig          KubeCertAgentSpec `json:"kubeCertAgent"`
 	Labels                       map[string]string `json:"labels"`
-	// Deprecated: use log.level instead
-	LogLevel *plog.LogLevel `json:"logLevel"`
-	Log      plog.LogSpec   `json:"log"`
+	Log                          plog.LogSpec      `json:"log"`
 }
 
 // DiscoveryInfoSpec contains configuration knobs specific to

--- a/internal/config/supervisor/config.go
+++ b/internal/config/supervisor/config.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package supervisor contains functionality to load/store Config's from/to
@@ -66,7 +66,6 @@ func FromPath(ctx context.Context, path string) (*Config, error) {
 		return nil, fmt.Errorf("validate names: %w", err)
 	}
 
-	plog.MaybeSetDeprecatedLogLevel(config.LogLevel, &config.Log)
 	if err := plog.ValidateAndSetLogLevelAndFormatGlobally(ctx, config.Log); err != nil {
 		return nil, fmt.Errorf("validate log level: %w", err)
 	}
@@ -80,23 +79,10 @@ func FromPath(ctx context.Context, path string) (*Config, error) {
 		Network: NetworkTCP,
 		Address: ":8443",
 	})
-	maybeSetEndpointDefault(&config.Endpoints.HTTP, Endpoint{
-		Network: NetworkDisabled,
-	})
 
 	if err := validateEndpoint(*config.Endpoints.HTTPS); err != nil {
 		return nil, fmt.Errorf("validate https endpoint: %w", err)
 	}
-	if err := validateEndpoint(*config.Endpoints.HTTP); err != nil {
-		return nil, fmt.Errorf("validate http endpoint: %w", err)
-	}
-	if err := validateAdditionalHTTPEndpointRequirements(*config.Endpoints.HTTP, config.AllowExternalHTTP); err != nil {
-		return nil, fmt.Errorf("validate http endpoint: %w", err)
-	}
-	if err := validateAtLeastOneEnabledEndpoint(*config.Endpoints.HTTPS, *config.Endpoints.HTTP); err != nil {
-		return nil, fmt.Errorf("validate endpoints: %w", err)
-	}
-
 	return &config, nil
 }
 
@@ -142,40 +128,10 @@ func validateEndpoint(endpoint Endpoint) error {
 		}
 		return nil
 	case NetworkDisabled:
-		if len(endpoint.Address) != 0 {
-			return fmt.Errorf("address set to %q when disabled, should be empty", endpoint.Address)
-		}
-		return nil
+		return fmt.Errorf("must not be disabled")
 	default:
 		return fmt.Errorf("unknown network %q", n)
 	}
-}
-
-func validateAdditionalHTTPEndpointRequirements(endpoint Endpoint, allowExternalHTTP stringOrBoolAsBool) error {
-	if endpoint.Network == NetworkTCP && !addrIsOnlyOnLoopback(endpoint.Address) {
-		if allowExternalHTTP {
-			// Log that the validation should have been triggered.
-			plog.Warning("Listening on non-loopback interfaces for the HTTP port is deprecated and will be removed " +
-				"in a future release. Your current configuration would not be allowed in that future release. " +
-				"Please see comments in deploy/supervisor/values.yaml and review your settings.")
-			// Skip enforcement of the validation.
-			return nil
-		}
-		return fmt.Errorf(
-			"http listener address %q for %q network may only bind to loopback interfaces",
-			endpoint.Address,
-			endpoint.Network)
-	}
-	return nil
-}
-
-func validateAtLeastOneEnabledEndpoint(endpoints ...Endpoint) error {
-	for _, endpoint := range endpoints {
-		if endpoint.Network != NetworkDisabled {
-			return nil
-		}
-	}
-	return constable.Error("all endpoints are disabled")
 }
 
 // For tcp networks, the address can be in several formats: host:port, host:, and :port.

--- a/internal/config/supervisor/types.go
+++ b/internal/config/supervisor/types.go
@@ -25,6 +25,7 @@ type NamesConfigSpec struct {
 
 type Endpoints struct {
 	HTTPS *Endpoint `json:"https,omitempty"`
+	HTTP  *Endpoint `json:"http,omitempty"`
 }
 
 type Endpoint struct {

--- a/internal/config/supervisor/types.go
+++ b/internal/config/supervisor/types.go
@@ -1,25 +1,20 @@
-// Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package supervisor
 
 import (
-	"errors"
-
 	"go.pinniped.dev/internal/plog"
 )
 
 // Config contains knobs to setup an instance of the Pinniped Supervisor.
 type Config struct {
-	APIGroupSuffix *string           `json:"apiGroupSuffix,omitempty"`
-	Labels         map[string]string `json:"labels"`
-	NamesConfig    NamesConfigSpec   `json:"names"`
-	// Deprecated: use log.level instead
-	LogLevel                *plog.LogLevel     `json:"logLevel"`
-	Log                     plog.LogSpec       `json:"log"`
-	Endpoints               *Endpoints         `json:"endpoints"`
-	AllowExternalHTTP       stringOrBoolAsBool `json:"insecureAcceptExternalUnencryptedHttpRequests"`
-	AggregatedAPIServerPort *int64             `json:"aggregatedAPIServerPort"`
+	APIGroupSuffix          *string           `json:"apiGroupSuffix,omitempty"`
+	Labels                  map[string]string `json:"labels"`
+	NamesConfig             NamesConfigSpec   `json:"names"`
+	Log                     plog.LogSpec      `json:"log"`
+	Endpoints               *Endpoints        `json:"endpoints"`
+	AggregatedAPIServerPort *int64            `json:"aggregatedAPIServerPort"`
 }
 
 // NamesConfigSpec configures the names of some Kubernetes resources for the Supervisor.
@@ -30,24 +25,9 @@ type NamesConfigSpec struct {
 
 type Endpoints struct {
 	HTTPS *Endpoint `json:"https,omitempty"`
-	HTTP  *Endpoint `json:"http,omitempty"`
 }
 
 type Endpoint struct {
 	Network string `json:"network"`
 	Address string `json:"address"`
-}
-
-type stringOrBoolAsBool bool
-
-func (sb *stringOrBoolAsBool) UnmarshalJSON(b []byte) error {
-	switch string(b) {
-	case "true", `"true"`:
-		*sb = true
-	case "false", `"false"`:
-		*sb = false
-	default:
-		return errors.New("invalid value for boolean")
-	}
-	return nil
 }

--- a/internal/plog/config.go
+++ b/internal/plog/config.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package plog
@@ -48,13 +48,6 @@ var _ json.Unmarshaler = func() *LogFormat {
 type LogSpec struct {
 	Level  LogLevel  `json:"level,omitempty"`
 	Format LogFormat `json:"format,omitempty"`
-}
-
-func MaybeSetDeprecatedLogLevel(level *LogLevel, log *LogSpec) {
-	if level != nil {
-		Warning("logLevel is deprecated, set log.level instead")
-		log.Level = *level
-	}
 }
 
 func ValidateAndSetLogLevelAndFormatGlobally(ctx context.Context, spec LogSpec) error {

--- a/internal/plog/config_test.go
+++ b/internal/plog/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package plog
@@ -166,7 +166,7 @@ testing.tRunner
 	// check for the deprecation warning
 	require.True(t, scanner.Scan())
 	require.NoError(t, scanner.Err())
-	require.Equal(t, fmt.Sprintf(`I1121 23:37:26.953313%8d config.go:96] "setting log.format to 'text' is deprecated - this option will be removed in a future release" warning=true`,
+	require.Equal(t, fmt.Sprintf(`I1121 23:37:26.953313%8d config.go:89] "setting log.format to 'text' is deprecated - this option will be removed in a future release" warning=true`,
 		pid), scanner.Text())
 
 	Debug("what is happening", "does klog", "work?")

--- a/internal/plog/config_test.go
+++ b/internal/plog/config_test.go
@@ -101,7 +101,7 @@ func TestFormat(t *testing.T) {
   "timestamp": "2022-11-21T23:37:26.953313Z",
   "caller": "%s/config_test.go:%d$plog.TestFormat.func1",
   "message": "something happened",
-  "error": "invalid log format, valid choices are the empty string, json and text",
+  "error": "invalid log format, valid choices are the empty string or 'json'",
   "an": "item"
 }`, wd, getLineNumberOfCaller()-11), scanner.Text())
 
@@ -148,7 +148,7 @@ testing.tRunner
 	DebugErr("something happened", errInvalidLogFormat, "an", "item")
 	require.True(t, scanner.Scan())
 	require.NoError(t, scanner.Err())
-	require.Equal(t, fmt.Sprintf(nowStr+`  plog/config_test.go:%d  something happened  {"error": "invalid log format, valid choices are the empty string, json and text", "an": "item"}`,
+	require.Equal(t, fmt.Sprintf(nowStr+`  plog/config_test.go:%d  something happened  {"error": "invalid log format, valid choices are the empty string or 'json'", "an": "item"}`,
 		getLineNumberOfCaller()-4), scanner.Text())
 
 	Logr().WithName("burrito").Error(errInvalidLogLevel, "wee", "a", "b", "slightly less than a year", 363*24*time.Hour, "slightly more than 2 years", 2*367*24*time.Hour)
@@ -156,74 +156,6 @@ testing.tRunner
 	require.NoError(t, scanner.Err())
 	require.Equal(t, fmt.Sprintf(nowStr+`  burrito  plog/config_test.go:%d  wee  {"a": "b", "slightly less than a year": "363d", "slightly more than 2 years": "2y4d", "error": "invalid log level, valid choices are the empty string, info, debug, trace and all"}`,
 		getLineNumberOfCaller()-4), scanner.Text())
-
-	old := New().WithName("created before mode change").WithValues("is", "old")
-
-	err = ValidateAndSetLogLevelAndFormatGlobally(ctx, LogSpec{Level: LevelDebug, Format: FormatText})
-	require.NoError(t, err)
-	pid := os.Getpid()
-
-	// check for the deprecation warning
-	require.True(t, scanner.Scan())
-	require.NoError(t, scanner.Err())
-	require.Equal(t, fmt.Sprintf(`I1121 23:37:26.953313%8d config.go:89] "setting log.format to 'text' is deprecated - this option will be removed in a future release" warning=true`,
-		pid), scanner.Text())
-
-	Debug("what is happening", "does klog", "work?")
-	require.True(t, scanner.Scan())
-	require.NoError(t, scanner.Err())
-	require.Equal(t, fmt.Sprintf(`I1121 23:37:26.953313%8d config_test.go:%d] "what is happening" does klog="work?"`,
-		pid, getLineNumberOfCaller()-4), scanner.Text())
-
-	Logr().WithName("panda").V(KlogLevelDebug).Info("are the best", "yes?", "yes.")
-	require.True(t, scanner.Scan())
-	require.NoError(t, scanner.Err())
-	require.Equal(t, fmt.Sprintf(`I1121 23:37:26.953313%8d config_test.go:%d] "are the best" logger="panda" yes?="yes."`,
-		pid, getLineNumberOfCaller()-4), scanner.Text())
-
-	New().WithName("hi").WithName("there").WithValues("a", 1, "b", 2).Always("do it")
-	require.True(t, scanner.Scan())
-	require.NoError(t, scanner.Err())
-	require.Equal(t, fmt.Sprintf(`I1121 23:37:26.953313%8d config_test.go:%d] "do it" logger="hi.there" a=1 b=2`,
-		pid, getLineNumberOfCaller()-4), scanner.Text())
-
-	l := WithValues("x", 33, "z", 22)
-	l.Debug("what to do")
-	l.Debug("and why")
-	require.True(t, scanner.Scan())
-	require.NoError(t, scanner.Err())
-	require.Equal(t, fmt.Sprintf(`I1121 23:37:26.953313%8d config_test.go:%d] "what to do" x=33 z=22`,
-		pid, getLineNumberOfCaller()-5), scanner.Text())
-	require.True(t, scanner.Scan())
-	require.NoError(t, scanner.Err())
-	require.Equal(t, fmt.Sprintf(`I1121 23:37:26.953313%8d config_test.go:%d] "and why" x=33 z=22`,
-		pid, getLineNumberOfCaller()-8), scanner.Text())
-
-	old.Always("should be klog text format", "for", "sure")
-	require.True(t, scanner.Scan())
-	require.NoError(t, scanner.Err())
-	require.Equal(t, fmt.Sprintf(`I1121 23:37:26.953313%8d config_test.go:%d] "should be klog text format" logger="created before mode change" is="old" for="sure"`,
-		pid, getLineNumberOfCaller()-4), scanner.Text())
-
-	// make sure child loggers do not share state
-	old1 := old.WithValues("i am", "old1")
-	old2 := old.WithName("old2")
-	old1.Warning("warn")
-	old2.Info("info")
-	require.True(t, scanner.Scan())
-	require.NoError(t, scanner.Err())
-	require.Equal(t, fmt.Sprintf(`I1121 23:37:26.953313%8d config_test.go:%d] "warn" logger="created before mode change" is="old" i am="old1" warning=true`,
-		pid, getLineNumberOfCaller()-5), scanner.Text())
-	require.True(t, scanner.Scan())
-	require.NoError(t, scanner.Err())
-	require.Equal(t, fmt.Sprintf(`I1121 23:37:26.953313%8d config_test.go:%d] "info" logger="created before mode change.old2" is="old"`,
-		pid, getLineNumberOfCaller()-8), scanner.Text())
-
-	Trace("should not be logged", "for", "sure")
-	require.Empty(t, buf.String())
-
-	Logr().V(klogLevelAll).Info("also should not be logged", "open", "close")
-	require.Empty(t, buf.String())
 
 	require.False(t, scanner.Scan())
 	require.NoError(t, scanner.Err())

--- a/internal/supervisor/server/server.go
+++ b/internal/supervisor/server/server.go
@@ -508,79 +508,60 @@ func runSupervisor(ctx context.Context, podInfo *downward.PodInfo, cfg *supervis
 		return fmt.Errorf("could not create aggregated API server: %w", err)
 	}
 
-	if e := cfg.Endpoints.HTTP; e.Network != supervisor.NetworkDisabled {
-		finishSetupPerms := maybeSetupUnixPerms(e, supervisorPod)
+	finishSetupPerms := maybeSetupUnixPerms(cfg.Endpoints.HTTPS, supervisorPod)
 
-		httpListener, err := net.Listen(e.Network, e.Address)
-		if err != nil {
-			return fmt.Errorf("cannot create http listener with network %q and address %q: %w", e.Network, e.Address, err)
-		}
-
-		if err := finishSetupPerms(); err != nil {
-			return fmt.Errorf("cannot setup http listener permissions for network %q and address %q: %w", e.Network, e.Address, err)
-		}
-
-		defer func() { _ = httpListener.Close() }()
-		startServer(ctx, shutdown, httpListener, oidProvidersManager)
-		plog.Debug("supervisor http listener started", "address", httpListener.Addr().String())
+	bootstrapCert, err := getBootstrapCert() // generate this in-memory once per process startup
+	if err != nil {
+		return fmt.Errorf("https listener bootstrap error: %w", err)
 	}
 
-	if e := cfg.Endpoints.HTTPS; e.Network != supervisor.NetworkDisabled { //nolint:nestif
-		finishSetupPerms := maybeSetupUnixPerms(e, supervisorPod)
+	c := ptls.Default(nil)
+	c.GetCertificate = func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
+		cert := dynamicTLSCertProvider.GetTLSCert(strings.ToLower(info.ServerName))
+		foundServerNameCert := cert != nil
 
-		bootstrapCert, err := getBootstrapCert() // generate this in-memory once per process startup
-		if err != nil {
-			return fmt.Errorf("https listener bootstrap error: %w", err)
+		defaultCert := dynamicTLSCertProvider.GetDefaultTLSCert()
+
+		if !foundServerNameCert {
+			cert = defaultCert
 		}
 
-		c := ptls.Default(nil)
-		c.GetCertificate = func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
-			cert := dynamicTLSCertProvider.GetTLSCert(strings.ToLower(info.ServerName))
-			foundServerNameCert := cert != nil
-
-			defaultCert := dynamicTLSCertProvider.GetDefaultTLSCert()
-
-			if !foundServerNameCert {
-				cert = defaultCert
-			}
-
-			// If we still don't have a cert for the request at this point, then using the bootstrapping cert,
-			// but in that case also set the request to fail unless it is a health check request.
-			usingBootstrapCert := false
-			if cert == nil {
-				usingBootstrapCert = true
-				setIsBootstrapConn(info.Context()) // make this connection only work for bootstrap requests
-				cert = bootstrapCert
-			}
-
-			// Emit logs visible at a higher level of logging than the default. Using Info level so the user
-			// can safely configure a production Supervisor to show this message if they choose.
-			plog.Info("choosing TLS cert for incoming request",
-				"requestSNIServerName", info.ServerName,
-				"foundCertForSNIServerNameFromFederationDomain", foundServerNameCert,
-				"foundDefaultCertFromSecret", defaultCert != nil,
-				"defaultCertSecretName", cfg.NamesConfig.DefaultTLSCertificateSecret,
-				"servingBootstrapHealthzCert", usingBootstrapCert,
-				"requestLocalAddr", info.Conn.LocalAddr().String(),
-				"requestRemoteAddr", info.Conn.RemoteAddr().String(),
-			)
-
-			return cert, nil
+		// If we still don't have a cert for the request at this point, then using the bootstrapping cert,
+		// but in that case also set the request to fail unless it is a health check request.
+		usingBootstrapCert := false
+		if cert == nil {
+			usingBootstrapCert = true
+			setIsBootstrapConn(info.Context()) // make this connection only work for bootstrap requests
+			cert = bootstrapCert
 		}
 
-		httpsListener, err := tls.Listen(e.Network, e.Address, c)
-		if err != nil {
-			return fmt.Errorf("cannot create https listener with network %q and address %q: %w", e.Network, e.Address, err)
-		}
+		// Emit logs visible at a higher level of logging than the default. Using Info level so the user
+		// can safely configure a production Supervisor to show this message if they choose.
+		plog.Info("choosing TLS cert for incoming request",
+			"requestSNIServerName", info.ServerName,
+			"foundCertForSNIServerNameFromFederationDomain", foundServerNameCert,
+			"foundDefaultCertFromSecret", defaultCert != nil,
+			"defaultCertSecretName", cfg.NamesConfig.DefaultTLSCertificateSecret,
+			"servingBootstrapHealthzCert", usingBootstrapCert,
+			"requestLocalAddr", info.Conn.LocalAddr().String(),
+			"requestRemoteAddr", info.Conn.RemoteAddr().String(),
+		)
 
-		if err := finishSetupPerms(); err != nil {
-			return fmt.Errorf("cannot setup https listener permissions for network %q and address %q: %w", e.Network, e.Address, err)
-		}
-
-		defer func() { _ = httpsListener.Close() }()
-		startServer(ctx, shutdown, httpsListener, oidProvidersManager)
-		plog.Debug("supervisor https listener started", "address", httpsListener.Addr().String())
+		return cert, nil
 	}
+
+	httpsListener, err := tls.Listen(cfg.Endpoints.HTTPS.Network, cfg.Endpoints.HTTPS.Address, c)
+	if err != nil {
+		return fmt.Errorf("cannot create https listener with network %q and address %q: %w", cfg.Endpoints.HTTPS.Network, cfg.Endpoints.HTTPS.Address, err)
+	}
+
+	if err := finishSetupPerms(); err != nil {
+		return fmt.Errorf("cannot setup https listener permissions for network %q and address %q: %w", cfg.Endpoints.HTTPS.Network, cfg.Endpoints.HTTPS.Address, err)
+	}
+
+	defer func() { _ = httpsListener.Close() }()
+	startServer(ctx, shutdown, httpsListener, oidProvidersManager)
+	plog.Debug("supervisor https listener started", "address", httpsListener.Addr().String())
 
 	plog.Debug("supervisor started")
 	defer plog.Debug("supervisor exiting")

--- a/site/content/docs/howto/supervisor/configure-supervisor.md
+++ b/site/content/docs/howto/supervisor/configure-supervisor.md
@@ -54,24 +54,15 @@ ingress and TLS configuration. In that case, please refer to the documentation f
 
 ## Exposing the Supervisor app's endpoints outside the cluster
 
-The Supervisor app's endpoints should be exposed as HTTPS endpoints with proper TLS certificates signed by a
+The Supervisor app's endpoints must be exposed as HTTPS endpoints with proper TLS certificates signed by a
 certificate authority (CA) which is trusted by your end user's web browsers.
 
-It is recommended that the traffic to these endpoints should be encrypted via TLS all the way into the
+Furthermore, all traffic to Supervisor endpoints must be encrypted via TLS all the way into the
 Supervisor pods, even when crossing boundaries that are entirely inside the Kubernetes cluster.
 The credentials and tokens that are handled by these endpoints are too sensitive to transmit without encryption.
 
-In previous versions of the Supervisor app, there were both HTTP and HTTPS ports available for use by default.
-These ports each host all the Supervisor's endpoints. Unfortunately, this has caused some confusion in the community
-and some blog posts have been written which demonstrate using the HTTP port in such a way that a portion of the traffic's
-path is unencrypted. Newer versions of the Supervisor disable the HTTP port by default to make it more clear that
-the Supervisor app is not intended to receive non-TLS HTTP traffic from outside the Pod. Furthermore, in these newer versions,
-when the HTTP listener is configured to be enabled it may only listen on loopback interfaces for traffic from within its own pod.
-To aid in transition for impacted users, the old behavior of allowing the HTTP listener to receive traffic from
-outside the pod may be re-enabled using the
-`deprecated_insecure_accept_external_unencrypted_http_requests` value in
-[values.yaml](https://github.com/vmware-tanzu/pinniped/blob/main/deploy/supervisor/values.yaml),
-until that setting is removed in a future release.
+Previous versions of the Supervisor app supported both HTTP and HTTPS ports. Starting with Pinniped v0.30.0,
+HTTP ports are no longer allowed.
 
 Because there are many ways to expose TLS services from a Kubernetes cluster, the Supervisor app leaves this up to the user.
 Some common approaches are:

--- a/site/content/docs/howto/supervisor/configure-supervisor.md
+++ b/site/content/docs/howto/supervisor/configure-supervisor.md
@@ -54,15 +54,15 @@ ingress and TLS configuration. In that case, please refer to the documentation f
 
 ## Exposing the Supervisor app's endpoints outside the cluster
 
-The Supervisor app's endpoints must be exposed as HTTPS endpoints with proper TLS certificates signed by a
+The Supervisor app's endpoints should be exposed as HTTPS endpoints with proper TLS certificates signed by a
 certificate authority (CA) which is trusted by your end user's web browsers.
 
-Furthermore, all traffic to Supervisor endpoints must be encrypted via TLS all the way into the
+It is recommended that the traffic to these endpoints should be encrypted via TLS all the way into the
 Supervisor pods, even when crossing boundaries that are entirely inside the Kubernetes cluster.
 The credentials and tokens that are handled by these endpoints are too sensitive to transmit without encryption.
 
-Previous versions of the Supervisor app supported both HTTP and HTTPS ports. Starting with Pinniped v0.30.0,
-HTTP ports are no longer allowed.
+The Supervisor only listens on an HTTPS port by default. Incoming traffic must use TLS. The only exception is for
+an advanced configuration style using a service mesh to deliver traffic into the Supervisor (discussed below).
 
 Because there are many ways to expose TLS services from a Kubernetes cluster, the Supervisor app leaves this up to the user.
 Some common approaches are:


### PR DESCRIPTION
Remove deprecated deploy options.

Note that `ytt` schemas do not allow you to specify unrecognized options, so there's no need to check whether these additional deprecated values have been provided. This likely means we [already have some dead code](https://github.com/vmware-tanzu/pinniped/blob/b99da0c805f43771c824bb9fc95b2d80804416a9/deploy/supervisor/service.yaml#L8-L19) (now removed in this PR). 

It also means we don't need code like this to check for deprecated/unrecognized/additional values:

```yaml
#@ load("@ytt:data", "data")
#@ load("@ytt:assert", "assert")
#@
#@ deprecated_values = (
#@   'service_http_nodeport_port',
#@   'service_http_nodeport_nodeport',
#@   'service_http_loadbalancer_port',
#@   'service_http_clusterip_port',
#@   'deprecated_service_http_nodeport_port',
#@   'deprecated_service_http_nodeport_nodeport',
#@   'deprecated_service_http_loadbalancer_port',
#@   'deprecated_service_http_clusterip_port',
#@   'deprecated_insecure_accept_external_unencrypted_http_requests',
#@   'deprecated_log_format')
#@
#@ for val in deprecated_values:
#@   if hasattr(data.values, val):
#@     assert.fail('value "' + val + '" has been removed')
#@   end
#@ end
```