### PR TITLE
introduce new configuration option to disable admission plugin types

### DIFF
--- a/deploy/concierge/deployment.yaml
+++ b/deploy/concierge/deployment.yaml
@@ -1,4 +1,4 @@
-#! Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
+#! Copyright 2020-2025 the Pinniped contributors. All Rights Reserved.
 #! SPDX-License-Identifier: Apache-2.0
 
 #@ load("@ytt:data", "data")
@@ -68,6 +68,7 @@ data:
     apiGroupSuffix: (@= data.values.api_group_suffix @)
     # aggregatedAPIServerPort may be set here, although other YAML references to the default port (10250) may also need to be updated
     # impersonationProxyServerPort may be set here, although other YAML references to the default port (8444) may also need to be updated
+    aggregatedAPIServerDisableAdmissionPlugins: []
     names:
       servingCertificateSecret: (@= defaultResourceNameWithSuffix("api-tls-serving-certificate") @)
       credentialIssuer: (@= defaultResourceNameWithSuffix("config") @)

--- a/deploy/supervisor/helpers.lib.yaml
+++ b/deploy/supervisor/helpers.lib.yaml
@@ -1,4 +1,4 @@
-#! Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
+#! Copyright 2020-2025 the Pinniped contributors. All Rights Reserved.
 #! SPDX-License-Identifier: Apache-2.0
 
 #@ load("@ytt:data", "data")
@@ -61,7 +61,8 @@ _: #@ template.replace(data.values.custom_labels)
 #@     "audit": {
 #@       "logUsernamesAndGroups": data.values.audit.log_usernames_and_groups,
 #@       "logInternalPaths": data.values.audit.log_internal_paths
-#@     }
+#@     },
+#@     "aggregatedAPIServerDisableAdmissionPlugins": []
 #@   }
 #@   if data.values.log_level:
 #@     config["log"] = {}

--- a/internal/admissionpluginconfig/admissionpluginconfig.go
+++ b/internal/admissionpluginconfig/admissionpluginconfig.go
@@ -1,23 +1,37 @@
-// Copyright 2024 the Pinniped contributors. All Rights Reserved.
+// Copyright 2024-2025 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package admissionpluginconfig
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/pkg/errors"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	"k8s.io/apiserver/pkg/admission"
-	"k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle"
-	"k8s.io/apiserver/pkg/admission/plugin/webhook/mutating"
-	"k8s.io/apiserver/pkg/admission/plugin/webhook/validating"
+	validatingadmissionpolicy "k8s.io/apiserver/pkg/admission/plugin/policy/validating"
 	"k8s.io/apiserver/pkg/server/options"
 	"k8s.io/client-go/discovery"
 
 	"go.pinniped.dev/internal/kubeclient"
 	"go.pinniped.dev/internal/plog"
 )
+
+// ValidateAdmissionPluginNames returns an error if any of the given pluginNames is unrecognized.
+func ValidateAdmissionPluginNames(pluginNames []string) error {
+	var pluginsNotFound []string
+	admissionOptions := options.NewAdmissionOptions()
+	for _, pluginName := range pluginNames {
+		if !slices.Contains(admissionOptions.RecommendedPluginOrder, pluginName) {
+			pluginsNotFound = append(pluginsNotFound, pluginName)
+		}
+	}
+	if len(pluginsNotFound) > 0 {
+		return fmt.Errorf("admission plugin names not recognized: %s (each must be one of %s)",
+			pluginsNotFound, admissionOptions.RecommendedPluginOrder)
+	}
+	return nil
+}
 
 // ConfigureAdmissionPlugins may choose to reconfigure the admission plugins present on the given
 // RecommendedOptions by mutating it.
@@ -27,34 +41,46 @@ import (
 // then the new admission ValidatingAdmissionPolicy plugin prevents all our aggregated APIs from working, seemingly
 // because it fails to sync informers created for watching the related resources. As a workaround, ask the k8s API
 // server if it has the ValidatingAdmissionPolicy resource, and configure our admission plugins accordingly.
-func ConfigureAdmissionPlugins(recommendedOptions *options.RecommendedOptions) error {
+//
+// Any plugin name passed via the disableAdmissionPlugins parameter will also be disabled.
+// The values in this parameter should be validated by the caller using ValidateAdmissionPluginNames before
+// being passed into this function.
+func ConfigureAdmissionPlugins(recommendedOptions *options.RecommendedOptions, disableAdmissionPlugins []string) error {
 	k8sClient, err := kubeclient.New()
 	if err != nil {
 		return fmt.Errorf("failed to create kube client: %w", err)
 	}
-	return configureAdmissionPlugins(k8sClient.Kubernetes.Discovery(), recommendedOptions)
+	return configureAdmissionPlugins(k8sClient.Kubernetes.Discovery(), recommendedOptions, disableAdmissionPlugins)
 }
 
 // configureAdmissionPlugins is the same as ConfigureAdmissionPlugins but allows client injection for unit testing.
-func configureAdmissionPlugins(discoveryClient discovery.ServerResourcesInterface, recommendedOptions *options.RecommendedOptions) error {
-	// Check if the API server has such a resource.
-	hasValidatingAdmissionPolicyResource, err := k8sAPIServerHasValidatingAdmissionPolicyResource(discoveryClient)
-	if err != nil {
-		return fmt.Errorf("failed looking up availability of ValidatingAdmissionPolicy resource: %w", err)
+func configureAdmissionPlugins(
+	discoveryClient discovery.ServerResourcesInterface,
+	recommendedOptions *options.RecommendedOptions,
+	disableAdmissionPlugins []string,
+) error {
+	if !slices.Contains(disableAdmissionPlugins, validatingadmissionpolicy.PluginName) {
+		// The admin did not explicitly disable the ValidatingAdmissionPolicy plugin, but we may still need disable it if
+		// the Kubernetes cluster on which we are running is too old. Check if the API server has such a resource.
+		hasValidatingAdmissionPolicyResource, err := k8sAPIServerHasValidatingAdmissionPolicyResource(discoveryClient)
+		if err != nil {
+			return fmt.Errorf("failed looking up availability of ValidatingAdmissionPolicy resource: %w", err)
+		}
+
+		if !hasValidatingAdmissionPolicyResource {
+			// Customize the admission plugins to avoid using the new ValidatingAdmissionPolicy plugin.
+			plog.Warning("could not find ValidatingAdmissionPolicy resource on this Kubernetes cluster " +
+				"(which is normal for clusters older than Kubernetes 1.30); " +
+				"disabling ValidatingAdmissionPolicy admission plugins for all Pinniped aggregated API resource types")
+
+			disableAdmissionPlugins = append(disableAdmissionPlugins, validatingadmissionpolicy.PluginName)
+		}
 	}
 
-	if hasValidatingAdmissionPolicyResource {
-		// Accept the default admission plugin configuration without any further modification.
-		return nil
+	// Mutate the recommendedOptions to potentially disable some admission plugins.
+	if len(disableAdmissionPlugins) > 0 {
+		recommendedOptions.Admission.DisablePlugins = disableAdmissionPlugins
 	}
-
-	// Customize the admission plugins to avoid using the new ValidatingAdmissionPolicy plugin.
-	plog.Warning("could not find ValidatingAdmissionPolicy resource on this Kubernetes cluster " +
-		"(which is normal for clusters older than Kubernetes 1.30); " +
-		"disabling ValidatingAdmissionPolicy admission plugins for all Pinniped aggregated API resource types")
-
-	mutateOptionsToUseOldStyleAdmissionPlugins(recommendedOptions)
-
 	return nil
 }
 
@@ -99,27 +125,4 @@ func k8sAPIServerHasValidatingAdmissionPolicyResource(discoveryClient discovery.
 
 	// Didn't findValidatingAdmissionPolicy on this cluster.
 	return false, nil
-}
-
-func mutateOptionsToUseOldStyleAdmissionPlugins(recommendedOptions *options.RecommendedOptions) {
-	plugins := admission.NewPlugins()
-
-	// These lines are copied from server.RegisterAllAdmissionPlugins in k8s.io/apiserver@v0.30.0/pkg/server/plugins.go.
-	lifecycle.Register(plugins)
-	validating.Register(plugins)
-	mutating.Register(plugins)
-	// Note that we are not adding this one:
-	// validatingadmissionpolicy.Register(newAdmissionPlugins)
-
-	// This list is copied from the implementation of NewAdmissionOptions() in k8s.io/apiserver@v0.30.0/pkg/server/options/admission.go
-	recommendedOptions.Admission.RecommendedPluginOrder = []string{
-		lifecycle.PluginName,
-		mutating.PluginName,
-		// Again, note that we are not adding this one:
-		// validatingadmissionpolicy.PluginName,
-		validating.PluginName,
-	}
-
-	// Overwrite the registered plugins with our new, smaller list.
-	recommendedOptions.Admission.Plugins = plugins
 }

--- a/internal/concierge/server/server.go
+++ b/internal/concierge/server/server.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2025 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package server is the command line entry point for pinniped-concierge.
@@ -214,6 +214,7 @@ func (a *App) runServer(ctx context.Context) error {
 		identityGV,
 		auditLogger,
 		tokenClient,
+		cfg.AggregatedAPIServerDisableAdmissionPlugins,
 	)
 	if err != nil {
 		return fmt.Errorf("could not configure aggregated API server: %w", err)
@@ -243,6 +244,7 @@ func getAggregatedAPIServerConfig(
 	loginConciergeGroupVersion, identityConciergeGroupVersion schema.GroupVersion,
 	auditLogger plog.AuditLogger,
 	tokenClient *tokenclient.TokenClient,
+	disableAdmissionPlugins []string,
 ) (*apiserver.Config, error) {
 	codecs := serializer.NewCodecFactory(scheme)
 
@@ -259,7 +261,7 @@ func getAggregatedAPIServerConfig(
 	// This port is configurable. It should be safe to cast because the config reader already validated it.
 	recommendedOptions.SecureServing.BindPort = int(aggregatedAPIServerPort)
 
-	err := admissionpluginconfig.ConfigureAdmissionPlugins(recommendedOptions)
+	err := admissionpluginconfig.ConfigureAdmissionPlugins(recommendedOptions, disableAdmissionPlugins)
 	if err != nil {
 		return nil, fmt.Errorf("failed to configure admission plugins on recommended options: %w", err)
 	}

--- a/internal/config/concierge/config.go
+++ b/internal/config/concierge/config.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2025 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package concierge contains functionality to load/store Config's from/to
@@ -14,6 +14,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 
+	"go.pinniped.dev/internal/admissionpluginconfig"
 	"go.pinniped.dev/internal/constable"
 	"go.pinniped.dev/internal/crypto/ptls"
 	"go.pinniped.dev/internal/groupsuffix"
@@ -66,6 +67,10 @@ func FromPath(ctx context.Context, path string, setAllowedCiphers ptls.SetAllowe
 
 	if err := validateAPIGroupSuffix(*config.APIGroupSuffix); err != nil {
 		return nil, fmt.Errorf("validate apiGroupSuffix: %w", err)
+	}
+
+	if err := admissionpluginconfig.ValidateAdmissionPluginNames(config.AggregatedAPIServerDisableAdmissionPlugins); err != nil {
+		return nil, fmt.Errorf("validate aggregatedAPIServerDisableAdmissionPlugins: %w", err)
 	}
 
 	if err := validateServerPort(config.AggregatedAPIServerPort); err != nil {

--- a/internal/config/concierge/config_test.go
+++ b/internal/config/concierge/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2025 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package concierge
@@ -36,6 +36,11 @@ func TestFromPath(t *testing.T) {
 					renewBeforeSeconds: 2400
 				apiGroupSuffix: some.suffix.com
 				aggregatedAPIServerPort: 12345
+				aggregatedAPIServerDisableAdmissionPlugins:
+				  - NamespaceLifecycle
+				  - MutatingAdmissionWebhook
+				  - ValidatingAdmissionPolicy
+				  - ValidatingAdmissionWebhook
 				impersonationProxyServerPort: 4242
 				names:
 				  servingCertificateSecret: pinniped-concierge-api-tls-serving-certificate
@@ -80,8 +85,14 @@ func TestFromPath(t *testing.T) {
 						RenewBeforeSeconds: ptr.To[int64](2400),
 					},
 				},
-				APIGroupSuffix:               ptr.To("some.suffix.com"),
-				AggregatedAPIServerPort:      ptr.To[int64](12345),
+				APIGroupSuffix:          ptr.To("some.suffix.com"),
+				AggregatedAPIServerPort: ptr.To[int64](12345),
+				AggregatedAPIServerDisableAdmissionPlugins: []string{
+					"NamespaceLifecycle",
+					"MutatingAdmissionWebhook",
+					"ValidatingAdmissionPolicy",
+					"ValidatingAdmissionWebhook",
+				},
 				ImpersonationProxyServerPort: ptr.To[int64](4242),
 				NamesConfig: NamesConfigSpec{
 					ServingCertificateSecret:          "pinniped-concierge-api-tls-serving-certificate",
@@ -134,6 +145,11 @@ func TestFromPath(t *testing.T) {
 					renewBeforeSeconds: 2400
 				apiGroupSuffix: some.suffix.com
 				aggregatedAPIServerPort: 12345
+				aggregatedAPIServerDisableAdmissionPlugins:
+				  - NamespaceLifecycle
+				  - MutatingAdmissionWebhook
+				  - ValidatingAdmissionPolicy
+				  - ValidatingAdmissionWebhook
 				impersonationProxyServerPort: 4242
 				names:
 				  servingCertificateSecret: pinniped-concierge-api-tls-serving-certificate
@@ -173,8 +189,14 @@ func TestFromPath(t *testing.T) {
 						RenewBeforeSeconds: ptr.To[int64](2400),
 					},
 				},
-				APIGroupSuffix:               ptr.To("some.suffix.com"),
-				AggregatedAPIServerPort:      ptr.To[int64](12345),
+				APIGroupSuffix:          ptr.To("some.suffix.com"),
+				AggregatedAPIServerPort: ptr.To[int64](12345),
+				AggregatedAPIServerDisableAdmissionPlugins: []string{
+					"NamespaceLifecycle",
+					"MutatingAdmissionWebhook",
+					"ValidatingAdmissionPolicy",
+					"ValidatingAdmissionWebhook",
+				},
 				ImpersonationProxyServerPort: ptr.To[int64](4242),
 				NamesConfig: NamesConfigSpec{
 					ServingCertificateSecret:          "pinniped-concierge-api-tls-serving-certificate",
@@ -298,6 +320,9 @@ func TestFromPath(t *testing.T) {
 					Image:      ptr.To("debian:latest"),
 				},
 				Audit: AuditSpec{LogUsernamesAndGroups: ""},
+				AggregatedAPIServerDisableAdmissionPlugins: nil,
+				TLS: TLSSpec{},
+				Log: plog.LogSpec{},
 			},
 		},
 		{
@@ -614,6 +639,22 @@ func TestFromPath(t *testing.T) {
 				  impersonationSignerSecret: impersonationSignerSecret-value
 			`),
 			wantError: "validate apiGroupSuffix: a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')",
+		},
+		{
+			name: "Invalid aggregatedAPIServerDisableAdmissionPlugins",
+			yaml: here.Doc(`
+				---
+				aggregatedAPIServerDisableAdmissionPlugins: [foobar, ValidatingAdmissionWebhook, foobaz]
+				names:
+				  servingCertificateSecret: pinniped-concierge-api-tls-serving-certificate
+				  credentialIssuer: pinniped-config
+				  apiService: pinniped-api
+				  impersonationLoadBalancerService: impersonationLoadBalancerService-value
+				  impersonationTLSCertificateSecret: impersonationTLSCertificateSecret-value
+				  impersonationCACertificateSecret: impersonationCACertificateSecret-value
+				  impersonationSignerSecret: impersonationSignerSecret-value
+			`),
+			wantError: "validate aggregatedAPIServerDisableAdmissionPlugins: admission plugin names not recognized: [foobar foobaz] (each must be one of [NamespaceLifecycle MutatingAdmissionWebhook ValidatingAdmissionPolicy ValidatingAdmissionWebhook])",
 		},
 		{
 			name: "returns setAllowedCiphers errors",

--- a/internal/config/concierge/types.go
+++ b/internal/config/concierge/types.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2025 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package concierge
@@ -12,17 +12,18 @@ const (
 
 // Config contains knobs to set up an instance of the Pinniped Concierge.
 type Config struct {
-	DiscoveryInfo                DiscoveryInfoSpec `json:"discovery"`
-	APIConfig                    APIConfigSpec     `json:"api"`
-	APIGroupSuffix               *string           `json:"apiGroupSuffix,omitempty"`
-	AggregatedAPIServerPort      *int64            `json:"aggregatedAPIServerPort"`
-	ImpersonationProxyServerPort *int64            `json:"impersonationProxyServerPort"`
-	NamesConfig                  NamesConfigSpec   `json:"names"`
-	KubeCertAgentConfig          KubeCertAgentSpec `json:"kubeCertAgent"`
-	Labels                       map[string]string `json:"labels"`
-	Log                          plog.LogSpec      `json:"log"`
-	TLS                          TLSSpec           `json:"tls"`
-	Audit                        AuditSpec         `json:"audit"`
+	DiscoveryInfo                              DiscoveryInfoSpec `json:"discovery"`
+	APIConfig                                  APIConfigSpec     `json:"api"`
+	APIGroupSuffix                             *string           `json:"apiGroupSuffix,omitempty"`
+	AggregatedAPIServerPort                    *int64            `json:"aggregatedAPIServerPort"`
+	AggregatedAPIServerDisableAdmissionPlugins []string          `json:"aggregatedAPIServerDisableAdmissionPlugins"`
+	ImpersonationProxyServerPort               *int64            `json:"impersonationProxyServerPort"`
+	NamesConfig                                NamesConfigSpec   `json:"names"`
+	KubeCertAgentConfig                        KubeCertAgentSpec `json:"kubeCertAgent"`
+	Labels                                     map[string]string `json:"labels"`
+	Log                                        plog.LogSpec      `json:"log"`
+	TLS                                        TLSSpec           `json:"tls"`
+	Audit                                      AuditSpec         `json:"audit"`
 }
 
 type AuditUsernamesAndGroups string

--- a/internal/config/supervisor/config.go
+++ b/internal/config/supervisor/config.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2025 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package supervisor contains functionality to load/store Config's from/to
@@ -15,6 +15,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 
+	"go.pinniped.dev/internal/admissionpluginconfig"
 	"go.pinniped.dev/internal/constable"
 	"go.pinniped.dev/internal/crypto/ptls"
 	"go.pinniped.dev/internal/groupsuffix"
@@ -55,6 +56,10 @@ func FromPath(ctx context.Context, path string, setAllowedCiphers ptls.SetAllowe
 
 	if err := validateAPIGroupSuffix(*config.APIGroupSuffix); err != nil {
 		return nil, fmt.Errorf("validate apiGroupSuffix: %w", err)
+	}
+
+	if err := admissionpluginconfig.ValidateAdmissionPluginNames(config.AggregatedAPIServerDisableAdmissionPlugins); err != nil {
+		return nil, fmt.Errorf("validate aggregatedAPIServerDisableAdmissionPlugins: %w", err)
 	}
 
 	maybeSetAggregatedAPIServerPortDefaults(&config.AggregatedAPIServerPort)

--- a/internal/config/supervisor/config_test.go
+++ b/internal/config/supervisor/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2025 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package supervisor
@@ -46,6 +46,11 @@ func TestFromPath(t *testing.T) {
 				  level: info
 				  format: json
 				aggregatedAPIServerPort: 12345
+				aggregatedAPIServerDisableAdmissionPlugins:
+				  - NamespaceLifecycle
+				  - MutatingAdmissionWebhook
+				  - ValidatingAdmissionPolicy
+				  - ValidatingAdmissionWebhook
 				tls:
 				  onedottwo:
 				    allowedCiphers:
@@ -80,6 +85,12 @@ func TestFromPath(t *testing.T) {
 					Format: plog.FormatJSON,
 				},
 				AggregatedAPIServerPort: ptr.To[int64](12345),
+				AggregatedAPIServerDisableAdmissionPlugins: []string{
+					"NamespaceLifecycle",
+					"MutatingAdmissionWebhook",
+					"ValidatingAdmissionPolicy",
+					"ValidatingAdmissionWebhook",
+				},
 				TLS: TLSSpec{
 					OneDotTwo: TLSProtocolSpec{
 						AllowedCiphers: []string{
@@ -134,6 +145,9 @@ func TestFromPath(t *testing.T) {
 					LogInternalPaths:      "",
 					LogUsernamesAndGroups: "",
 				},
+				AggregatedAPIServerDisableAdmissionPlugins: nil,
+				TLS: TLSSpec{},
+				Log: plog.LogSpec{},
 			},
 		},
 		{
@@ -345,6 +359,16 @@ func TestFromPath(t *testing.T) {
 			`),
 			allowedCiphersError: fmt.Errorf("some error from setAllowedCiphers"),
 			wantError:           "validate tls: some error from setAllowedCiphers",
+		},
+		{
+			name: "invalid aggregatedAPIServerDisableAdmissionPlugins",
+			yaml: here.Doc(`
+				---
+				names:
+				  defaultTLSCertificateSecret: my-secret-name
+				aggregatedAPIServerDisableAdmissionPlugins: [foobar, ValidatingAdmissionWebhook, foobaz]
+			`),
+			wantError: "validate aggregatedAPIServerDisableAdmissionPlugins: admission plugin names not recognized: [foobar foobaz] (each must be one of [NamespaceLifecycle MutatingAdmissionWebhook ValidatingAdmissionPolicy ValidatingAdmissionWebhook])",
 		},
 	}
 	for _, test := range tests {

--- a/internal/config/supervisor/types.go
+++ b/internal/config/supervisor/types.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2025 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package supervisor
@@ -14,14 +14,15 @@ const (
 
 // Config contains knobs to set up an instance of the Pinniped Supervisor.
 type Config struct {
-	APIGroupSuffix          *string           `json:"apiGroupSuffix,omitempty"`
-	Labels                  map[string]string `json:"labels"`
-	NamesConfig             NamesConfigSpec   `json:"names"`
-	Log                     plog.LogSpec      `json:"log"`
-	Endpoints               *Endpoints        `json:"endpoints"`
-	AggregatedAPIServerPort *int64            `json:"aggregatedAPIServerPort"`
-	TLS                     TLSSpec           `json:"tls"`
-	Audit                   AuditSpec         `json:"audit"`
+	APIGroupSuffix                             *string           `json:"apiGroupSuffix,omitempty"`
+	Labels                                     map[string]string `json:"labels"`
+	NamesConfig                                NamesConfigSpec   `json:"names"`
+	Log                                        plog.LogSpec      `json:"log"`
+	Endpoints                                  *Endpoints        `json:"endpoints"`
+	AggregatedAPIServerPort                    *int64            `json:"aggregatedAPIServerPort"`
+	AggregatedAPIServerDisableAdmissionPlugins []string          `json:"aggregatedAPIServerDisableAdmissionPlugins"`
+	TLS                                        TLSSpec           `json:"tls"`
+	Audit                                      AuditSpec         `json:"audit"`
 }
 
 type AuditInternalPaths string

--- a/internal/registry/credentialrequest/rest.go
+++ b/internal/registry/credentialrequest/rest.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2025 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package credentialrequest provides REST functionality for the CredentialRequest resource.
@@ -224,10 +224,6 @@ func validateRequest(ctx context.Context, obj runtime.Object, createValidation r
 	}
 
 	// let dynamic admission webhooks have a chance to validate (but not mutate) as well
-	//  TODO Since we are an aggregated API, we should investigate to see if the kube API server is already invoking admission hooks for us.
-	//   Even if it is, its okay to call it again here. However, if the kube API server is already calling the webhooks and passing
-	//   the token, then there is probably no reason for us to avoid passing the token when we call the webhooks here, since
-	//   they already got the token.
 	if createValidation != nil {
 		requestForValidation := obj.DeepCopyObject()
 		requestForValidation.(*loginapi.TokenCredentialRequest).Spec.Token = ""

--- a/internal/supervisor/server/server.go
+++ b/internal/supervisor/server/server.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2025 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package server defines the entrypoint for the Pinniped Supervisor server.
@@ -530,6 +530,7 @@ func runSupervisor(ctx context.Context, podInfo *downward.PodInfo, cfg *supervis
 		client.PinnipedSupervisor.ConfigV1alpha1().OIDCClients(serverInstallationNamespace),
 		serverInstallationNamespace,
 		auditLogger,
+		cfg.AggregatedAPIServerDisableAdmissionPlugins,
 	)
 	if err != nil {
 		return fmt.Errorf("could not configure aggregated API server: %w", err)
@@ -641,6 +642,7 @@ func getAggregatedAPIServerConfig(
 	oidcClients v1alpha1.OIDCClientInterface,
 	serverInstallationNamespace string,
 	auditLogger plog.AuditLogger,
+	disableAdmissionPlugins []string,
 ) (*apiserver.Config, error) {
 	codecs := serializer.NewCodecFactory(scheme)
 
@@ -657,7 +659,7 @@ func getAggregatedAPIServerConfig(
 	// This port is configurable. It should be safe to cast because the config reader already validated it.
 	recommendedOptions.SecureServing.BindPort = int(aggregatedAPIServerPort)
 
-	err := admissionpluginconfig.ConfigureAdmissionPlugins(recommendedOptions)
+	err := admissionpluginconfig.ConfigureAdmissionPlugins(recommendedOptions, disableAdmissionPlugins)
 	if err != nil {
 		return nil, fmt.Errorf("failed to configure admission plugins on recommended options: %w", err)
 	}


### PR DESCRIPTION
When a cluster on which the Pinniped Concierge or Supervisor is installed has hundreds of ValidatingAdmissionPolicies and hundreds of corresponding ValidatingAdmissionPolicyBindings, then the Concierge and Supervisor pods may exceed their default memory limits, get OOMKilled, and go into CrashLoopBackOff.

This is because both the Concierge and Supervisor are serving aggregated APIs added to the Kubernetes API server. The Concierge serves the WhoAmIRequest and TokenCredentialRequest APIs, and the Supervisor serves the OIDCClientSecretRequest API. It is the responsibility of an aggregated API server to invoke the Kubernetes dynamic admission plugins for the APIs that they serve. To accomplish this, Pinniped uses the Go packages from Kubernetes intended for this purpose. However, these packages consume a large amount of memory for watching and processing ValidatingAdmissionPolicies and ValidatingAdmissionPolicyBindings. Because this memory is getting consumed in the Kubernetes Go packages that are also used on the Kubernetes API server, you will observe similar memory usage growth on your Kubernetes API server pods under the same circumstances. The difference is that the Kube API server pods usually do not have a memory limit imposed upon them.

You have three options to work around this problem:
1. Don't create hundreds of ValidatingAdmissionPolicies and ValidatingAdmissionPolicyBindings.
2. Increase the memory limit on the Supervisor and Concierge pods. Each 1,000 ValidatingAdmissionPolicies and ValidatingAdmissionPolicyBindings might need as much as ~1 GB of memory as recently observed through experimentation. Although it uses a lot of memory, it will otherwise work just fine.
3. Use the new feature introduced by this PR to disable the `ValidatingAdmissionPolicy` admission plugins for the Concierge and/or Supervisor pods. This will completely disable enforcement of ValidatingAdmissionPolicies on the Concierge WhoAmIRequest and TokenCredentialRequest APIs and/or Supervisor OIDCClientSecretRequest API. The Kubernetes API server will not process the ValidatingAdmissionPolicies for aggregated APIs. Requests that might have been denied by a ValidatingAdmissionPolicy for the Pinniped aggregated APIs will instead succeed when the plugin is disabled. The Concierge and/or Supervisor pods' memory usage will no longer increase when ValidatingAdmissionPolicies and ValidatingAdmissionPolicyBindings are defined on the cluster, because the pods are no longer watching or processing those resources.

This PR adds a new configuration option to static ConfigMaps of both the Concierge and Supervisor called `aggregatedAPIServerDisableAdmissionPlugins`. When present, its value must be a YAML array of strings. Valid strings are currently: `NamespaceLifecycle`, `MutatingAdmissionWebhook`, `ValidatingAdmissionPolicy`, and `ValidatingAdmissionWebhook`. Disabling one of these admission plugin types will disable all instances of that plugin type for that server's API(s). For example, putting `ValidatingAdmissionWebhook` in this list in the Concierge's ConfigMap will cause all validating admission webhooks defined on the cluster to be completely ignored for the Concierge's WhoAmIRequest and TokenCredentialRequest APIs.

This new configuration option is conceptually similar to this flag of the Kube API server: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#how-do-i-turn-off-an-admission-controller.

**Release note**:

```release-note
TODO
```
