### PR TITLE
rewrite flaky category test

### DIFF
--- a/test/integration/category_test.go
+++ b/test/integration/category_test.go
@@ -1,16 +1,18 @@
-// Copyright 2021-2022 the Pinniped contributors. All Rights Reserved.
+// Copyright 2021-2024 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package integration
 
 import (
 	"bytes"
+	"fmt"
 	"os/exec"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"go.pinniped.dev/test/testlib"
 )
@@ -51,57 +53,82 @@ func TestGetPinnipedCategory(t *testing.T) {
 	env := testlib.IntegrationEnv(t)
 	dotSuffix := "." + env.APIGroupSuffix
 
-	t.Run("category, no special params", func(t *testing.T) {
+	aggregatedAPIResources := []struct {
+		metav1.GroupVersion
+		ListKind string
+		Resource string
+	}{
+		{
+			GroupVersion: metav1.GroupVersion{
+				Group:   "login.concierge" + dotSuffix,
+				Version: "v1alpha1",
+			},
+			ListKind: "TokenCredentialRequestList",
+			Resource: "tokencredentialrequests",
+		},
+		{
+			GroupVersion: metav1.GroupVersion{
+				Group:   "identity.concierge" + dotSuffix,
+				Version: "v1alpha1",
+			},
+			ListKind: "WhoAmIRequestList",
+			Resource: "whoamirequests",
+		},
+		{
+			GroupVersion: metav1.GroupVersion{
+				Group:   "clientsecret.supervisor" + dotSuffix,
+				Version: "v1alpha1",
+			},
+			ListKind: "OIDCClientSecretRequestList",
+			Resource: "oidcclientsecretrequests",
+		},
+	}
+
+	t.Run("can kubectl get whole category as table", func(t *testing.T) {
 		t.Parallel()
+
 		stdout, stderr := runTestKubectlCommand(t, "get", "pinniped", "-A")
 		requireCleanKubectlStderr(t, stderr)
 		require.NotContains(t, stdout, "MethodNotAllowed")
+
+		// The resulting table should include at least a CredentialIssuer.
 		require.Contains(t, stdout, dotSuffix)
 	})
 
-	t.Run("category, table params", func(t *testing.T) {
+	t.Run("can kubectl get each aggregated API as table, and listing these aggregated always results in an empty list", func(t *testing.T) {
 		t.Parallel()
-		stdout, stderr := runTestKubectlCommand(t, "get", "pinniped", "-A", "-o", "wide", "-v", "10")
-		require.NotContains(t, stdout, "MethodNotAllowed")
-		require.Contains(t, stdout, dotSuffix)
-		require.Contains(t, stderr, `"kind":"Table"`)
-		require.Contains(t, stderr, `"resourceVersion":"0"`)
-		require.Contains(t, stderr, `/v1alpha1/tokencredentialrequests`)
-		require.Contains(t, stderr, `/v1alpha1/whoamirequests`)
+
+		for _, tt := range aggregatedAPIResources {
+			t.Run(tt.Resource, func(t *testing.T) {
+				t.Parallel()
+
+				stdout, stderr := runTestKubectlCommand(t, "get", fmt.Sprintf("%s.%s", tt.Resource, tt.Group), "-A")
+				require.Empty(t, stdout)
+
+				require.NotContains(t, stderr, "MethodNotAllowed")
+				require.Contains(t, stderr, `No resources found`)
+			})
+		}
 	})
 
-	t.Run("list, no special params", func(t *testing.T) {
+	t.Run("can kubectl get each aggregated API using raw request, and listing these aggregated always results in an empty list", func(t *testing.T) {
 		t.Parallel()
-		stdout, stderr := runTestKubectlCommand(t, "get", "tokencredentialrequests.login.concierge"+dotSuffix, "-A")
-		require.Empty(t, stdout)
-		require.NotContains(t, stderr, "MethodNotAllowed")
-		require.Contains(t, stderr, `No resources found`)
-	})
 
-	t.Run("list, table params", func(t *testing.T) {
-		t.Parallel()
-		stdout, stderr := runTestKubectlCommand(t, "get", "tokencredentialrequests.login.concierge"+dotSuffix, "-A", "-o", "wide", "-v", "10")
-		require.Empty(t, stdout)
-		require.NotContains(t, stderr, "MethodNotAllowed")
-		require.Contains(t, stderr, `"kind":"Table"`)
-		require.Contains(t, stderr, `"resourceVersion":"0"`)
-	})
+		for _, tt := range aggregatedAPIResources {
+			t.Run(tt.Resource, func(t *testing.T) {
+				t.Parallel()
 
-	t.Run("raw request to see body, token cred", func(t *testing.T) {
-		t.Parallel()
-		stdout, stderr := runTestKubectlCommand(t, "get", "--raw", "/apis/login.concierge"+dotSuffix+"/v1alpha1/tokencredentialrequests")
-		require.NotContains(t, stdout, "MethodNotAllowed")
-		require.Contains(t, stdout, `{"kind":"TokenCredentialRequestList","apiVersion":"login.concierge`+
-			dotSuffix+`/v1alpha1","metadata":{"resourceVersion":"0"},"items":[]}`)
-		requireCleanKubectlStderr(t, stderr)
-	})
+				stdout, stderr := runTestKubectlCommand(t, "get",
+					"--raw", fmt.Sprintf("/apis/%s/%s/%s", tt.Group, tt.Version, tt.Resource))
 
-	t.Run("raw request to see body, whoami", func(t *testing.T) {
-		t.Parallel()
-		stdout, stderr := runTestKubectlCommand(t, "get", "--raw", "/apis/identity.concierge"+dotSuffix+"/v1alpha1/whoamirequests")
-		require.NotContains(t, stdout, "MethodNotAllowed")
-		require.Contains(t, stdout, `{"kind":"WhoAmIRequestList","apiVersion":"identity.concierge`+
-			dotSuffix+`/v1alpha1","metadata":{"resourceVersion":"0"},"items":[]}`)
-		requireCleanKubectlStderr(t, stderr)
+				requireCleanKubectlStderr(t, stderr)
+				require.NotContains(t, stdout, "MethodNotAllowed")
+
+				require.Contains(t, stdout,
+					fmt.Sprintf(`{"kind":"%s","apiVersion":"%s/%s","metadata":{"resourceVersion":"0"},"items":[]}`,
+						tt.ListKind, tt.Group, tt.Version),
+				)
+			})
+		}
 	})
 }


### PR DESCRIPTION
The integration test called `TestGetPinnipedCategory` has been very flaky in CI lately. I reviewed what it tries to cover and rewrote it. Hopefully this will make it less flaky, and hopefully the new implementation is more clear in what it is trying to cover.

Note that which specific custom APIs should be included in the "pinniped" category is already covered by [this other test](https://github.com/vmware-tanzu/pinniped/blob/791b785deab3f1244406ba0f2d61a151122ace67/test/integration/kube_api_discovery_test.go#L377) and so it does not need to be covered by `TestGetPinnipedCategory`.

I retained the parts of the test which show that listing the resources of the aggregated APIs should work and should always return an empty list, but I rewrote that too.

**Release note**:

Test-only changes.

```release-note
NONE
```
