### PR TITLE
fix authenticators bug: stop allowing usage when validation fails

### DIFF
--- a/internal/controller/authenticator/jwtcachefiller/jwtcachefiller.go
+++ b/internal/controller/authenticator/jwtcachefiller/jwtcachefiller.go
@@ -119,6 +119,9 @@ type cachedJWTAuthenticator struct {
 }
 
 func (c *cachedJWTAuthenticator) Close() {
+	if c == nil {
+		return
+	}
 	c.cancel()
 }
 
@@ -162,12 +165,12 @@ type jwtCacheFillerController struct {
 // Sync implements controllerlib.Syncer.
 func (c *jwtCacheFillerController) Sync(ctx controllerlib.Context) error {
 	obj, err := c.jwtAuthenticators.Lister().Get(ctx.Key.Name)
-
 	if err != nil && apierrors.IsNotFound(err) {
 		c.log.Info("Sync() found that the JWTAuthenticator does not exist yet or was deleted")
 		return nil
 	}
 	if err != nil {
+		// no unit test for this failure
 		return fmt.Errorf("failed to get JWTAuthenticator %s/%s: %w", ctx.Key.Namespace, ctx.Key.Name, err)
 	}
 
@@ -179,33 +182,29 @@ func (c *jwtCacheFillerController) Sync(ctx controllerlib.Context) error {
 
 	// If this authenticator already exists, then only recreate it if is different from the desired
 	// authenticator. We don't want to be creating a new authenticator for every resync period.
-	//
-	// If we do need to recreate the authenticator, then make sure cancel the old one to avoid
-	// goroutine leaks.
-	if value := c.cache.Get(cacheKey); value != nil {
-		jwtAuthenticator := c.extractValueAsJWTAuthenticator(value)
-		if jwtAuthenticator != nil {
-			if reflect.DeepEqual(jwtAuthenticator.spec, &obj.Spec) {
-				c.log.WithValues("jwtAuthenticator", klog.KObj(obj), "issuer", obj.Spec.Issuer).Info("actual jwt authenticator and desired jwt authenticator are the same")
-				return nil
-			}
-			jwtAuthenticator.Close()
+	var jwtAuthenticatorFromCache *cachedJWTAuthenticator
+	if valueFromCache := c.cache.Get(cacheKey); valueFromCache != nil {
+		jwtAuthenticatorFromCache = c.cacheValueAsJWTAuthenticator(valueFromCache)
+		if jwtAuthenticatorFromCache != nil && reflect.DeepEqual(jwtAuthenticatorFromCache.spec, &obj.Spec) {
+			c.log.WithValues("jwtAuthenticator", klog.KObj(obj), "issuer", obj.Spec.Issuer).
+				Info("actual jwt authenticator and desired jwt authenticator are the same")
+			// Stop, no more work to be done. This authenticator is already validated and cached.
+			return nil
 		}
 	}
 
 	conditions := make([]*metav1.Condition, 0)
-	specCopy := obj.Spec.DeepCopy()
 	var errs []error
 
-	rootCAs, conditions, tlsOk := c.validateTLS(specCopy.TLS, conditions)
-	_, conditions, issuerOk := c.validateIssuer(specCopy.Issuer, conditions)
+	rootCAs, conditions, tlsOk := c.validateTLSBundle(obj.Spec.TLS, conditions)
+	_, conditions, issuerOk := c.validateIssuer(obj.Spec.Issuer, conditions)
 	okSoFar := tlsOk && issuerOk
 
 	client := phttp.Default(rootCAs)
 	client.Timeout = 30 * time.Second // copied from Kube OIDC code
 	coreOSCtx := coreosoidc.ClientContext(context.Background(), client)
 
-	pJSON, provider, conditions, providerErr := c.validateProviderDiscovery(coreOSCtx, specCopy.Issuer, conditions, okSoFar)
+	pJSON, provider, conditions, providerErr := c.validateProviderDiscovery(coreOSCtx, obj.Spec.Issuer, conditions, okSoFar)
 	errs = append(errs, providerErr)
 	okSoFar = okSoFar && providerErr == nil
 
@@ -217,20 +216,28 @@ func (c *jwtCacheFillerController) Sync(ctx controllerlib.Context) error {
 	errs = append(errs, jwksFetchErr)
 	okSoFar = okSoFar && jwksFetchErr == nil
 
-	// Make a deep copy of the spec so we aren't storing pointers to something that the informer cache
-	// may mutate! We don't store status as status is derived from spec.
-	cachedAuthenticator, conditions, err := c.newCachedJWTAuthenticator(
+	newJWTAuthenticatorForCache, conditions, err := c.newCachedJWTAuthenticator(
 		client,
-		obj.Spec.DeepCopy(),
+		obj.Spec.DeepCopy(), // deep copy to avoid caching original object
 		keySet,
 		conditions,
 		okSoFar)
 	errs = append(errs, err)
 
-	if !conditionsutil.HadErrorCondition(conditions) {
-		c.cache.Store(cacheKey, cachedAuthenticator)
-		c.log.Info("added new jwt authenticator", "jwtAuthenticator", klog.KObj(obj), "issuer", obj.Spec.Issuer)
+	if conditionsutil.HadErrorCondition(conditions) {
+		// The authenticator was determined to be invalid. Remove it from the cache, in case it was previously
+		// validated and cached. Do not allow an old, previously validated spec of the authenticator to continue
+		// being used for authentication.
+		c.cache.Delete(cacheKey)
+	} else {
+		c.cache.Store(cacheKey, newJWTAuthenticatorForCache)
+		c.log.WithValues("jwtAuthenticator", klog.KObj(obj), "issuer", obj.Spec.Issuer).
+			Info("added new jwt authenticator")
 	}
+
+	// In case we just overwrote or deleted the authenticator from the cache, clean up the old instance
+	// to avoid leaking goroutines. It's safe to call Close() on nil.
+	jwtAuthenticatorFromCache.Close()
 
 	err = c.updateStatus(ctx.Context, obj, conditions)
 	errs = append(errs, err)
@@ -243,7 +250,7 @@ func (c *jwtCacheFillerController) Sync(ctx controllerlib.Context) error {
 	return utilerrors.NewAggregate(errs)
 }
 
-func (c *jwtCacheFillerController) extractValueAsJWTAuthenticator(value authncache.Value) *cachedJWTAuthenticator {
+func (c *jwtCacheFillerController) cacheValueAsJWTAuthenticator(value authncache.Value) *cachedJWTAuthenticator {
 	jwtAuthenticator, ok := value.(*cachedJWTAuthenticator)
 	if !ok {
 		actualType := "<nil>"
@@ -256,7 +263,7 @@ func (c *jwtCacheFillerController) extractValueAsJWTAuthenticator(value authncac
 	return jwtAuthenticator
 }
 
-func (c *jwtCacheFillerController) validateTLS(tlsSpec *authenticationv1alpha1.TLSSpec, conditions []*metav1.Condition) (*x509.CertPool, []*metav1.Condition, bool) {
+func (c *jwtCacheFillerController) validateTLSBundle(tlsSpec *authenticationv1alpha1.TLSSpec, conditions []*metav1.Condition) (*x509.CertPool, []*metav1.Condition, bool) {
 	rootCAs, _, err := pinnipedcontroller.BuildCertPoolAuth(tlsSpec)
 	if err != nil {
 		msg := fmt.Sprintf("%s: %s", "invalid TLS configuration", err.Error())

--- a/internal/controller/authenticator/jwtcachefiller/jwtcachefiller_test.go
+++ b/internal/controller/authenticator/jwtcachefiller/jwtcachefiller_test.go
@@ -998,7 +998,7 @@ func TestController(t *testing.T) {
 			runTestsOnResultingAuthenticator: false, // skip the tests because the authenticator left in the cache is the mock version that was added above
 		},
 		{
-			name: "Sync: JWTAuthenticator update when cached authenticator is different type: loop will complete successfully and update status conditions.",
+			name: "Sync: authenticator update when cached authenticator is the wrong data type, which should never really happen: loop will complete successfully and update status conditions.",
 			cache: func(t *testing.T, cache *authncache.Cache, wantClose bool) {
 				cache.Store(
 					authncache.Key{
@@ -1006,6 +1006,9 @@ func TestController(t *testing.T) {
 						Kind:     "JWTAuthenticator",
 						APIGroup: authenticationv1alpha1.SchemeGroupVersion.Group,
 					},
+					// Only entries of type cachedJWTAuthenticator are ever put into the cache, so this should never really happen.
+					// This test is to provide coverage on the production code which reads from the cache and casts those entries to
+					// the appropriate data type.
 					struct{ authenticator.Token }{},
 				)
 			},

--- a/internal/controller/authenticator/webhookcachefiller/webhookcachefiller.go
+++ b/internal/controller/authenticator/webhookcachefiller/webhookcachefiller.go
@@ -115,8 +115,14 @@ func (c *webhookCacheFillerController) Sync(ctx controllerlib.Context) error {
 		Name:     ctx.Key.Name,
 	}
 
-	// If this authenticator already exists, then only recreate it if is different from the desired
-	// authenticator. We don't want to be creating a new authenticator for every resync period.
+	// Only revalidate and update the cache if the cached authenticator is different from the desired authenticator.
+	// There is no need to repeat validations for a spec that was already successfully validated. We are making a
+	// design decision to avoid repeating the validation which dials the server, even though the server's TLS
+	// configuration could have changed, because it is also possible that the network could be flaky. We are choosing
+	// to prefer to keep the authenticator cached (available for end-user auth attempts) during times of network flakes
+	// rather than trying to show the most up-to-date status possible. These validations are for administrator
+	// convenience at the time of a configuration change, to catch typos and blatant misconfigurations, rather
+	// than to constantly monitor for external issues.
 	if valueFromCache := c.cache.Get(cacheKey); valueFromCache != nil {
 		webhookAuthenticatorFromCache := c.cacheValueAsWebhookAuthenticator(valueFromCache)
 		if webhookAuthenticatorFromCache != nil && reflect.DeepEqual(webhookAuthenticatorFromCache.spec, &obj.Spec) {

--- a/internal/controller/authenticator/webhookcachefiller/webhookcachefiller_test.go
+++ b/internal/controller/authenticator/webhookcachefiller/webhookcachefiller_test.go
@@ -471,7 +471,7 @@ func TestController(t *testing.T) {
 			wantCacheEntries: 1,
 		},
 		{
-			name: "Sync: authenticator update when cached authenticator is different type: loop will complete successfully and update status conditions.",
+			name: "Sync: authenticator update when cached authenticator is the wrong data type, which should never really happen: loop will complete successfully and update status conditions.",
 			cache: func(t *testing.T, cache *authncache.Cache) {
 				cache.Store(
 					authncache.Key{
@@ -479,6 +479,9 @@ func TestController(t *testing.T) {
 						Kind:     "WebhookAuthenticator",
 						APIGroup: authenticationv1alpha1.SchemeGroupVersion.Group,
 					},
+					// Only entries of type cachedWebhookAuthenticator are ever put into the cache, so this should never really happen.
+					// This test is to provide coverage on the production code which reads from the cache and casts those entries to
+					// the appropriate data type.
 					struct{ authenticator.Token }{},
 				)
 			},

--- a/test/integration/concierge_webhookauthenticator_status_test.go
+++ b/test/integration/concierge_webhookauthenticator_status_test.go
@@ -266,12 +266,13 @@ func TestConciergeWebhookAuthenticatorCRDValidations_Parallel(t *testing.T) {
 }
 
 func allSuccessfulWebhookAuthenticatorConditions() []metav1.Condition {
-	return []metav1.Condition{{
-		Type:    "AuthenticatorValid",
-		Status:  "True",
-		Reason:  "Success",
-		Message: "authenticator initialized",
-	},
+	return []metav1.Condition{
+		{
+			Type:    "AuthenticatorValid",
+			Status:  "True",
+			Reason:  "Success",
+			Message: "authenticator initialized",
+		},
 		{
 			Type:    "EndpointURLValid",
 			Status:  "True",


### PR DESCRIPTION
When the spec of a JWTAuthenticator or WebhookAuthenticator changes, and if the resource goes from being valid to being invalid, then that authenticator should not be used anymore. This PR removes it from the in-memory cache so it cannot be used during auth anymore.

This PR also reduces how often the WebhookAuthenticators are revalidated. When the spec has not changed since it was previously validated, then skip performing validations and leave it in the in-memory cache for usage during auth.

These changes also have the side benefit of making the code for controller for WebhookAuthenticators and the controller for JWTAuthenticator more similar/consistent.

**Release note**:

```release-note
WebhookAuthenticators and JWTAuthenticators which were previously validated,
and then become invalid due to a spec change, are not considered usable for
authentication anymore. WebhookAuthenticators that are already validated by
a Concierge pod will not be validated again by that same pod unless the spec
changes or the pod restarts, to reduce the number of TCP dials to the remote
webhook server.
```
