### PR TITLE
only auto-detect version v1 of ValidatingAdmissionPlugin during startup

### DIFF
--- a/internal/admissionpluginconfig/admissionpluginconfg_test.go
+++ b/internal/admissionpluginconfig/admissionpluginconfg_test.go
@@ -57,6 +57,14 @@ func TestConfigureAdmissionPlugins(t *testing.T) {
 		},
 	}
 
+	newStyleAdmissionResourcesWithValidatingAdmissionPoliciesAtOlderAPIVersion := &metav1.APIResourceList{
+		GroupVersion: admissionregistrationv1.SchemeGroupVersion.Group + "/v1beta1",
+		APIResources: []metav1.APIResource{
+			{Name: "validatingwebhookconfigurations", Kind: "ValidatingWebhookConfiguration"},
+			{Name: "validatingadmissionpolicies", Kind: "ValidatingAdmissionPolicy"},
+		},
+	}
+
 	oldStyleAdmissionResourcesWithoutValidatingAdmissionPolicies := &metav1.APIResourceList{
 		GroupVersion: admissionregistrationv1.SchemeGroupVersion.String(),
 		APIResources: []metav1.APIResource{
@@ -87,6 +95,16 @@ func TestConfigureAdmissionPlugins(t *testing.T) {
 			availableAPIResources: []*metav1.APIResourceList{
 				coreResources,
 				oldStyleAdmissionResourcesWithoutValidatingAdmissionPolicies,
+				appsResources,
+			},
+			wantRegisteredPlugins:      customOldStylePluginsRegistered,
+			wantRecommendedPluginOrder: customOldStyleRecommendedPluginOrder,
+		},
+		{
+			name: "when there is only an older version of ValidatingAdmissionPolicy resource, as there would be in an old Kubernetes cluster with the feature flag enabled, then we change the plugin configuration to be more like it was for old versions of Kubernetes (because the admission code wants to watch v1)",
+			availableAPIResources: []*metav1.APIResourceList{
+				coreResources,
+				newStyleAdmissionResourcesWithValidatingAdmissionPoliciesAtOlderAPIVersion,
 				appsResources,
 			},
 			wantRegisteredPlugins:      customOldStylePluginsRegistered,


### PR DESCRIPTION
This is a follow-up to #1921.

CI showed that in an AKS 1.29 cluster which had version `v1beta1` of `admissionregistration.k8s.io`, Pinniped would fail because the new 1.30 Kube libraries are specifically trying to start a watch for `v1` of this resource.

This PR changes our new auto-detection code to specifically look for `v1`, and to only enable the validating admission plugin when `v1` is found.

**Release note**:

```release-note
NONE
```
