### PR TITLE
add SAN to default cert in supervisor_discovery_test.go

### DIFF
--- a/test/testlib/env.go
+++ b/test/testlib/env.go
@@ -85,7 +85,7 @@ type TestOIDCUpstream struct {
 }
 
 // InferSupervisorIssuerURL infers the downstream issuer URL from the callback associated with the upstream test client registration.
-func (e *TestEnv) InferSupervisorIssuerURL(t *testing.T) SupervisorIssuer {
+func (e *TestEnv) InferSupervisorIssuerURL(t *testing.T) *SupervisorIssuer {
 	t.Helper()
 	supervisorIssuer := NewSupervisorIssuer(t, e.SupervisorUpstreamOIDC.CallbackURL)
 	require.True(t, strings.HasSuffix(supervisorIssuer.issuerURL.Path, "/callback"))

--- a/test/testlib/supervisor_issuer_test.go
+++ b/test/testlib/supervisor_issuer_test.go
@@ -12,41 +12,43 @@ import (
 
 func TestSupervisorIssuer(t *testing.T) {
 	tests := []struct {
-		name            string
-		issuer          string
-		wantHostname    string
+		name             string
+		issuer           string
+		alternativeNames []string
+
+		wantHostnames   []string
 		wantAddress     string
 		wantIP          net.IP
 		wantIsIPAddress bool
 	}{
 		{
-			name:         "works for localhost",
-			issuer:       "https://localhost:443",
-			wantHostname: "localhost",
-			wantAddress:  "localhost:443",
+			name:          "works for localhost",
+			issuer:        "https://localhost:443",
+			wantHostnames: []string{"localhost"},
+			wantAddress:   "localhost:443",
 		},
 		{
-			name:         "works for localhost with path",
-			issuer:       "https://localhost:443/some/path",
-			wantHostname: "localhost",
-			wantAddress:  "localhost:443",
+			name:          "works for localhost with path",
+			issuer:        "https://localhost:443/some/path",
+			wantHostnames: []string{"localhost"},
+			wantAddress:   "localhost:443",
 		},
 		{
-			name:         "works for domain",
-			issuer:       "https://example.com:443",
-			wantHostname: "example.com",
-			wantAddress:  "example.com:443",
+			name:          "works for domain",
+			issuer:        "https://example.com:443",
+			wantHostnames: []string{"example.com"},
+			wantAddress:   "example.com:443",
 		},
 		{
-			name:         "works for domain with path",
-			issuer:       "https://example.com:443/some/path",
-			wantHostname: "example.com",
-			wantAddress:  "example.com:443",
+			name:          "works for domain with path",
+			issuer:        "https://example.com:443/some/path",
+			wantHostnames: []string{"example.com"},
+			wantAddress:   "example.com:443",
 		},
 		{
 			name:            "works for IPv4",
 			issuer:          "https://1.2.3.4:443",
-			wantHostname:    "", // don't want DNS records in the cert when using IP address
+			wantHostnames:   nil, // don't want DNS records in the cert when using IP address without SANs
 			wantAddress:     "1.2.3.4:443",
 			wantIP:          net.ParseIP("1.2.3.4"),
 			wantIsIPAddress: true,
@@ -54,27 +56,53 @@ func TestSupervisorIssuer(t *testing.T) {
 		{
 			name:            "works for IPv4 with path",
 			issuer:          "https://1.2.3.4:443/some/path",
-			wantHostname:    "", // don't want DNS records in the cert when using IP address
+			wantHostnames:   nil, // don't want DNS records in the cert when using IP address without SANs
 			wantAddress:     "1.2.3.4:443",
 			wantIP:          net.ParseIP("1.2.3.4"),
 			wantIsIPAddress: true,
+		},
+		{
+			name:             "works with one SAN",
+			issuer:           "https://example.com:443",
+			alternativeNames: []string{"alt.example.com"},
+			wantHostnames:    []string{"example.com", "alt.example.com"},
+			wantAddress:      "example.com:443",
+		},
+		{
+			name:             "works with two SANs",
+			issuer:           "https://example.com:443",
+			alternativeNames: []string{"alt1.example.com", "alt2.example.com"},
+			wantHostnames:    []string{"example.com", "alt1.example.com", "alt2.example.com"},
+			wantAddress:      "example.com:443",
+		},
+		{
+			name:             "IP works with SANs",
+			issuer:           "https://1.2.3.4:443",
+			alternativeNames: []string{"alt1.example.com", "alt2.example.com"},
+			wantHostnames:    []string{"alt1.example.com", "alt2.example.com"},
+			wantAddress:      "1.2.3.4:443",
+			wantIP:           net.ParseIP("1.2.3.4"),
+			wantIsIPAddress:  true,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			supervisorIssuer := NewSupervisorIssuer(t, test.issuer)
+			for _, n := range test.alternativeNames {
+				supervisorIssuer.AddAlternativeName(n)
+			}
 			require.Equal(t, test.issuer, supervisorIssuer.Issuer())
 			require.Equal(t, test.wantAddress, supervisorIssuer.Address())
-			if test.wantHostname != "" {
-				require.Equal(t, []string{test.wantHostname}, supervisorIssuer.Hostnames())
+			if test.wantHostnames != nil {
+				require.Equal(t, test.wantHostnames, supervisorIssuer.hostnamesForCert())
 			} else {
-				require.Nil(t, supervisorIssuer.Hostnames())
+				require.Nil(t, supervisorIssuer.hostnamesForCert())
 			}
 			if test.wantIP != nil {
-				require.Equal(t, []net.IP{test.wantIP}, supervisorIssuer.IPs())
+				require.Equal(t, []net.IP{test.wantIP}, supervisorIssuer.ipsForCert())
 			} else {
-				require.Nil(t, supervisorIssuer.IPs())
+				require.Nil(t, supervisorIssuer.ipsForCert())
 			}
 			require.Equal(t, test.wantIsIPAddress, supervisorIssuer.IsIPAddress())
 		})


### PR DESCRIPTION
Attempting to help with this test flake seen often in CI:

```
=== RUN   TestIntegrationDisruptive/TestSupervisorOIDCDiscovery_Disruptive/ingress_https
    supervisor_discovery_test.go:90: created test OIDCIdentityProvider test-upstream-oidc-idp-4mqvq
    supervisor_discovery_test.go:96: failed to complete even after 2m0s (601 attempts): context deadline exceeded
    supervisor_discovery_test.go:96: 
        	Error Trace:	/work/test/integration/supervisor_discovery_test.go:513
        	            				/work/test/testlib/assertions.go:102
        	            				/cache/gomodcache/k8s.io/apimachinery@v0.31.2/pkg/util/wait/loop.go:87
        	            				/cache/gomodcache/k8s.io/apimachinery@v0.31.2/pkg/util/wait/loop.go:88
        	            				/cache/gomodcache/k8s.io/apimachinery@v0.31.2/pkg/util/wait/poll.go:48
        	            				/work/test/testlib/assertions.go:90
        	            				/work/test/integration/supervisor_discovery_test.go:501
        	            				/work/test/integration/supervisor_discovery_test.go:493
        	            				/work/test/integration/supervisor_discovery_test.go:96
        	Error:      	Not equal: 
        	            	expected: 404
        	            	actual  : 502
```

E.g. seen here:: https://ci.pinniped.dev/teams/main/pipelines/main/jobs/deploy-and-test-acceptance-gke/builds/33#L672346c5:173:188

**Release note**:

```release-note
NONE
```
