### PR TITLE
update Go toolchain directives to match current version of Go

### DIFF
--- a/generated/1.30/apis/go.mod
+++ b/generated/1.30/apis/go.mod
@@ -3,7 +3,7 @@ module go.pinniped.dev/generated/1.30/apis
 
 go 1.22.0
 
-toolchain go1.22.4
+toolchain go1.22.5
 
 require (
 	k8s.io/api v0.30.2

--- a/generated/1.30/client/go.mod
+++ b/generated/1.30/client/go.mod
@@ -3,7 +3,7 @@ module go.pinniped.dev/generated/1.30/client
 
 go 1.22.0
 
-toolchain go1.22.4
+toolchain go1.22.5
 
 replace go.pinniped.dev/generated/1.30/apis => ../apis
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module go.pinniped.dev
 
 go 1.22.0
 
-toolchain go1.22.4
+toolchain go1.22.5
 
 // This version taken from https://github.com/kubernetes/apiserver/blob/v0.30.0/go.mod#L14 to avoid compile failures.
 replace github.com/google/cel-go => github.com/google/cel-go v0.17.8

--- a/hack/update-go-mod/go.mod
+++ b/hack/update-go-mod/go.mod
@@ -2,6 +2,6 @@ module go.pinniped.dev/update-go-mod
 
 go 1.22.0
 
-toolchain go1.22.2
+toolchain go1.22.5
 
 require golang.org/x/mod v0.18.0


### PR DESCRIPTION
**Release note**:

```release-note
NONE
```
