### PR TITLE
"pinniped get kubeconfig" discovers CA bundle from JWTAuthenticator's spec.TLS.CertificateAuthorityDataSource

### DIFF
--- a/cmd/pinniped/cmd/kube_util.go
+++ b/cmd/pinniped/cmd/kube_util.go
@@ -1,34 +1,36 @@
-// Copyright 2021 the Pinniped contributors. All Rights Reserved.
+// Copyright 2021-2025 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package cmd
 
 import (
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+	aggregatorclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 
 	conciergeclientset "go.pinniped.dev/generated/latest/client/concierge/clientset/versioned"
 	"go.pinniped.dev/internal/groupsuffix"
 	"go.pinniped.dev/internal/kubeclient"
 )
 
-// getConciergeClientsetFunc is a function that can return a clientset for the Concierge API given a
+// getClientsetsFunc is a function that can return clients for the Concierge and Kubernetes APIs given a
 // clientConfig and the apiGroupSuffix with which the API is running.
-type getConciergeClientsetFunc func(clientConfig clientcmd.ClientConfig, apiGroupSuffix string) (conciergeclientset.Interface, error)
+type getClientsetsFunc func(clientConfig clientcmd.ClientConfig, apiGroupSuffix string) (conciergeclientset.Interface, kubernetes.Interface, aggregatorclient.Interface, error)
 
-// getRealConciergeClientset returns a real implementation of a conciergeclientset.Interface.
-func getRealConciergeClientset(clientConfig clientcmd.ClientConfig, apiGroupSuffix string) (conciergeclientset.Interface, error) {
+// getRealClientsets returns real implementations of the Concierge and Kubernetes client interfaces.
+func getRealClientsets(clientConfig clientcmd.ClientConfig, apiGroupSuffix string) (conciergeclientset.Interface, kubernetes.Interface, aggregatorclient.Interface, error) {
 	restConfig, err := clientConfig.ClientConfig()
 	if err != nil {
-		return nil, err
+		return nil, nil, nil, err
 	}
 	client, err := kubeclient.New(
 		kubeclient.WithConfig(restConfig),
 		kubeclient.WithMiddleware(groupsuffix.New(apiGroupSuffix)),
 	)
 	if err != nil {
-		return nil, err
+		return nil, nil, nil, err
 	}
-	return client.PinnipedConcierge, nil
+	return client.PinnipedConcierge, client.Kubernetes, client.Aggregation, nil
 }
 
 // newClientConfig returns a clientcmd.ClientConfig given an optional kubeconfig path override and

--- a/cmd/pinniped/cmd/whoami.go
+++ b/cmd/pinniped/cmd/whoami.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2024 the Pinniped contributors. All Rights Reserved.
+// Copyright 2021-2025 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package cmd
@@ -25,14 +25,14 @@ import (
 )
 
 type whoamiDeps struct {
-	getenv       func(key string) string
-	getClientset getConciergeClientsetFunc
+	getenv        func(key string) string
+	getClientsets getClientsetsFunc
 }
 
 func whoamiRealDeps() whoamiDeps {
 	return whoamiDeps{
-		getenv:       os.Getenv,
-		getClientset: getRealConciergeClientset,
+		getenv:        os.Getenv,
+		getClientsets: getRealClientsets,
 	}
 }
 
@@ -82,7 +82,7 @@ func newWhoamiCommand(deps whoamiDeps) *cobra.Command {
 
 func runWhoami(output io.Writer, deps whoamiDeps, flags *whoamiFlags) error {
 	clientConfig := newClientConfig(flags.kubeconfigPath, flags.kubeconfigContextOverride)
-	clientset, err := deps.getClientset(clientConfig, flags.apiGroupSuffix)
+	conciergeClient, _, _, err := deps.getClientsets(clientConfig, flags.apiGroupSuffix)
 	if err != nil {
 		return fmt.Errorf("could not configure Kubernetes client: %w", err)
 	}
@@ -108,7 +108,7 @@ func runWhoami(output io.Writer, deps whoamiDeps, flags *whoamiFlags) error {
 		defer cancelFunc()
 	}
 
-	whoAmI, err := clientset.IdentityV1alpha1().WhoAmIRequests().Create(ctx, &identityv1alpha1.WhoAmIRequest{}, metav1.CreateOptions{})
+	whoAmI, err := conciergeClient.IdentityV1alpha1().WhoAmIRequests().Create(ctx, &identityv1alpha1.WhoAmIRequest{}, metav1.CreateOptions{})
 	if err != nil {
 		hint := ""
 		if apierrors.IsNotFound(err) {

--- a/hack/install-linter.sh
+++ b/hack/install-linter.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2022-2024 the Pinniped contributors. All Rights Reserved.
+# Copyright 2022-2025 the Pinniped contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -13,7 +13,11 @@ go version
 
 lint_version="v$(cat hack/lib/lint-version.txt)"
 
-echo "Installing golangci-lint@${lint_version}"
+# Find the toolchain version from our go.mod file. "go install" pays attention to $GOTOOLCHAIN.
+GOTOOLCHAIN=$(sed -rn 's/^toolchain (go[0-9\.]+)$/\1/p' go.mod)
+export GOTOOLCHAIN
+
+echo "Installing golangci-lint@${lint_version} using toolchain ${GOTOOLCHAIN}"
 
 # Install the same version of the linter that the pipelines will use
 # so you can get the same results when running the linter locally.

--- a/test/integration/e2e_test.go
+++ b/test/integration/e2e_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2025 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 package integration
 
@@ -174,7 +174,6 @@ func TestE2EFullIntegration_Browser(t *testing.T) {
 			"--concierge-authenticator-type", "jwt",
 			"--concierge-authenticator-name", authenticator.Name,
 			"--oidc-skip-browser",
-			"--oidc-ca-bundle", federationDomainCABundlePath,
 			"--oidc-session-cache", sessionCachePath,
 			"--credential-cache", credentialCachePath,
 			// use default for --oidc-scopes, which is to request all relevant scopes
@@ -276,7 +275,6 @@ func TestE2EFullIntegration_Browser(t *testing.T) {
 			"--concierge-authenticator-type", "jwt",
 			"--concierge-authenticator-name", authenticator.Name,
 			"--oidc-skip-browser",
-			"--oidc-ca-bundle", federationDomainCABundlePath,
 			"--oidc-session-cache", sessionCachePath,
 			"--credential-cache", credentialCachePath,
 			"--oidc-scopes", "offline_access,openid,pinniped:request-audience", // does not request username or groups
@@ -379,7 +377,6 @@ func TestE2EFullIntegration_Browser(t *testing.T) {
 			"--concierge-authenticator-name", authenticator.Name,
 			"--oidc-skip-browser",
 			"--oidc-skip-listen",
-			"--oidc-ca-bundle", federationDomainCABundlePath,
 			"--oidc-session-cache", sessionCachePath,
 			"--credential-cache", credentialCachePath,
 			// use default for --oidc-scopes, which is to request all relevant scopes
@@ -517,7 +514,6 @@ func TestE2EFullIntegration_Browser(t *testing.T) {
 			"--concierge-authenticator-name", authenticator.Name,
 			"--oidc-skip-browser",
 			"--oidc-skip-listen",
-			"--oidc-ca-bundle", federationDomainCABundlePath,
 			"--oidc-session-cache", sessionCachePath,
 			"--credential-cache", credentialCachePath,
 			// use default for --oidc-scopes, which is to request all relevant scopes
@@ -651,7 +647,6 @@ func TestE2EFullIntegration_Browser(t *testing.T) {
 			"--oidc-skip-browser",
 			"--oidc-skip-listen",
 			"--upstream-identity-provider-flow", "cli_password", // create a kubeconfig configured to use the cli_password flow
-			"--oidc-ca-bundle", federationDomainCABundlePath,
 			"--oidc-session-cache", sessionCachePath,
 			"--credential-cache", credentialCachePath,
 			// use default for --oidc-scopes, which is to request all relevant scopes
@@ -731,7 +726,6 @@ func TestE2EFullIntegration_Browser(t *testing.T) {
 			"--upstream-identity-provider-name", oidcIdentityProvider.Name,
 			"--upstream-identity-provider-type", "oidc",
 			"--upstream-identity-provider-flow", "cli_password",
-			"--oidc-ca-bundle", federationDomainCABundlePath,
 			"--oidc-session-cache", sessionCachePath,
 			"--credential-cache", credentialCachePath,
 			// use default for --oidc-scopes, which is to request all relevant scopes
@@ -1118,7 +1112,6 @@ func TestE2EFullIntegration_Browser(t *testing.T) {
 			"--concierge-authenticator-type", "jwt",
 			"--concierge-authenticator-name", authenticator.Name,
 			"--oidc-skip-browser",
-			"--oidc-ca-bundle", federationDomainCABundlePath,
 			"--upstream-identity-provider-flow", "browser_authcode",
 			"--oidc-session-cache", sessionCachePath,
 			"--credential-cache", credentialCachePath,
@@ -1174,7 +1167,6 @@ func TestE2EFullIntegration_Browser(t *testing.T) {
 			"--concierge-authenticator-type", "jwt",
 			"--concierge-authenticator-name", authenticator.Name,
 			"--oidc-skip-browser",
-			"--oidc-ca-bundle", federationDomainCABundlePath,
 			"--upstream-identity-provider-flow", "browser_authcode",
 			"--oidc-session-cache", sessionCachePath,
 			"--credential-cache", credentialCachePath,
@@ -1230,7 +1222,6 @@ func TestE2EFullIntegration_Browser(t *testing.T) {
 			"--concierge-authenticator-type", "jwt",
 			"--concierge-authenticator-name", authenticator.Name,
 			"--oidc-skip-browser",
-			"--oidc-ca-bundle", federationDomainCABundlePath,
 			"--upstream-identity-provider-flow", "cli_password", // put cli_password in the kubeconfig, so we can override it with the env var
 			"--oidc-session-cache", sessionCachePath,
 			"--credential-cache", credentialCachePath,
@@ -1319,7 +1310,6 @@ func TestE2EFullIntegration_Browser(t *testing.T) {
 			"--concierge-authenticator-type", "jwt",
 			"--concierge-authenticator-name", authenticator.Name,
 			"--oidc-skip-browser",
-			"--oidc-ca-bundle", federationDomainCABundlePath,
 			"--oidc-session-cache", sessionCachePath,
 			"--credential-cache", credentialCachePath,
 			// use default for --oidc-scopes, which is to request all relevant scopes


### PR DESCRIPTION
Fixes #2178.

The "pinniped get kubeconfig" CLI command now auto-discovers the Concierge's installation namespace by looking for the APIService with the expected API group name and reading the namespace from its spec. Then looks up the Secret or ConfigMap from that namespace using the values from the JWTAuthenticator's spec.TLS.CertificateAuthorityDataSource. Handles possible errors, and handles custom API group suffix values if specified by the user.

**Release note**:

```release-note
The "pinniped get kubeconfig" CLI command now auto-discovers the issuer's CA bundle from a
JWTAuthenticator's spec.TLS.CertificateAuthorityDataSource, and this CA bundle is written
into the resulting kubeconfig.
```
