### PR TITLE
make tools deployment proxy server optional

### DIFF
--- a/test/deploy/tools/proxy.yaml
+++ b/test/deploy/tools/proxy.yaml
@@ -1,7 +1,8 @@
-#! Copyright 2020-2023 the Pinniped contributors. All Rights Reserved.
+#! Copyright 2020-2025 the Pinniped contributors. All Rights Reserved.
 #! SPDX-License-Identifier: Apache-2.0
 
 #@ load("@ytt:data", "data")
+#@ if data.values.deploy_proxy:
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -75,3 +76,4 @@ spec:
   ports:
     - port: 3128
       nodePort: #@ data.values.ports.node
+#@ end

--- a/test/deploy/tools/values.yaml
+++ b/test/deploy/tools/values.yaml
@@ -1,4 +1,4 @@
-#! Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
+#! Copyright 2020-2025 the Pinniped contributors. All Rights Reserved.
 #! SPDX-License-Identifier: Apache-2.0
 
 #@data/values
@@ -16,6 +16,8 @@ ports:
   #! our Kind configuration which maps 127.0.0.1:12346 to port 31235 on the Kind worker node.
   local: 12346
 
+#! deploy_proxy deploys the proxy server when true.
+deploy_proxy: true
 
 #! dex_issuer_hostname can be used to provide Dex with a DNS record or IP address for its hostname,
 #! which is used to construct an issuer uri and create a certificate to serve TLS.


### PR DESCRIPTION
Introduce a new ytt value that can be used by CI jobs. The default behavior is the same as before, which is to deploy the proxy server.

**Release note**:

```release-note
NONE
```
