### PR TITLE
use "latest" dir for API docs in doc URLs on the web site

### DIFF
--- a/site/content/docs/background/architecture.md
+++ b/site/content/docs/background/architecture.md
@@ -48,7 +48,7 @@ Pinniped supports the following IDPs.
 1. Any Active Directory identity provider (via LDAP).
 
 The
-[`idp.supervisor.pinniped.dev`](https://github.com/vmware-tanzu/pinniped/blob/main/generated/{{< latestcodegenversion >}}/README.adoc#k8s-api-idp-supervisor-pinniped-dev-v1alpha1)
+[`idp.supervisor.pinniped.dev`](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#k8s-api-idp-supervisor-pinniped-dev-v1alpha1)
 API group contains the Kubernetes custom resources that configure the Pinniped
 Supervisor's upstream IDPs.
 
@@ -83,7 +83,7 @@ Pinniped supports the following authenticator types.
    set on the `kube-apiserver` process.
 
 The
-[`authentication.concierge.pinniped.dev`](https://github.com/vmware-tanzu/pinniped/blob/main/generated/{{< latestcodegenversion >}}/README.adoc#k8s-api-authentication-concierge-pinniped-dev-v1alpha1)
+[`authentication.concierge.pinniped.dev`](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#k8s-api-authentication-concierge-pinniped-dev-v1alpha1)
 API group contains the Kubernetes custom resources that configure the Pinniped
 Concierge's authenticators.
 

--- a/site/content/docs/howto/cicd.md
+++ b/site/content/docs/howto/cicd.md
@@ -47,7 +47,7 @@ on each cluster.
    and make those kubeconfigs available to CI/CD
    * Be sure to use `pinniped get kubeconfig` with option `--upstream-identity-provider-flow=cli_password` to authenticate non-interactively (without a browser)
    * When using OIDC, the optional CLI-based flow must be enabled by the administrator in the OIDCIdentityProvider configuration before use
-     (see `allowPasswordGrant` in the [API docs](https://github.com/vmware-tanzu/pinniped/blob/main/generated/{{< latestcodegenversion >}}/README.adoc#oidcauthorizationconfig) for more details).
+     (see `allowPasswordGrant` in the [API docs](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#oidcauthorizationconfig) for more details).
 2. A CI/CD admin should make the non-human user account credentials available to CI/CD tasks
 3. Each CI/CD task should set the environment variables `PINNIPED_USERNAME` and `PINNIPED_PASSWORD` for the `kubectl` process to avoid the interactive prompts.
 The values should be provided from the non-human user account credentials.

--- a/site/content/docs/howto/configure-auth-for-webapps.md
+++ b/site/content/docs/howto/configure-auth-for-webapps.md
@@ -376,7 +376,7 @@ scenes is actually served by the Pinniped Concierge. It can be accessed just lik
 not require any authentication on the request.
 
 The details of the request and response formats are documented in the
-[API docs](https://github.com/vmware-tanzu/pinniped/blob/main/generated/{{< latestcodegenversion >}}/README.adoc#tokencredentialrequest).
+[API docs](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#tokencredentialrequest).
 
 Here is a sample YAML representation of a request:
 

--- a/site/content/docs/howto/login.md
+++ b/site/content/docs/howto/login.md
@@ -125,7 +125,7 @@ will depend on which type of identity provider was configured.
   `kubectl` process to avoid the interactive prompts. Note that the optional CLI-based flow must be enabled by the
   administrator in the OIDCIdentityProvider configuration before use
   (see `allowPasswordGrant` in the
-  [API docs](https://github.com/vmware-tanzu/pinniped/blob/main/generated/{{< latestcodegenversion >}}/README.adoc#oidcauthorizationconfig)
+  [API docs](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#oidcauthorizationconfig)
   for more details).
 
 - For LDAP and Active Directory identity providers, there are also two supported client flows:

--- a/site/content/docs/howto/supervisor/configure-supervisor-federationdomain-idps.md
+++ b/site/content/docs/howto/supervisor/configure-supervisor-federationdomain-idps.md
@@ -20,7 +20,7 @@ This how-to guide assumes that you have already [installed the Pinniped Supervis
 and have already read the guide about how to [configure the Supervisor as an OIDC issuer]({{< ref "configure-supervisor" >}}).
 
 This guide focuses on the use of the `spec.identityProviders` setting on the
-[FederationDomain](https://github.com/vmware-tanzu/pinniped/blob/main/generated/{{< latestcodegenversion >}}/README.adoc#federationdomain)
+[FederationDomain](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#federationdomain)
 resource.
 
 Note that the `spec.identityProviders` setting on the FederationDomain resource was added in v0.26.0 of Pinniped.
@@ -230,7 +230,7 @@ The following example is contrived to demonstrate every feature of the `transfor
 (constants, expressions, and examples). It is likely more complex than a typical configuration.
 
 Documentation for each of the fields shown below can be found in the API docs for the
-[FederationDomain](https://github.com/vmware-tanzu/pinniped/blob/main/generated/{{< latestcodegenversion >}}/README.adoc#federationdomain)
+[FederationDomain](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#federationdomain)
 resource.
 
 ```yaml

--- a/site/content/docs/howto/supervisor/configure-supervisor-with-activedirectory.md
+++ b/site/content/docs/howto/supervisor/configure-supervisor-with-activedirectory.md
@@ -24,7 +24,7 @@ and that you have [configured a FederationDomain to issue tokens for your downst
 
 ## Configure the Supervisor cluster
 
-Create an [ActiveDirectoryIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/{{< latestcodegenversion >}}/README.adoc#activedirectoryidentityprovider) in the same namespace as the Supervisor.
+Create an [ActiveDirectoryIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#activedirectoryidentityprovider) in the same namespace as the Supervisor.
 
 ### ActiveDirectoryIdentityProvider with default options
 

--- a/site/content/docs/howto/supervisor/configure-supervisor-with-auth0.md
+++ b/site/content/docs/howto/supervisor/configure-supervisor-with-auth0.md
@@ -71,7 +71,7 @@ To configure your Kubernetes authorization, please see [how-to login]({{< ref "l
 
 ## Configure the Supervisor
 
-Create an [OIDCIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/{{< latestcodegenversion >}}/README.adoc#oidcidentityprovider) in the same namespace as the Supervisor.
+Create an [OIDCIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#oidcidentityprovider) in the same namespace as the Supervisor.
 
 For example, this OIDCIdentityProvider uses Auth0's `email` claim as the Kubernetes username:
 

--- a/site/content/docs/howto/supervisor/configure-supervisor-with-azuread.md
+++ b/site/content/docs/howto/supervisor/configure-supervisor-with-azuread.md
@@ -46,7 +46,7 @@ For example, to create a tenant:
 
 ## Configure the Supervisor 
 
-Create an [OIDCIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/{{< latestcodegenversion >}}/README.adoc#oidcidentityprovider) 
+Create an [OIDCIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#oidcidentityprovider) 
 in the same namespace as the Supervisor.
 
 1. In the [Azure portal](portal.azure.com), navigate to _Home_ > _Azure Active Directory_ > _App Registrations_.

--- a/site/content/docs/howto/supervisor/configure-supervisor-with-dex.md
+++ b/site/content/docs/howto/supervisor/configure-supervisor-with-dex.md
@@ -73,7 +73,7 @@ staticClients:
 
 ## Configure the Supervisor
 
-Create an [OIDCIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/{{< latestcodegenversion >}}/README.adoc#oidcidentityprovider) resource in the same namespace as the Supervisor.
+Create an [OIDCIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#oidcidentityprovider) resource in the same namespace as the Supervisor.
 
 For example, the following OIDCIdentityProvider and the corresponding Secret use Dex's `email` claim as the Kubernetes username:
 

--- a/site/content/docs/howto/supervisor/configure-supervisor-with-gitlab.md
+++ b/site/content/docs/howto/supervisor/configure-supervisor-with-gitlab.md
@@ -43,7 +43,7 @@ For example, to create a user-owned application:
 
 ## Configure the Supervisor cluster
 
-Create an [OIDCIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/{{< latestcodegenversion >}}/README.adoc#oidcidentityprovider) in the same namespace as the Supervisor.
+Create an [OIDCIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#oidcidentityprovider) in the same namespace as the Supervisor.
 
 For example, this OIDCIdentityProvider and corresponding Secret for [gitlab.com](https://gitlab.com) use the `nickname` claim (GitLab username) as the Kubernetes username:
 

--- a/site/content/docs/howto/supervisor/configure-supervisor-with-jumpcloudldap.md
+++ b/site/content/docs/howto/supervisor/configure-supervisor-with-jumpcloudldap.md
@@ -48,7 +48,7 @@ Here are some good resources to review while setting up and using JumpCloud's LD
 
 ## Configure the Supervisor cluster
 
-Create an [LDAPIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/{{< latestcodegenversion >}}/README.adoc#ldapidentityprovider) in the same namespace as the Supervisor.
+Create an [LDAPIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#ldapidentityprovider) in the same namespace as the Supervisor.
 
 For example, this LDAPIdentityProvider configures the LDAP entry's `uid` as the Kubernetes username,
 and the `cn` (common name) of each group to which the user belongs as the Kubernetes group names.

--- a/site/content/docs/howto/supervisor/configure-supervisor-with-okta.md
+++ b/site/content/docs/howto/supervisor/configure-supervisor-with-okta.md
@@ -51,7 +51,7 @@ For example, to create an app:
 
 ## Configure the Supervisor
 
-Create an [OIDCIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/{{< latestcodegenversion >}}/README.adoc#oidcidentityprovider) in the same namespace as the Supervisor.
+Create an [OIDCIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#oidcidentityprovider) in the same namespace as the Supervisor.
 
 For example, this OIDCIdentityProvider and corresponding Secret use Okta's `email` claim as the Kubernetes username:
 

--- a/site/content/docs/howto/supervisor/configure-supervisor-with-openldap.md
+++ b/site/content/docs/howto/supervisor/configure-supervisor-with-openldap.md
@@ -188,7 +188,7 @@ kubectl apply -f openldap.yaml
 
 ## Configure the Supervisor cluster
 
-Create an [LDAPIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/{{< latestcodegenversion >}}/README.adoc#ldapidentityprovider) in the same namespace as the Supervisor.
+Create an [LDAPIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#ldapidentityprovider) in the same namespace as the Supervisor.
 
 For example, this LDAPIdentityProvider configures the LDAP entry's `uid` as the Kubernetes username,
 and the `cn` (common name) of each group to which the user belongs as the Kubernetes group names.

--- a/site/content/docs/howto/supervisor/configure-supervisor-with-workspace_one_access.md
+++ b/site/content/docs/howto/supervisor/configure-supervisor-with-workspace_one_access.md
@@ -54,7 +54,7 @@ For example, to create an app:
 
 ## Configure the Supervisor
 
-Create an [OIDCIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/{{< latestcodegenversion >}}/README.adoc#oidcidentityprovider) in the same namespace as the Supervisor.
+Create an [OIDCIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#oidcidentityprovider) in the same namespace as the Supervisor.
 
 For example, this OIDCIdentityProvider and corresponding Secret use Workspace ONE Access's `email` claim as the Kubernetes username:
 

--- a/site/content/docs/reference/active-directory-configuration.md
+++ b/site/content/docs/reference/active-directory-configuration.md
@@ -11,7 +11,7 @@ menu:
 ---
 
 This describes the default values for the `ActiveDirectoryIdentityProvider` user and group search. For more about `ActiveDirectoryIdentityProvider`
-configuration, see [the API reference documentation](https://github.com/vmware-tanzu/pinniped/blob/main/generated/{{< latestcodegenversion >}}/README.adoc#activedirectoryidentityprovider).
+configuration, see [the API reference documentation](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#activedirectoryidentityprovider).
 
 ### `spec.userSearch.base`
 

--- a/site/content/docs/reference/api.md
+++ b/site/content/docs/reference/api.md
@@ -9,4 +9,4 @@ menu:
     weight: 35
     parent: reference
 ---
-Full API reference documentation for the Pinniped Kubernetes API is available [on GitHub](https://github.com/vmware-tanzu/pinniped/blob/main/generated/{{< latestcodegenversion >}}/README.adoc).
+Full API reference documentation for the Pinniped Kubernetes API is available [on GitHub](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc).

--- a/site/content/docs/reference/supported-clusters.md
+++ b/site/content/docs/reference/supported-clusters.md
@@ -30,7 +30,7 @@ Most managed Kubernetes services do not support this.
 2. Impersonation Proxy: Can be run on any Kubernetes cluster. Default configuration requires that a `LoadBalancer` service can be created. Most cloud-hosted Kubernetes environments have this
 capability. The Impersonation Proxy automatically provisions (when `spec.impersonationProxy.mode` is set to `auto`) a `LoadBalancer` for ingress to the impersonation endpoint. Users who wish to use the impersonation proxy without an automatically
 configured `LoadBalancer` can do so with an automatically provisioned `ClusterIP` or with a Service that they provision themselves. These options
-can be configured in the spec of the [`CredentialIssuer`](https://github.com/vmware-tanzu/pinniped/blob/main/generated/{{< latestcodegenversion >}}/README.adoc#credentialissuer).
+can be configured in the spec of the [`CredentialIssuer`](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#credentialissuer).
 
 If a cluster is capable of supporting both strategies, the Pinniped CLI will use the
 token credential request API strategy by default.

--- a/site/content/docs/tutorials/concierge-and-supervisor-demo.md
+++ b/site/content/docs/tutorials/concierge-and-supervisor-demo.md
@@ -361,7 +361,7 @@ kubectl get secret supervisor-tls-cert \
 
 ### Configure a FederationDomain in the Pinniped Supervisor
 
-The Supervisor should be configured to have a [FederationDomain](https://github.com/vmware-tanzu/pinniped/blob/main/generated/{{< latestcodegenversion >}}/README.adoc#federationdomain), which, under the hood:
+The Supervisor should be configured to have a [FederationDomain](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#federationdomain), which, under the hood:
 - Acts as an OIDC provider to the Pinniped CLI, creating a consistent interface for the CLI to use regardless
   of which protocol the Supervisor is using to talk to the external identity provider
 - Also acts as an OIDC provider to the workload cluster's Concierge component, which will receive JWT tokens
@@ -417,7 +417,7 @@ The general steps required to create and configure a client in Okta are:
 
 ### Configure the Supervisor to use Okta as the external identity provider
 
-Create an [OIDCIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/{{< latestcodegenversion >}}/README.adoc#oidcidentityprovider) and a Secret.
+Create an [OIDCIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#oidcidentityprovider) and a Secret.
 
 ```sh
 # Replace the issuer's domain, the client ID, and client secret below.
@@ -488,7 +488,7 @@ kubectl apply -f \
 
 Configure the Concierge on the first workload cluster to trust the Supervisor's
 FederationDomain for authentication by creating a
-[JWTAuthenticator](https://github.com/vmware-tanzu/pinniped/blob/main/generated/{{< latestcodegenversion >}}/README.adoc#jwtauthenticator).
+[JWTAuthenticator](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#jwtauthenticator).
 
 ```sh
 # The audience value below is an arbitrary value which must uniquely

--- a/site/content/posts/2023-09-19-multiple-idps-and-identity-transformations.md
+++ b/site/content/posts/2023-09-19-multiple-idps-and-identity-transformations.md
@@ -132,7 +132,7 @@ with these new features, see:
 - The documentation for [creating FederationDomains]({{< ref "docs/howto/supervisor/configure-supervisor.md" >}}).
 - The documentation for [configuring identity providers on FederationDomains]({{< ref "docs/howto/supervisor/configure-supervisor-federationdomain-idps.md" >}}).
 - The API documentation for the `spec.identityProviders` setting on the
-[FederationDomain](https://github.com/vmware-tanzu/pinniped/blob/main/generated/{{< latestcodegenversion >}}/README.adoc#federationdomain)
+[FederationDomain](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#federationdomain)
 resource.
 
 {{< community >}}


### PR DESCRIPTION
When we released Pinniped v0.30.0, we included generated code for Kubernetes 1.30. The release process updated this config file for our web site to say 1.30: https://github.com/vmware-tanzu/pinniped/blob/main/site/config.yaml#L11

Sadly, 1.30 in YAML means the decimal value 1.3, not the string "1.30". This broke many API doc links on our web site because they accidentally use 1.3 where they should use 1.30.

This PR changes all those links to use `https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc` instead of interpolating the specific version number like `https://github.com/vmware-tanzu/pinniped/blob/main/generated/1.30/README.adoc`.


**Release note**:

```release-note
NONE
```
