### PR TITLE
changes related to migrating CI code from private repo to `ci` branch

### DIFF
--- a/.github/ISSUE_TEMPLATE/add_new_k8s_version.md
+++ b/.github/ISSUE_TEMPLATE/add_new_k8s_version.md
@@ -1,0 +1,36 @@
+---
+name: Add new K8s version
+about: 'Checklist for maintainers to add new K8s minor version'
+title: 'Add new K8s version vX.X'
+labels: ''
+assignees: ''
+
+---
+
+<!-- Note: Please update the issue title to include the new Kubernetes version number. -->
+
+# Adding a new Kubernetes Version
+
+## `pinniped's ci branch`
+
+- [ ] Update `dockerfile-builders` pipeline
+- [ ] Update `pull-requests` pipeline
+- [ ] Update `main` pipeline
+
+## `pinniped`
+
+- [ ] Bump all golang dependencies (especially the `k8s.io` dependencies to use the new minor version).
+  - [ ] Be sure to verify that everything compiles and unit tests pass locally. This is probably a good starting point.
+```shell
+./hack/update-go-mod/update-go-mod.sh
+./hack/module.sh unit
+./hack/prepare-for-integration-tests.sh
+```
+- [ ] Log in to github as pinniped-ci-bot, then go to [this page](https://github.com/pinniped-ci-bot?tab=packages) and change the settings for the new `k8s-code-generator-1.*` image to be publicly visible
+- [ ] Add the new K8s version to `hack/lib/kube-versions.txt` and run code generation.
+
+## General Tasks
+
+- [ ] Consider dropping support for any older versions of Kubernetes
+- [ ] Create stories or chores to take advantage of features in the new Kubernetes version
+- [ ] Close this issue

--- a/.github/ISSUE_TEMPLATE/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist.md
@@ -1,0 +1,30 @@
+---
+name: Release checklist
+about: Checklist for maintainers to prepare for an upcoming release
+title: 'Release checklist for vX.X.X'
+labels: ''
+assignees: ''
+
+---
+
+<!-- Note: Please update the issue title to include the planned release's version number. -->
+
+# Release checklist
+
+- [ ] Ensure that Pinniped's dependencies have been upgraded, to the extent desired by the team (refer to the diff output from the latest run of the [all-golang-deps-updated](https://ci.pinniped.dev/teams/main/pipelines/security-scan/jobs/all-golang-deps-updated/) CI job)
+  - [ ] If you are updating golang in Pinniped, be sure to update golang in CI as well.  Do a search-and-replace to update the version number everywhere in the pinniped `ci` branch.
+  - [ ] If the Fosite library is being updated and the format of the content of the Supervisor's storage Secrets are changed, or if any change to our own code changes the format of the content of the Supervisor's session storage Secrets, then be sure to update the `accessTokenStorageVersion`, `authorizeCodeStorageVersion`, `oidcStorageVersion`, `pkceStorageVersion`, `refreshTokenStorageVersion`, variables in files such as `internal/fositestorage/accesstoken/accesstoken.go`.  Failing tests should signal the need to update these values.
+  - [ ] For go.mod direct dependencies that are v2 or above, such as `github.com/google/go-github/vXX`, check to see if there is a new major version available.
+- [ ] Ensure that Pinniped's codegen is up-to-date with the latest Kubernetes releases by making sure this [file](https://github.com/vmware-tanzu/pinniped/blob/main/hack/lib/kube-versions.txt) is updated compared to the latest releases listed [here for active branches](https://kubernetes.io/releases/) and [here for non-active branches](https://kubernetes.io/releases/patch-releases/#non-active-branch-history)
+- [ ] Ensure that the `k8s-code-generator` CI job definitions are up-to-date with the latest Go, K8s, and `controller-gen` versions
+- [ ] All relevant feature and docs PRs are merged
+- [ ] The [main pipeline](https://ci.pinniped.dev/teams/main/pipelines/main) is green, up to and including the `ready-to-release` job. Check that the expected git commit has passed the `ready-to-release` job.
+- [ ] Optional: a blog post for the release is written and submitted as a PR but not merged yet
+- [ ] All merged user stories are accepted (manually tested)
+- [ ] Only after all stories are accepted, manually trigger the `release` job to create a draft GitHub release
+- [ ] Manually edit the draft release notes on the [GitHub release](https://github.com/vmware-tanzu/pinniped/releases) to describe the contents of the release, using the format which was automatically added to the draft release
+- [ ] Publish (i.e. make public) the draft release
+- [ ] After making the release public, the jobs in the [main pipeline](https://ci.pinniped.dev/teams/main/pipelines/main) beyond the release job should auto-trigger, so check to make sure that they passed
+- [ ] Edit the blog post's date to make it match the actual release date, and merge the blog post PR to make it live on the website
+- [ ] Publicize the release via tweets, etc.
+- [ ] Close this issue

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,3 +40,106 @@ updates:
 #    directory: "/hack"  # this should keep the FIPS dockerfile updated per https://github.com/dependabot/feedback/issues/145#issuecomment-414738498
 #    schedule:
 #      interval: "daily"
+
+  - package-ecosystem: "docker"
+    directory: "/dockerfiles/code-coverage-uploader/"
+    open-pull-requests-limit: 100
+    schedule:
+      interval: "daily"
+    target-branch: ci
+  - package-ecosystem: "docker"
+    directory: "/dockerfiles/crane/"
+    open-pull-requests-limit: 100
+    schedule:
+      interval: "daily"
+    target-branch: ci
+  - package-ecosystem: "docker"
+    directory: "/dockerfiles/deployment-yaml-formatter/"
+    open-pull-requests-limit: 100
+    schedule:
+      interval: "daily"
+    target-branch: ci
+  - package-ecosystem: "docker"
+    directory: "/dockerfiles/eks-deployer/"
+    open-pull-requests-limit: 100
+    schedule:
+      interval: "daily"
+    target-branch: ci
+  - package-ecosystem: "docker"
+    directory: "/dockerfiles/gh-cli/"
+    open-pull-requests-limit: 100
+    schedule:
+      interval: "daily"
+    target-branch: ci
+  - package-ecosystem: "docker"
+    directory: "/dockerfiles/go-lint-runner/"
+    open-pull-requests-limit: 100
+    schedule:
+      interval: "daily"
+    target-branch: ci
+  - package-ecosystem: "docker"
+    directory: "/dockerfiles/integration-test-runner/"
+    open-pull-requests-limit: 100
+    schedule:
+      interval: "daily"
+    target-branch: ci
+  - package-ecosystem: "docker"
+    directory: "/dockerfiles/integration-test-runner-beta/"
+    open-pull-requests-limit: 100
+    schedule:
+      interval: "daily"
+    target-branch: ci
+  - package-ecosystem: "docker"
+    directory: "/dockerfiles/k8s-app-deployer/"
+    open-pull-requests-limit: 100
+    schedule:
+      interval: "daily"
+    target-branch: ci
+  - package-ecosystem: "docker"
+    directory: "/dockerfiles/k8s-code-generator/"
+    open-pull-requests-limit: 100
+    schedule:
+      interval: "daily"
+    target-branch: ci
+  - package-ecosystem: "docker"
+    directory: "/dockerfiles/pool-trigger-resource/"
+    open-pull-requests-limit: 100
+    schedule:
+      interval: "daily"
+    target-branch: ci
+  - package-ecosystem: "docker"
+    directory: "/dockerfiles/test-bitnami-ldap/"
+    open-pull-requests-limit: 100
+    schedule:
+      interval: "daily"
+    target-branch: ci
+  - package-ecosystem: "docker"
+    directory: "/dockerfiles/test-cfssl/"
+    open-pull-requests-limit: 100
+    schedule:
+      interval: "daily"
+    target-branch: ci
+  - package-ecosystem: "docker"
+    directory: "/dockerfiles/test-dex/"
+    open-pull-requests-limit: 100
+    schedule:
+      interval: "daily"
+    target-branch: ci
+  - package-ecosystem: "docker"
+    directory: "/dockerfiles/test-forward-proxy/"
+    open-pull-requests-limit: 100
+    schedule:
+      interval: "daily"
+    target-branch: ci
+  - package-ecosystem: "docker"
+    directory: "/dockerfiles/test-kubectl/"
+    open-pull-requests-limit: 100
+    schedule:
+      interval: "daily"
+    target-branch: ci
+  - package-ecosystem: "docker"
+    directory: "/pipelines/shared-helpers/test-binaries-image/"
+    open-pull-requests-limit: 100
+    schedule:
+      interval: "daily"
+    target-branch: ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,6 +184,11 @@ the progress and results will appear on the Github page for that
 [pull request](https://github.com/vmware-tanzu/pinniped/pulls) as checks. Links
 will appear to view the details of each check.
 
+## CI
+
+Pinniped's CI configuration and code is in the [`ci`](https://github.com/vmware-tanzu/pinniped/tree/ci)
+branch of this repo. The CI results are visible to the public at https://ci.pinniped.dev.
+
 ## Documentation
 
 Any pull request which adds a new feature or changes the behavior of any feature which was previously documented


### PR DESCRIPTION
- Add issue templates that previously lived in private CI repo
- Add Dependabot config for Dockerfiles that previously lived in private CI repo
- Add references to `ci` branch in CONTRIBUTING.md to help people find the now-public CI code

**Release note**:

```release-note
NONE
```
