### PR TITLE
temporarily avoid upgrades to kube v0.32.0 without replace directives for direct reps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG BUILD_IMAGE=golang:1.23.4@sha256:574185e5c6b9d09873f455a7c205ea0514bfd99738c5dc7750196403a44ed4b7
+ARG BUILD_IMAGE=golang:1.23.4@sha256:70031844b8c225351d0bb63e2c383f80db85d92ba894e3da7e13bcf80efa9a37
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:6cd937e9155bdfd805d1b94e037f9d6a899603306030936a3b11680af0c2ed58
 
 # Prepare to cross-compile by always running the build stage in the build platform, not the target platform.

--- a/go.mod
+++ b/go.mod
@@ -4,23 +4,13 @@ go 1.23.0
 
 toolchain go1.23.4
 
-replace (
-	k8s.io/api => k8s.io/api v0.31.4
-	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.31.4
-	k8s.io/apimachinery => k8s.io/apimachinery v0.31.4
-	k8s.io/apiserver => k8s.io/apiserver v0.31.4
-	k8s.io/client-go => k8s.io/client-go v0.31.4
-	k8s.io/component-base => k8s.io/component-base v0.31.4
-	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.31.4
-	// see https://github.com/kubernetes/apiserver/blob/v0.31.4/go.mod#L54
-	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340
-	// see https://github.com/kubernetes/apimachinery/blob/v0.31.4/go.mod#L30
-	sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.4.1
-)
+// When using v0.31.4, need to use this version of structured-merge-diff.
+// See https://github.com/kubernetes/apimachinery/blob/v0.31.4/go.mod#L30
+replace sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.4.1
 
 require (
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
-	github.com/chromedp/cdproto v0.0.0-20241208230723-d1c7de7e5dd2
+	github.com/chromedp/cdproto v0.0.0-20241222144035-c16d098c0fb6
 	github.com/chromedp/chromedp v0.11.2
 	github.com/coreos/go-oidc/v3 v3.11.0
 	github.com/coreos/go-semver v0.3.1
@@ -60,16 +50,16 @@ require (
 	golang.org/x/sync v0.10.0
 	golang.org/x/term v0.27.0
 	golang.org/x/text v0.21.0
-	k8s.io/api v0.32.0
-	k8s.io/apiextensions-apiserver v0.32.0
-	k8s.io/apimachinery v0.32.0
-	k8s.io/apiserver v0.32.0
-	k8s.io/client-go v0.32.0
-	k8s.io/component-base v0.32.0
+	k8s.io/api v0.31.4
+	k8s.io/apiextensions-apiserver v0.31.4
+	k8s.io/apimachinery v0.31.4
+	k8s.io/apiserver v0.31.4
+	k8s.io/client-go v0.31.4
+	k8s.io/component-base v0.31.4
 	k8s.io/gengo v0.0.0-20240911193312-2b36238f13e9
 	k8s.io/klog/v2 v2.130.1
-	k8s.io/kube-aggregator v0.32.0
-	k8s.io/kube-openapi v0.0.0-20241212222426-2c72e554b1e7
+	k8s.io/kube-aggregator v0.31.4
+	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340
 	k8s.io/utils v0.0.0-20241210054802-24370beab758
 	sigs.k8s.io/yaml v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyY
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chromedp/cdproto v0.0.0-20241208230723-d1c7de7e5dd2 h1:fJob5N/Eprtd427U84kFpQhAHIEqJYuDzveaL6T4Xsk=
-github.com/chromedp/cdproto v0.0.0-20241208230723-d1c7de7e5dd2/go.mod h1:4XqMl3iIW08jtieURWL6Tt5924w21pxirC6th662XUM=
+github.com/chromedp/cdproto v0.0.0-20241222144035-c16d098c0fb6 h1:dAUcp/W5RpJSZW/HksEHfAAoMBIvSFFIwslAFEte+6g=
+github.com/chromedp/cdproto v0.0.0-20241222144035-c16d098c0fb6/go.mod h1:4XqMl3iIW08jtieURWL6Tt5924w21pxirC6th662XUM=
 github.com/chromedp/chromedp v0.11.2 h1:ZRHTh7DjbNTlfIv3NFTbB7eVeu5XCNkgrpcGSpn2oX0=
 github.com/chromedp/chromedp v0.11.2/go.mod h1:lr8dFRLKsdTTWb75C/Ttol2vnBKOSnt0BW8R9Xaupi8=
 github.com/chromedp/sysutil v1.1.0 h1:PUFNv5EcprjqXZD9nJb9b/c9ibAbxiYo4exNWZyipwM=

--- a/hack/Dockerfile_fips
+++ b/hack/Dockerfile_fips
@@ -16,7 +16,7 @@
 # See https://go.googlesource.com/go/+/dev.boringcrypto/README.boringcrypto.md
 # and https://kupczynski.info/posts/fips-golang/ for details.
 
-ARG BUILD_IMAGE=golang:1.23.4@sha256:574185e5c6b9d09873f455a7c205ea0514bfd99738c5dc7750196403a44ed4b7
+ARG BUILD_IMAGE=golang:1.23.4@sha256:70031844b8c225351d0bb63e2c383f80db85d92ba894e3da7e13bcf80efa9a37
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:6cd937e9155bdfd805d1b94e037f9d6a899603306030936a3b11680af0c2ed58
 
 # This is not currently using --platform to prepare to cross-compile because we use gcc below to build

--- a/hack/update-go-mod/overrides.conf
+++ b/hack/update-go-mod/overrides.conf
@@ -3,3 +3,17 @@
 
 # Fosite has not had a release for a long time, so use the head of their main branch.
 github.com/ory/fosite github.com/ory/fosite@master
+
+# Temporarily prevent upgrading the Kube packages due to a bug in v0.32.0 which
+# causes the race detector to fail our unit tests. We hope to remove these
+# version locks as soon as possible.
+k8s.io/api k8s.io/api@v0.31.4
+k8s.io/apiextensions-apiserver k8s.io/apiextensions-apiserver@v0.31.4
+k8s.io/apimachinery k8s.io/apimachinery@v0.31.4
+k8s.io/apiserver k8s.io/apiserver@v0.31.4
+k8s.io/client-go k8s.io/client-go@v0.31.4
+k8s.io/component-base k8s.io/component-base@v0.31.4
+k8s.io/kube-aggregator k8s.io/kube-aggregator@v0.31.4
+# When using v0.31.4, need to use this version of kube-openapi.
+# See https://github.com/kubernetes/apiserver/blob/v0.31.4/go.mod#L54
+k8s.io/kube-openapi k8s.io/kube-openapi@v0.0.0-20240228011516-70dd3763d340


### PR DESCRIPTION
Replaces https://github.com/vmware-tanzu/pinniped/pull/2165. This PR tries to avoid the problems described by my comments in https://github.com/vmware-tanzu/pinniped/pull/2165. In this PR, I lock the version of the Kubernetes packages by using an override config for our dependency-bumping automation, instead of using `replace` directives for our direct dependencies.

This PR also bumps build image to latest in Dockerfiles, and bumps the version of `github.com/chromedp/cdproto` because there are new versions available for those.

**Release note**:

```release-note
NONE
```
