### PR TITLE
handle another github login interstitial page

### DIFF
--- a/generated/1.30/apis/go.mod
+++ b/generated/1.30/apis/go.mod
@@ -3,7 +3,7 @@ module go.pinniped.dev/generated/1.30/apis
 
 go 1.22.0
 
-toolchain go1.22.3
+toolchain go1.22.4
 
 require (
 	k8s.io/api v0.30.1

--- a/generated/1.30/client/go.mod
+++ b/generated/1.30/client/go.mod
@@ -3,7 +3,7 @@ module go.pinniped.dev/generated/1.30/client
 
 go 1.22.0
 
-toolchain go1.22.3
+toolchain go1.22.4
 
 replace go.pinniped.dev/generated/1.30/apis => ../apis
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module go.pinniped.dev
 
 go 1.22.0
 
-toolchain go1.22.2
+toolchain go1.22.4
 
 // This version taken from https://github.com/kubernetes/apiserver/blob/v0.30.0/go.mod#L14 to avoid compile failures.
 replace github.com/google/cel-go => github.com/google/cel-go v0.17.8

--- a/test/testlib/browsertest/browsertest.go
+++ b/test/testlib/browsertest/browsertest.go
@@ -499,6 +499,18 @@ func handleOccasionalGithubLoginPage(t *testing.T, b *Browser, upstream testlib.
 		b.ClickFirstMatch(t, submitConfirmButtonSelector)
 		return true
 
+	case strings.HasPrefix(lowercaseTitle, "verify two-factor authentication"):
+		// Next GitHub might occasionally as you to confirm your MFA settings.
+		// Wait for the page to be rendered.
+		t.Logf("waiting for GitHub skip link")
+		// There are several buttons and links. We want to click this link to "skip 2FA verification":
+		// <button type="submit" data-view-component="true" class="Button--link Button--medium Button">
+		submitSkipButtonSelector := "button.Button--link[type=submit]"
+		b.WaitForVisibleElements(t, submitSkipButtonSelector)
+		t.Logf("clicking skip link")
+		b.ClickFirstMatch(t, submitSkipButtonSelector)
+		return true
+
 	case strings.HasPrefix(lowercaseTitle, "configure passwordless authentication"):
 		// Next GitHub might occasionally ask if we want to configure a passkey for auth.
 		// The URL bar shows https://github.com/sessions/trusted-device for this page.


### PR DESCRIPTION
Handle another page that can happen during github login in integration tests.

The page looks like this:
![image](https://github.com/vmware-tanzu/pinniped/assets/25013435/24e27f65-04f4-4787-b2ff-ddda5e38f80a)

Tests that see this page should try to click the "skip" link to move past it.

**Release note**:

```release-note
NONE
```
