### PR TITLE
support response_mode=form_post in upstream OIDC IDPs

### DIFF
--- a/internal/federationdomain/endpoints/auth/auth_handler_test.go
+++ b/internal/federationdomain/endpoints/auth/auth_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2025 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package auth
@@ -1551,7 +1551,7 @@ func TestAuthorizationEndpoint(t *testing.T) { //nolint:gocyclo
 			cookieEncoder:                          happyCookieEncoder,
 			method:                                 http.MethodGet,
 			path:                                   happyGetRequestPathForOIDCUpstream,
-			csrfCookie:                             "__Host-pinniped-csrf=" + encodedIncomingCookieCSRFValue + " ",
+			csrfCookie:                             "__Host-pinniped-csrf-v2=" + encodedIncomingCookieCSRFValue + " ",
 			wantStatus:                             http.StatusSeeOther,
 			wantContentType:                        htmlContentType,
 			wantLocationHeader:                     expectedRedirectLocationForUpstreamOIDC(expectedUpstreamStateParam(nil, incomingCookieCSRFValue, oidcUpstreamName, "oidc"), nil),
@@ -1568,7 +1568,7 @@ func TestAuthorizationEndpoint(t *testing.T) { //nolint:gocyclo
 			cookieEncoder:                          happyCookieEncoder,
 			method:                                 http.MethodGet,
 			path:                                   happyGetRequestPathForLDAPUpstream,
-			csrfCookie:                             "__Host-pinniped-csrf=" + encodedIncomingCookieCSRFValue + " ",
+			csrfCookie:                             "__Host-pinniped-csrf-v2=" + encodedIncomingCookieCSRFValue + " ",
 			wantStatus:                             http.StatusSeeOther,
 			wantContentType:                        htmlContentType,
 			wantLocationHeader:                     urlWithQuery(downstreamIssuer+"/login", map[string]string{"state": expectedUpstreamStateParam(nil, incomingCookieCSRFValue, ldapUpstreamName, "ldap")}),
@@ -1585,7 +1585,7 @@ func TestAuthorizationEndpoint(t *testing.T) { //nolint:gocyclo
 			cookieEncoder:                          happyCookieEncoder,
 			method:                                 http.MethodGet,
 			path:                                   happyGetRequestPathForADUpstream,
-			csrfCookie:                             "__Host-pinniped-csrf=" + encodedIncomingCookieCSRFValue + " ",
+			csrfCookie:                             "__Host-pinniped-csrf-v2=" + encodedIncomingCookieCSRFValue + " ",
 			wantStatus:                             http.StatusSeeOther,
 			wantContentType:                        htmlContentType,
 			wantLocationHeader:                     urlWithQuery(downstreamIssuer+"/login", map[string]string{"state": expectedUpstreamStateParam(nil, incomingCookieCSRFValue, activeDirectoryUpstreamName, "activedirectory")}),
@@ -1931,7 +1931,7 @@ func TestAuthorizationEndpoint(t *testing.T) { //nolint:gocyclo
 			cookieEncoder:   happyCookieEncoder,
 			method:          http.MethodGet,
 			path:            happyGetRequestPathForOIDCUpstream,
-			csrfCookie:      "__Host-pinniped-csrf=this-value-was-not-signed-by-pinniped",
+			csrfCookie:      "__Host-pinniped-csrf-v2=this-value-was-not-signed-by-pinniped",
 			wantStatus:      http.StatusSeeOther,
 			wantContentType: htmlContentType,
 			// Generated a new CSRF cookie and set it in the response.
@@ -4217,7 +4217,7 @@ func TestAuthorizationEndpoint(t *testing.T) { //nolint:gocyclo
 		if test.wantCSRFValueInCookieHeader != "" {
 			require.Len(t, rsp.Header().Values("Set-Cookie"), 1)
 			actualCookie := rsp.Header().Get("Set-Cookie")
-			regex := regexp.MustCompile("__Host-pinniped-csrf=([^;]+); Path=/; HttpOnly; Secure; SameSite=Lax")
+			regex := regexp.MustCompile("__Host-pinniped-csrf-v2=([^;]+); Path=/; HttpOnly; Secure; SameSite=None")
 			submatches := regex.FindStringSubmatch(actualCookie)
 			require.Len(t, submatches, 2)
 			captured := submatches[1]

--- a/internal/federationdomain/endpoints/login/login_handler_test.go
+++ b/internal/federationdomain/endpoints/login/login_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 the Pinniped contributors. All Rights Reserved.
+// Copyright 2022-2025 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package login
@@ -109,7 +109,7 @@ func TestLoginEndpoint(t *testing.T) {
 
 	encodedIncomingCookieCSRFValue, err := happyCookieCodec.Encode("csrf", happyDownstreamCSRF)
 	require.NoError(t, err)
-	happyCSRFCookie := "__Host-pinniped-csrf=" + encodedIncomingCookieCSRFValue
+	happyCSRFCookie := "__Host-pinniped-csrf-v2=" + encodedIncomingCookieCSRFValue
 
 	tests := []struct {
 		name           string
@@ -261,7 +261,7 @@ func TestLoginEndpoint(t *testing.T) {
 			name:            "the CSRF cookie was not signed correctly, has expired, or otherwise cannot be decoded for any reason on GET request",
 			method:          http.MethodGet,
 			path:            happyPathWithState,
-			csrfCookie:      "__Host-pinniped-csrf=this-value-was-not-signed-by-pinniped",
+			csrfCookie:      "__Host-pinniped-csrf-v2=this-value-was-not-signed-by-pinniped",
 			wantStatus:      http.StatusForbidden,
 			wantContentType: htmlContentType,
 			wantBody:        "Forbidden: error reading CSRF cookie\n",
@@ -270,7 +270,7 @@ func TestLoginEndpoint(t *testing.T) {
 			name:            "the CSRF cookie was not signed correctly, has expired, or otherwise cannot be decoded for any reason on POST request",
 			method:          http.MethodPost,
 			path:            happyPathWithState,
-			csrfCookie:      "__Host-pinniped-csrf=this-value-was-not-signed-by-pinniped",
+			csrfCookie:      "__Host-pinniped-csrf-v2=this-value-was-not-signed-by-pinniped",
 			wantStatus:      http.StatusForbidden,
 			wantContentType: htmlContentType,
 			wantBody:        "Forbidden: error reading CSRF cookie\n",
@@ -519,7 +519,7 @@ func TestLoginEndpoint(t *testing.T) {
 			require.Equal(t, test.wantBody, rsp.Body.String())
 
 			if test.wantAuditLogs != nil {
-				wantAuditLogs := test.wantAuditLogs(testutil.GetStateParam(t, test.path))
+				wantAuditLogs := test.wantAuditLogs(testutil.GetStateParamFromRequestURL(t, test.path))
 				testutil.WantAuditIDOnEveryAuditLog(wantAuditLogs, "fake-audit-id")
 				testutil.CompareAuditLogs(t, wantAuditLogs, actualAuditLog.String())
 			}

--- a/internal/federationdomain/endpointsmanager/manager_test.go
+++ b/internal/federationdomain/endpointsmanager/manager_test.go
@@ -187,7 +187,7 @@ func TestManager(t *testing.T) {
 			cookies := recorder.Result().Cookies()
 			r.Len(cookies, 1)
 			csrfCookie := cookies[0]
-			r.Equal("__Host-pinniped-csrf", csrfCookie.Name)
+			r.Equal("__Host-pinniped-csrf-v2", csrfCookie.Name)
 			r.NotEmpty(csrfCookie.Value)
 
 			// Return the important parts of the response so we can use them in our next request to the callback endpoint
@@ -201,7 +201,7 @@ func TestManager(t *testing.T) {
 
 			getRequest := newGetRequest(requestIssuer + oidc.CallbackEndpointPath + requestURLSuffix)
 			getRequest.AddCookie(&http.Cookie{
-				Name:  "__Host-pinniped-csrf",
+				Name:  "__Host-pinniped-csrf-v2",
 				Value: csrfCookieValue,
 			})
 			subject.HandlerChain().ServeHTTP(recorder, getRequest)

--- a/internal/federationdomain/oidc/oidc.go
+++ b/internal/federationdomain/oidc/oidc.go
@@ -61,9 +61,11 @@ const (
 	UpstreamStateParamEncodingName = "s"
 
 	// CSRFCookieName is the name of the browser cookie which shall hold our CSRF value.
+	// The "-v2" suffix was added when the SameSite value was changed from Lax to None,
+	// to force the creation and use of a new cookie upon upgrade.
 	// The `__Host` prefix has a special meaning. See:
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#Cookie_prefixes.
-	CSRFCookieName = "__Host-pinniped-csrf"
+	CSRFCookieName = "__Host-pinniped-csrf-v2"
 
 	// CSRFCookieEncodingName is the `name` passed to the encoder for encoding and decoding the CSRF
 	// cookie contents.

--- a/internal/testutil/log_lines.go
+++ b/internal/testutil/log_lines.go
@@ -1,4 +1,4 @@
-// Copyright 2024 the Pinniped contributors. All Rights Reserved.
+// Copyright 2025 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package testutil
@@ -44,7 +44,7 @@ func WantAuditIDOnEveryAuditLog(wantedAuditLogs []WantedAuditLog, wantAuditID st
 	}
 }
 
-func GetStateParam(t *testing.T, fullURL string) stateparam.Encoded {
+func GetStateParamFromRequestURL(t *testing.T, fullURL string) stateparam.Encoded {
 	if fullURL == "" {
 		var empty stateparam.Encoded
 		return empty
@@ -53,6 +53,12 @@ func GetStateParam(t *testing.T, fullURL string) stateparam.Encoded {
 	path, err := url.Parse(fullURL)
 	require.NoError(t, err)
 	return stateparam.Encoded(path.Query().Get("state"))
+}
+
+func GetStateParamFromRequestBody(t *testing.T, body string) stateparam.Encoded {
+	values, err := url.ParseQuery(body)
+	require.NoError(t, err)
+	return stateparam.Encoded(values.Get("state"))
 }
 
 func CompareAuditLogs(t *testing.T, wantAuditLogs []WantedAuditLog, actualAuditLogsOneLiner string) {


### PR DESCRIPTION
Addresses #2238.

This PR makes it possible to use `response_mode=form_post` with an OIDCIdentityProvider.

For example:

```yaml
apiVersion: idp.supervisor.pinniped.dev/v1alpha1
kind: OIDCIdentityProvider
metadata:
  name: my-oidc-idp
  namespace: pinniped-supervisor
spec:
  issuer: https://my-oidc-provider.example.com/path
  authorizationConfig:
    additionalAuthorizeParameters:
      # This is the part that could not work before this PR.
      - name: response_mode
        value: form_post
      # End new part.
  claims:
    username: email
    groups: groups
  client:
    secretName: oidc-client-creds
```

This is typically not needed. However, see #2238 for a case where it might be needed when using certain versions of ADFS.

I manually tested that this works on my Mac laptop using Okta as the IDP and using the latest Safari, Chrome, Firefox, and Edge browsers (all for MacOS).

**Release note**:

```release-note
The Pinniped Supervisor now supports using `response_mode=form_post` with an OIDCIdentityProvider.
Some versions of ADFS might require this in order for Pinniped to receive certain claims in the
ADFS-issued ID token.
```
