### PR TITLE
change `remoteAddr` to `sourceIPs` in Supervisor audit log for incoming http requests

### DIFF
--- a/site/content/docs/reference/audit-logging.md
+++ b/site/content/docs/reference/audit-logging.md
@@ -98,6 +98,12 @@ correlate an audit event log line to other logs. The values for these keys are o
 
 Each audit event may also have more key-value pairs specific to the event's type.
 
+- Some audit logs for the Supervisor contain a `sourceIPs` key.
+  The value at this key is calculated using the same method as the `sourceIPs`
+  field in the Kubernetes audit logs. See the definition of the `sourceIPs` field in
+  [the Kubernetes auditing documentation](https://kubernetes.io/docs/reference/config-api/apiserver-audit.v1/)
+  for details.
+
 ## Configuration options for audit events
 
 Logging of audit events is always enabled. There are two configuration options available:
@@ -176,7 +182,7 @@ The logs from the authorize endpoint are shown below.
   "serverName": "example-supervisor.pinniped.dev",
   "path": "/oauth2/authorize",
   "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.1.1 Safari/605.1.15",
-  "remoteAddr": "1.2.3.4:58586"
+  "sourceIPs": [ "1.2.3.4:58586" ]
 }
 {
   "level": "info",
@@ -258,7 +264,7 @@ with the logs from this callback request, shown below.
   "serverName": "example-supervisor.pinniped.dev",
   "path": "/callback",
   "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.1.1 Safari/605.1.15",
-  "remoteAddr": "1.2.3.4:58586"
+  "sourceIPs": [ "1.2.3.4:58586" ]
 }
 {
   "level": "info",
@@ -354,7 +360,7 @@ The logs from the token endpoint are shown below.
   "serverName": "example-supervisor.pinniped.dev",
   "path": "/oauth2/token",
   "userAgent": "pinniped/v0.0.0 (darwin/arm64) kubernetes/$Format",
-  "remoteAddr": "1.2.3.4:59420"
+  "sourceIPs": [ "1.2.3.4:59420" ]
 }
 {
   "level": "info",
@@ -423,7 +429,7 @@ for the target workload cluster (technically, an ID token with a different `aud`
   "serverName": "example-supervisor.pinniped.dev",
   "path": "/oauth2/token",
   "userAgent": "pinniped/v0.0.0 (darwin/arm64) kubernetes/$Format",
-  "remoteAddr": "1.2.3.4:59420"
+  "sourceIPs": [ "1.2.3.4:59420" ]
 }
 {
   "level": "info",

--- a/test/integration/audit_test.go
+++ b/test/integration/audit_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 the Pinniped contributors. All Rights Reserved.
+// Copyright 2024-2025 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package integration
@@ -702,7 +702,7 @@ func removeSomeKeysFromEachAuditLogEvent(logs []map[string]any) {
 		delete(log, "level")
 		delete(log, "auditEvent")
 		delete(log, "caller")
-		delete(log, "remoteAddr")
+		delete(log, "sourceIPs")
 		delete(log, "userAgent")
 		delete(log, "timestamp")
 		delete(log, "latency")


### PR DESCRIPTION
Previously the Supervisor audit logs logged the `http.Request`'s `remoteAddr` value for all incoming http requests. However, this does not propagate the values of the `X-Forwarded-For` or `X-Real-Ip` headers into the audit logs. This would lose some valuable information in the case where a proxy server is placed in front of the Supervisor.

This PR removes the `remoteAddr` field from the Supervisor's `HTTP Request Received` audit log events, and replaces it with a new `sourceIPs` field. The value of this field is filled using the same code that fills the `sourceIPs` field in the Kubernetes audit logs, so it will have the exact same behavior. The `sourceIPs` value will always be an array of strings, and each string will be an IP address. The request's `remoteAddr` will always be the last value in the list. Other values included in the list will be the IP addresses taken from the request's `X-Forwarded-For` and/or `X-Real-Ip` headers.

This is a breaking change for anyone who has built custom tooling to parse the Supervisor's audit logs. Please note the change in the field name, and note that the new `sourceIPs` field's value will always be an array of IP addresses instead of a single IP address. Since we just recently released the audit logging feature, hopefully this does not actually break anyone.

Here is a real example from a Supervisor log after running the following command:

```shell
curl \
  --cacert root_ca.crt  \
  "https://pinniped-supervisor-clusterip.supervisor.svc.cluster.local/some/path/.well-known/openid-configuration" \
  -H "X-Forwarded-For: 1.2.3.4, 5.6.7.8"
```

Log output includes the `X-Forwarded-For` values followed by the `remoteAddr` value:

```json
{
  "level": "info",
  "timestamp": "2025-01-06T20:04:31.649240Z",
  "caller": "go.pinniped.dev/internal/federationdomain/requestlogger/request_logger.go:84$requestlogger.(*requestLogger).logRequestReceived",
  "message": "HTTP Request Received",
  "auditEvent": true,
  "auditID": "183bd147-0448-49dc-b042-1d6f706f4c76",
  "proto": "HTTP/2.0",
  "method": "GET",
  "host": "pinniped-supervisor-clusterip.supervisor.svc.cluster.local",
  "serverName": "pinniped-supervisor-clusterip.supervisor.svc.cluster.local",
  "path": "/some/path/.well-known/openid-configuration",
  "userAgent": "curl/8.7.1",
  "sourceIPs": [
    "1.2.3.4",
    "5.6.7.8",
    "10.244.0.17"
  ]
}
```

**Release note**:

```release-note
The `remoteAddr` key in the Supervisor's `HTTP Request Received` audit log event has been removed
and replaced with a new key called `sourceIPs`. The value of `sourceIPs` is always an array of string
IP addresses, and the last item in the list is always the address that was previously shown as the
`remoteAddr`. Other items in the list can come from the `X-Forwarded-For` and `X-Real-Ip` request
headers. See `sourceIPs` in https://kubernetes.io/docs/reference/config-api/apiserver-audit.v1
for details.
```
