### PR TITLE
account for move of repo from vmware-tanzu to vmware on GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist.md
@@ -17,7 +17,7 @@ assignees: ''
   - [ ] For go.mod direct dependencies that are v2 or above, such as `github.com/google/go-github/vXX`, check to see if there is a new major version available. Try using `hack/update-go-mod/update-majors.sh`.
   - [ ] Evaluate all `replace` directives in the `go.mod` file. Are those versions up-to-date? Can any `replace` directives be removed?
   - [ ] Evaluate all overrides in the `hack/update-go-mod/overrides.conf` file. Are those versions up-to-date? Can those overrides be removed?
-- [ ] Ensure that Pinniped's codegen is up-to-date with the latest Kubernetes releases by making sure this [file](https://github.com/vmware-tanzu/pinniped/blob/main/hack/lib/kube-versions.txt) is updated compared to the latest releases listed [here for active branches](https://kubernetes.io/releases/) and [here for non-active branches](https://kubernetes.io/releases/patch-releases/#non-active-branch-history)
+- [ ] Ensure that Pinniped's codegen is up-to-date with the latest Kubernetes releases by making sure this [file](https://github.com/vmware/pinniped/blob/main/hack/lib/kube-versions.txt) is updated compared to the latest releases listed [here for active branches](https://kubernetes.io/releases/) and [here for non-active branches](https://kubernetes.io/releases/patch-releases/#non-active-branch-history)
 - [ ] Ensure that the `k8s-code-generator` CI job definitions are up-to-date with the latest Go, K8s, and `controller-gen` versions
 - [ ] All relevant feature and docs PRs are merged
 - [ ] The [main pipeline](https://ci.pinniped.broadcom.net/teams/main/pipelines/main) is green, up to and including the `ready-to-release` job. Check that the expected git commit has passed the `ready-to-release` job.
@@ -25,7 +25,7 @@ assignees: ''
 - [ ] Optional: a blog post for the release is written and submitted as a PR but not merged yet
 - [ ] All merged user stories are accepted (manually tested)
 - [ ] Only after all stories are accepted, manually trigger the `release` job to create a draft GitHub release
-- [ ] Manually edit the draft release notes on the [GitHub release](https://github.com/vmware-tanzu/pinniped/releases) to describe the contents of the release, using the format which was automatically added to the draft release
+- [ ] Manually edit the draft release notes on the [GitHub release](https://github.com/vmware/pinniped/releases) to describe the contents of the release, using the format which was automatically added to the draft release
 - [ ] Publish (i.e. make public) the draft release
 - [ ] After making the release public, the jobs in the [main pipeline](https://ci.pinniped.broadcom.net/teams/main/pipelines/main) beyond the release job should auto-trigger, so check to make sure that they passed
 - [ ] Edit the blog post's date to make it match the actual release date, and merge the blog post PR to make it live on the website

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -30,5 +30,5 @@ TMC uses Pinniped to provide a uniform authentication experience across all atta
 ## Adding your organization to the list of adopters
 
 If you are using Pinniped and would like to be included in the list of Pinniped Adopters, add an SVG version of your logo that is less than 150 KB to
-the [img directory](https://github.com/vmware-tanzu/pinniped/tree/main/site/themes/pinniped/static/img) in this repo and submit a pull request with your change including 1-2 sentences describing how your organization is using Pinniped. Name the image file something that
+the [img directory](https://github.com/vmware/pinniped/tree/main/site/themes/pinniped/static/img) in this repo and submit a pull request with your change including 1-2 sentences describing how your organization is using Pinniped. Name the image file something that
 reflects your company (e.g., if your company is called Acme, name the image acme.svg). Please feel free to send us a message in [#pinniped](https://kubernetes.slack.com/archives/C01BW364RJA) with any questions you may have.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,26 +20,26 @@ The near-term and mid-term roadmap for the work planned for the project [maintai
 ## Discussion
 
 Got a question, comment, or idea? Please don't hesitate to reach out
-via GitHub [Discussions](https://github.com/vmware-tanzu/pinniped/discussions),
-GitHub [Issues](https://github.com/vmware-tanzu/pinniped/issues),
+via GitHub [Discussions](https://github.com/vmware/pinniped/discussions),
+GitHub [Issues](https://github.com/vmware/pinniped/issues),
 or in the Kubernetes Slack Workspace within the [#pinniped channel](https://go.pinniped.dev/community/slack).
 Join our [Google Group](https://go.pinniped.dev/community/group) to receive updates and meeting invitations.
 
 ## Issues
 
 Need an idea for a project to get started contributing? Take a look at the open
-[issues](https://github.com/vmware-tanzu/pinniped/issues).
+[issues](https://github.com/vmware/pinniped/issues).
 Also check to see if any open issues are labeled with
-["good first issue"](https://github.com/vmware-tanzu/pinniped/labels/good%20first%20issue)
-or ["help wanted"](https://github.com/vmware-tanzu/pinniped/labels/help%20wanted).
+["good first issue"](https://github.com/vmware/pinniped/labels/good%20first%20issue)
+or ["help wanted"](https://github.com/vmware/pinniped/labels/help%20wanted).
 
 ### Bugs
 
 To file a bug report, please first open an
-[issue](https://github.com/vmware-tanzu/pinniped/issues/new?template=bug_report.md). The project team
+[issue](https://github.com/vmware/pinniped/issues/new?template=bug_report.md). The project team
 will work with you on your bug report.
 
-Once the bug has been validated, a [pull request](https://github.com/vmware-tanzu/pinniped/compare)
+Once the bug has been validated, a [pull request](https://github.com/vmware/pinniped/compare)
 can be opened to fix the bug.
 
 For specifics on what to include in your bug report, please follow the
@@ -48,11 +48,11 @@ guidelines in the issue and pull request templates.
 ### Features
 
 To suggest a feature, please first open an
-[issue](https://github.com/vmware-tanzu/pinniped/issues/new?template=feature-proposal.md)
-and tag it with `proposal`, or create a new [Discussion](https://github.com/vmware-tanzu/pinniped/discussions).
+[issue](https://github.com/vmware/pinniped/issues/new?template=feature-proposal.md)
+and tag it with `proposal`, or create a new [Discussion](https://github.com/vmware/pinniped/discussions).
 The project [maintainers](MAINTAINERS.md) will work with you on your feature request.
 
-Once the feature request has been validated, a [pull request](https://github.com/vmware-tanzu/pinniped/compare)
+Once the feature request has been validated, a [pull request](https://github.com/vmware/pinniped/compare)
 can be opened to implement the feature.
 
 For specifics on what to include in your feature request, please follow the
@@ -127,7 +127,7 @@ go build -o pinniped ./cmd/pinniped
    On macOS, these tools can be installed with [Homebrew](https://brew.sh/) (assuming you have Chrome installed already):
 
    ```bash
-   brew install kind vmware-tanzu/carvel/ytt vmware-tanzu/carvel/kapp kubectl nmap && brew cask install docker
+   brew install kind carvel-dev/carvel/ytt carvel-dev/carvel/kapp kubectl nmap && brew cask install docker
    ```
 
 1. Create a kind cluster, compile, create container images, and install Pinniped and supporting test dependencies using:
@@ -144,7 +144,7 @@ go build -o pinniped ./cmd/pinniped
 
    To run specific integration tests, add the `-run` flag to the above command to specify a regexp for the test names.
    Use a leading `/` on the regexp because the Pinniped integration tests are automatically nested under several parent tests
-   (see [integration/main_test.go](https://github.com/vmware-tanzu/pinniped/blob/main/test/integration/main_test.go)).
+   (see [integration/main_test.go](https://github.com/vmware/pinniped/blob/main/test/integration/main_test.go)).
    For example, to run an integration test called `TestE2E`, add `-run /TestE2E` to the command shown above.
 
 1. After making production code changes, recompile, redeploy, and run tests again by repeating the same
@@ -180,7 +180,7 @@ Each run of `hack/prepare-for-integration-tests.sh` can result in different valu
 CI will not be triggered on a pull request until the pull request is reviewed and
 approved for CI by a project [maintainer](MAINTAINERS.md). Once CI is triggered,
 the progress and results will appear on the Github page for that
-[pull request](https://github.com/vmware-tanzu/pinniped/pulls) as checks. Links
+[pull request](https://github.com/vmware/pinniped/pulls) as checks. Links
 will appear to view the details of each check.
 
 Starting in mid-2025, Pinniped's CI system is no longer externally visible due to corporate policies.
@@ -189,7 +189,7 @@ They will be happy to share CI logs with you directly for your PR.
 
 ## CI
 
-Pinniped's CI configuration and code is in the [`ci`](https://github.com/vmware-tanzu/pinniped/tree/ci)
+Pinniped's CI configuration and code is in the [`ci`](https://github.com/vmware/pinniped/tree/ci)
 branch of this repo.
 
 ## Documentation

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -11,7 +11,7 @@ all members should work together to achieve this goal.
 # Code of Conduct
 
 The Pinniped community abides by this
-[code of conduct](https://github.com/vmware-tanzu/pinniped/blob/main/CODE_OF_CONDUCT.md).
+[code of conduct](https://github.com/vmware/pinniped/blob/main/CODE_OF_CONDUCT.md).
 
 # Community Roles
 
@@ -29,7 +29,7 @@ notifying one of the maintainers.
 
 **Note:** If a maintainer leaves their employer they are still considered a maintainer of Pinniped, unless they
 voluntarily resign. Employment is not taken into consideration when determining maintainer eligibility unless the
-company itself violates our [Code of Conduct](https://github.com/vmware-tanzu/pinniped/blob/main/CODE_OF_CONDUCT.md).
+company itself violates our [Code of Conduct](https://github.com/vmware/pinniped/blob/main/CODE_OF_CONDUCT.md).
 
 # Decision Making
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Care to kick the tires? It's easy to [install and try Pinniped](https://pinniped
 ## Discussion
 
 Got a question, comment, or idea? Please don't hesitate to reach out
-via GitHub [Discussions](https://github.com/vmware-tanzu/pinniped/discussions),
-GitHub [Issues](https://github.com/vmware-tanzu/pinniped/issues),
+via GitHub [Discussions](https://github.com/vmware/pinniped/discussions),
+GitHub [Issues](https://github.com/vmware/pinniped/issues),
 or in the Kubernetes Slack Workspace within the [#pinniped channel](https://go.pinniped.dev/community/slack).
 Join our [Google Group](https://go.pinniped.dev/community/group) to receive updates and meeting invitations.
 
@@ -37,7 +37,7 @@ building and testing the code, submitting PRs, and other contributor topics.
 ## Adopters
 
 Some organizations and products using Pinniped are featured in [ADOPTERS.md](ADOPTERS.md).
-Add your own organization or product [here](https://github.com/vmware-tanzu/pinniped/discussions/152).
+Add your own organization or product [here](https://github.com/vmware/pinniped/discussions/152).
 
 ## Reporting security vulnerabilities
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,17 +10,17 @@ help determine if a contribution could be conflicting with a longer term plan.
 
 Discussion on the roadmap is welcomed. If you want to provide suggestions, use cases, and feedback to an item in the
 roadmap, please reach out to the maintainers using one of the methods described in the project's
-[README.md](https://github.com/vmware-tanzu/pinniped#discussion).
-[Contributions](https://github.com/vmware-tanzu/pinniped/blob/main/CONTRIBUTING.md) to Pinniped are also welcomed.
+[README.md](https://github.com/vmware/pinniped#discussion).
+[Contributions](https://github.com/vmware/pinniped/blob/main/CONTRIBUTING.md) to Pinniped are also welcomed.
 
 ### How to add an item to the roadmap
 
 One of the most important aspects in any open source community is the concept of proposals. Large changes to the
 codebase and / or new features should be preceded by
-a [proposal](https://github.com/vmware-tanzu/pinniped/tree/main/proposals) in our repo.
+a [proposal](https://github.com/vmware/pinniped/tree/main/proposals) in our repo.
 For smaller enhancements, you can open an issue to track that initiative or feature request.
 We work with and rely on community feedback to focus our efforts to improve Pinniped and maintain a healthy roadmap.
 
 Priorities and requirements change based on community feedback, roadblocks encountered, community contributions,
 etc. If you depend on a specific item, we encourage you to reach out for updated status information, or help us deliver
-that feature by [contributing](https://github.com/vmware-tanzu/pinniped/blob/main/CONTRIBUTING.md) to Pinniped.
+that feature by [contributing](https://github.com/vmware/pinniped/blob/main/CONTRIBUTING.md) to Pinniped.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ If you know of a publicly disclosed security vulnerability for Pinniped, please 
 
 **IMPORTANT: Do not file public issues on GitHub for security vulnerabilities**
 
-To report a vulnerability or a security-related issue, please contact the VMware email address with the details of the vulnerability. The email will be fielded by the VMware Security Team and then shared with the Pinniped maintainers who have committer and release permissions. Emails will be addressed within 3 business days, including a detailed plan to investigate the issue and any potential workarounds to perform in the meantime. Do not report non-security-impacting bugs through this channel. Use [GitHub issues](https://github.com/vmware-tanzu/pinniped/issues/new/choose) instead.
+To report a vulnerability or a security-related issue, please contact the VMware email address with the details of the vulnerability. The email will be fielded by the VMware Security Team and then shared with the Pinniped maintainers who have committer and release permissions. Emails will be addressed within 3 business days, including a detailed plan to investigate the issue and any potential workarounds to perform in the meantime. Do not report non-security-impacting bugs through this channel. Use [GitHub issues](https://github.com/vmware/pinniped/issues/new/choose) instead.
 
 ## Proposed Email Content
 
@@ -48,7 +48,7 @@ The VMware Security Team will respond to vulnerability reports as follows:
 
 ## Public Disclosure Process
 
-The Security Team publishes a [public advisory](https://github.com/vmware-tanzu/pinniped/security/advisories) to the Pinniped community via GitHub. In most cases, additional communication via Slack, Twitter, mailing lists, blog and other channels will assist in educating Pinniped users and rolling out the patched release to affected users.
+The Security Team publishes a [public advisory](https://github.com/vmware/pinniped/security/advisories) to the Pinniped community via GitHub. In most cases, additional communication via Slack, Twitter, mailing lists, blog and other channels will assist in educating Pinniped users and rolling out the patched release to affected users.
 
 The Security Team will also publish any mitigating steps users can take until the fix can be applied to their Pinniped instances. Pinniped distributors will handle creating and publishing their own security advisories.
 

--- a/deploy/concierge/values.yaml
+++ b/deploy/concierge/values.yaml
@@ -52,7 +52,7 @@ replicas: 2
 #@schema/title "Image repo"
 #@schema/desc "The repository for the Concierge container image."
 #@schema/validation min_len=1
-image_repo: ghcr.io/vmware-tanzu/pinniped/pinniped-server
+image_repo: ghcr.io/vmware/pinniped/pinniped-server
 
 #@schema/title "Image digest"
 #@schema/desc "The image digest for the Concierge container image. If both image_digest or an image_tag are given, only image_digest will be used."
@@ -72,7 +72,7 @@ image_tag: latest
 #@ on the control plane. This image needs only to include `sleep` and `cat` binaries. \
 #@ By default, the same image specified for image_repo/image_digest/image_tag will be re-used."
 #@schema/desc kube_cert_agent_image_desc
-#@schema/examples ("Image including tag or digest", "ghcr.io/vmware-tanzu/pinniped/pinniped-server:latest")
+#@schema/examples ("Image including tag or digest", "ghcr.io/vmware/pinniped/pinniped-server:latest")
 #@schema/nullable
 #@schema/validation min_len=1
 kube_cert_agent_image: ""

--- a/deploy/local-user-authenticator/README.md
+++ b/deploy/local-user-authenticator/README.md
@@ -20,7 +20,7 @@ kubectl apply -f https://get.pinniped.dev/latest/install-local-user-authenticato
 
 ## Installing a Specific Version with Default Options
 
-Choose your preferred [release](https://github.com/vmware-tanzu/pinniped/releases) version number
+Choose your preferred [release](https://github.com/vmware/pinniped/releases) version number
 and use it to replace the version number in the URL below.
 
 ```bash

--- a/deploy/local-user-authenticator/values.yaml
+++ b/deploy/local-user-authenticator/values.yaml
@@ -1,4 +1,4 @@
-#! Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
+#! Copyright 2020-2025 the Pinniped contributors. All Rights Reserved.
 #! SPDX-License-Identifier: Apache-2.0
 
 #@data/values-schema
@@ -6,7 +6,7 @@
 #@schema/title "Image repo"
 #@schema/desc "The repository for the local-user-authenticator container image."
 #@schema/validation min_len=1
-image_repo: ghcr.io/vmware-tanzu/pinniped/pinniped-server
+image_repo: ghcr.io/vmware/pinniped/pinniped-server
 
 #@schema/title "Image digest"
 #@schema/desc "The image digest for the local-user-authenticator container image. If both image_digest or an image_tag are given, only image_digest will be used."

--- a/deploy/supervisor/values.yaml
+++ b/deploy/supervisor/values.yaml
@@ -1,4 +1,4 @@
-#! Copyright 2020-2024 the Pinniped contributors. All Rights Reserved.
+#! Copyright 2020-2025 the Pinniped contributors. All Rights Reserved.
 #! SPDX-License-Identifier: Apache-2.0
 
 #@ def validate_strings_map(obj):
@@ -52,7 +52,7 @@ replicas: 2
 #@schema/title "Image repo"
 #@schema/desc "The repository for the Supervisor container image."
 #@schema/validation min_len=1
-image_repo: ghcr.io/vmware-tanzu/pinniped/pinniped-server
+image_repo: ghcr.io/vmware/pinniped/pinniped-server
 
 #@schema/title "Image digest"
 #@schema/desc "The image digest for the Supervisor container image. If both image_digest or an image_tag are given, only image_digest will be used."

--- a/hack/debug-ldapidentityprovider.sh
+++ b/hack/debug-ldapidentityprovider.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2023-2024 the Pinniped contributors. All Rights Reserved.
+# Copyright 2023-2025 the Pinniped contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -113,7 +113,7 @@ kubectl get "$resource_type_and_name" \
   --output yaml >"$RESOURCE_FILE"
 
 # See docs for LDAPIdentityProvider.spec for details about these settings.
-# https://github.com/vmware-tanzu/pinniped/blob/main/generated/1.28/README.adoc#k8s-api-go-pinniped-dev-generated-1-28-apis-supervisor-idp-v1alpha1-ldapidentityproviderspec
+# https://github.com/vmware/pinniped/blob/main/generated/1.28/README.adoc#k8s-api-go-pinniped-dev-generated-1-28-apis-supervisor-idp-v1alpha1-ldapidentityproviderspec
 LDAP_HOST=$(yq '.spec.host' "$RESOURCE_FILE")                                                                       # required
 LDAP_CA_BUNDLE=$(yq '.spec.tls.certificateAuthorityData // ""' "$RESOURCE_FILE")                                    # optional
 LDAP_BIND_SECRETNAME=$(yq '.spec.bind.secretName' "$RESOURCE_FILE")                                                 # required

--- a/hack/lib/carvel_packages/build.sh
+++ b/hack/lib/carvel_packages/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2023 the Pinniped contributors. All Rights Reserved.
+# Copyright 2023-2025 the Pinniped contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 #
@@ -25,9 +25,9 @@ cd "${hack_lib_path}/../../" || exit 1
 source hack/lib/helpers.sh
 
 # Check for dependencies
-check_dependency kbld "Please install kbld. e.g. 'brew tap vmware-tanzu/carvel && brew install kbld' for MacOS"
-check_dependency imgpkg "Please install imgpkg. e.g. 'brew tap vmware-tanzu/carvel && brew install imgpkg' for MacOS"
-check_dependency vendir "Please install vendir. e.g. 'brew tap vmware-tanzu/carvel && brew install vendir' for MacOS"
+check_dependency kbld "Please install kbld. e.g. 'brew tap carvel-dev/carvel && brew install kbld' for MacOS"
+check_dependency imgpkg "Please install imgpkg. e.g. 'brew tap carvel-dev/carvel && brew install imgpkg' for MacOS"
+check_dependency vendir "Please install vendir. e.g. 'brew tap carvel-dev/carvel && brew install vendir' for MacOS"
 
 # Expected arguments.
 app=${1:-"app-argument-not-provided"}

--- a/hack/lib/carvel_packages/deploy.sh
+++ b/hack/lib/carvel_packages/deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2023 the Pinniped contributors. All Rights Reserved.
+# Copyright 2023-2025 the Pinniped contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 #
@@ -53,7 +53,7 @@ dest_dir="deploy_carvel_tmp"
 # Deploy kapp-controller onto kind cluster.
 log_note "Installing kapp-controller on cluster..."
 KAPP_CONTROLLER_GLOBAL_NAMESPACE="kapp-controller-packaging-global"
-kapp deploy --app kapp-controller --file "https://github.com/vmware-tanzu/carvel-kapp-controller/releases/latest/download/release.yml" -y
+kapp deploy --app kapp-controller --file "https://github.com/carvel-dev/kapp-controller/releases/latest/download/release.yml" -y
 
 # Ensure this directory exists though this script will run several times.
 mkdir -p "${dest_dir}/install"

--- a/hack/prepare-for-integration-tests.sh
+++ b/hack/prepare-for-integration-tests.sh
@@ -143,8 +143,8 @@ fi
 #
 check_dependency docker "Please install docker. See https://docs.docker.com/get-docker"
 check_dependency kind "Please install kind. e.g. 'brew install kind' for MacOS"
-check_dependency ytt "Please install ytt. e.g. 'brew tap vmware-tanzu/carvel && brew install ytt' for MacOS"
-check_dependency kapp "Please install kapp. e.g. 'brew tap vmware-tanzu/carvel && brew install kapp' for MacOS"
+check_dependency ytt "Please install ytt. e.g. 'brew tap carvel-dev/carvel && brew install ytt' for MacOS"
+check_dependency kapp "Please install kapp. e.g. 'brew tap carvel-dev/carvel && brew install kapp' for MacOS"
 check_dependency kubectl "Please install kubectl. e.g. 'brew install kubectl' for MacOS"
 check_dependency htpasswd "Please install htpasswd. Should be pre-installed on MacOS. Usually found in 'apache2-utils' package for linux."
 check_dependency openssl "Please install openssl. Should be pre-installed on MacOS."

--- a/internal/controller/kubecertagent/kubecertagent.go
+++ b/internal/controller/kubecertagent/kubecertagent.go
@@ -647,7 +647,7 @@ func (c *agentController) newAgentDeployment(controllerManagerPod *corev1.Pod) *
 								},
 								Requests: corev1.ResourceList{
 									corev1.ResourceMemory: resource.MustParse("32Mi"),
-									// Must be explicitly 0 (not unset) to avoid problem described in https://github.com/vmware-tanzu/pinniped/issues/1507.
+									// Must be explicitly 0 (not unset) to avoid problem described in https://github.com/vmware/pinniped/issues/1507.
 									corev1.ResourceCPU: resource.MustParse("0"),
 								},
 							},

--- a/proposals/1113_ldap-ad-web-ui/README.md
+++ b/proposals/1113_ldap-ad-web-ui/README.md
@@ -160,7 +160,7 @@ Once dynamic clients are implemented:
 #### New Dependencies
 This should be kept to a very simple HTML page with minimal, clean CSS styling.
 Javascript should be avoided.
-The styling should match the [form post html page](https://github.com/vmware-tanzu/pinniped/tree/main/internal/federationdomain/formposthtml)
+The styling should match the [form post html page](https://github.com/vmware/pinniped/tree/main/internal/federationdomain/formposthtml)
 as much as possible, we should reuse some of the existing css and add to it to keep the style consistent.
 
 #### Observability Considerations
@@ -208,4 +208,4 @@ Then once dynamic clients exist, we can add functionality to accept requests
 from those clients as well.
 
 ## Implementation PRs
-- https://github.com/vmware-tanzu/pinniped/pull/1163
+- https://github.com/vmware/pinniped/pull/1163

--- a/proposals/1125_dynamic-supervisor-oidc-clients/README.md
+++ b/proposals/1125_dynamic-supervisor-oidc-clients/README.md
@@ -25,7 +25,7 @@ proposed in this document.
 ### How Pinniped Works Today (as of version v0.15.0)
 
 Each
-[FederationDomain](https://github.com/vmware-tanzu/pinniped/blob/main/generated/1.23/README.adoc#federationdomain)
+[FederationDomain](https://github.com/vmware/pinniped/blob/main/generated/1.23/README.adoc#federationdomain)
 configured in the Pinniped Supervisor is an OIDC Provider issuer which implements
 the [OIDC authorization code flow](https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth).
 
@@ -61,8 +61,8 @@ Goals for this proposal:
 - Support a web UI based LDAP/ActiveDirectory login screen. This is needed to avoid having webapps handle the user's
   password, which must only be seen by the Supervisor and the LDAP server. However, the details of this item have been
   split out to a
-  [separate proposal document](https://github.com/vmware-tanzu/pinniped/tree/main/proposals/1113_ldap-ad-web-ui).
-  The feature was released in [v0.18.0](https://github.com/vmware-tanzu/pinniped/releases/tag/v0.18.0).
+  [separate proposal document](https://github.com/vmware/pinniped/tree/main/proposals/1113_ldap-ad-web-ui).
+  The feature was released in [v0.18.0](https://github.com/vmware/pinniped/releases/tag/v0.18.0).
 - Client secrets must be stored encrypted or hashed, not in plain text.
 - Creation of client credentials on the operator's behalf - the server must generate any secrets.
 - The operator must be able to initiate manual rotation of client credentials.
@@ -527,6 +527,6 @@ The Pinniped maintainers will implement these features.
 
 ## Implementation PRs
 
-The implementation is in [PR #1181](https://github.com/vmware-tanzu/pinniped/pull/1181). During implementation,
+The implementation is in [PR #1181](https://github.com/vmware/pinniped/pull/1181). During implementation,
 several PRs have been prepared against this PR's branch, and merged into the PR's branch when reviewed and ready.
 When the whole feature is finished, PR #1181 will be merged to `main` and released.

--- a/proposals/1141_audit-logging/README.md
+++ b/proposals/1141_audit-logging/README.md
@@ -220,7 +220,7 @@ Depending on the event type, an event might include other keys, such as:
 
 The names of many of these keys are purposefully similar to the names of the keys used by Kubernetes audit events to
 make them feel familiar. Also, where it makes sense, the key names should be similar to
-[those used in the Pinniped Pod logs](https://github.com/vmware-tanzu/pinniped/blob/main/internal/plog/zap.go#L104-L120).
+[those used in the Pinniped Pod logs](https://github.com/vmware/pinniped/blob/main/internal/plog/zap.go#L104-L120).
 
 The details of these additional keys will be worked out as the details of the specific events are being worked out,
 during implementation of this proposal.

--- a/proposals/1406_multiple-idps/README.md
+++ b/proposals/1406_multiple-idps/README.md
@@ -36,7 +36,7 @@ Additionally, the server-side code also contains the necessary support to handle
 providers.
 
 We added
-[an artificial limitation](https://github.com/vmware-tanzu/pinniped/blob/60d12d88ac7b32235cc4dd848289adf06ab9c58b/internal/oidc/auth/auth_handler.go#L407-L409)
+[an artificial limitation](https://github.com/vmware/pinniped/blob/60d12d88ac7b32235cc4dd848289adf06ab9c58b/internal/oidc/auth/auth_handler.go#L407-L409)
 in the FederationDomain's authorize endpoint's source code which prevents all logins from proceeding when there are
 multiple OIDCIdentityProviders, LDAPIdentityProviders, and ActiveDirectoryIdentityProviders in use at the same time.
 This was done to defer designing the feature to make it possible to disambiguate usernames and group names from
@@ -161,7 +161,7 @@ The JWKS and OIDC discovery endpoints don't know anything about identity provide
 
 To allow admin users to define their own simple business logic for identity transformations and authentication policies,
 we will embed the Common Expressions Language (CEL) in the Supervisor.
-(See [#694](https://github.com/vmware-tanzu/pinniped/pull/694) for more details about why CEL is a
+(See [#694](https://github.com/vmware/pinniped/pull/694) for more details about why CEL is a
 good fit for this use case.)
 
 The FederationDomain CRD would be further enhanced to allow identity transformation and authentication policy functions
@@ -415,7 +415,7 @@ See "Implementation Plan" section below.
 ### Other Approaches Considered
 
 Rather than using CEL, other embedded languages were also considered.
-See [#694](https://github.com/vmware-tanzu/pinniped/pull/694).
+See [#694](https://github.com/vmware/pinniped/pull/694).
 
 Rather than using any embedded language, Pinniped could implement a library of similar identity transformations and authentication
 policy functions in the Golang source code and allow them to be used by reference on a FederationDomain in a similar
@@ -471,7 +471,7 @@ stories. Each story would include writing all applicable unit and integration te
    to have multiple. Add a validation that FederationDomains are not allowed to have conflicting URL paths. Add tests
    that ensure FederationDomains cannot lookup sessions from other FederationDomains. Improve logging to make debugging
    easier for ingress and TLS certificates problems for FederationDomains
-   (see [#1393](https://github.com/vmware-tanzu/pinniped/issues/1393)).
+   (see [#1393](https://github.com/vmware/pinniped/issues/1393)).
 6. *Docs Story*: Document how to configure FederationDomains, including what is the concept of a
    FederationDomain, why/when to have multiple, how to debug ingress and TLS certificates for multiple FederationDomains,
    and how to decide on issuer URLs for the FederationDomains.

--- a/proposals/1859_github-auth/README.md
+++ b/proposals/1859_github-auth/README.md
@@ -399,7 +399,7 @@ This will cause two concerns:
    sessions will increase the number of Secrets.
 2. Each new session will need to make several calls to the GitHub API, impacting the GitHub user's hourly rate limit.
 
-We can mitigate both effects using the techniques outlined in https://github.com/vmware-tanzu/pinniped/pull/1857.
+We can mitigate both effects using the techniques outlined in https://github.com/vmware/pinniped/pull/1857.
 By making the access token lifetime slightly longer, the user will be able to use their clusters for about 10 minutes,
 rather than 5 minutes, reducing the number of new sessions that they need to start per hour.
 By garbage collecting the session storage much faster for these sessions, the number of session storage Secrets
@@ -497,7 +497,7 @@ The implementation of these CLI commands would be as follows:
       the "pinniped login oidc" command to check the expiration date of the cached access token to make sure that
       it has not expired or is about to expire (otherwise, it checks the expiry of the cached ID token). Note that
       this is assuming that the related bug in the Pinniped CLI is fixed as outlined in
-      [this PR](https://github.com/vmware-tanzu/pinniped/pull/1857).
+      [this PR](https://github.com/vmware/pinniped/pull/1857).
     - It should take care to correctly handle unicode characters that might exist in flag values when
       invoking the subcommand, e.g. emojis in the upstream IDP name flag.
       As long as the subcommand is successful, its stdout results can be ignored, because we only care about

--- a/proposals/1984_ca-bundle-from-secret-ref/README.md
+++ b/proposals/1984_ca-bundle-from-secret-ref/README.md
@@ -30,7 +30,7 @@ tls:
 
 ## Background: TLS Certificate management tooling in Kubernetes Ecosystem
 
-[Cert-manager](https://cert-manager.io/docs/) and [trust-manager](https://cert-manager.io/docs/trust/trust-manager/) are among popular tools 
+[Cert-manager](https://cert-manager.io/docs/) and [trust-manager](https://cert-manager.io/docs/trust/trust-manager/) are among popular tools
 in the kubernetes ecosystem for certificate management.
 Vault is another tool of choice that allows cluster-operators to sync certificates and certificate authority bundles from sources external to the cluster.
 
@@ -145,7 +145,7 @@ metadata:
 
 ### Vault
 
-Based on the usage reported in [issues/1886](https://github.com/vmware-tanzu/pinniped/issues/1886) the CA trust bundle is externally sourced into the kubernetes cluster as a secret.
+Based on the usage reported in [issues/1886](https://github.com/vmware/pinniped/issues/1886) the CA trust bundle is externally sourced into the kubernetes cluster as a secret.
 
 Vault will source TLS CA bundles from external sources and distibute the trust bundle by creating a secret of type Opaque, according to the docs. See [vault developer docs](https://developer.hashicorp.com/vault/docs/platform/k8s/vso/api-reference#destination).
 
@@ -155,7 +155,7 @@ In conclusion, almost all of the tooling available to handle certificate operati
 
 ## Proposal
 
-Based on the brief survey of the certificate management tooling in the kubernetes ecosystem, having Pinniped custom resources carry reference to 
+Based on the brief survey of the certificate management tooling in the kubernetes ecosystem, having Pinniped custom resources carry reference to
 either kubernetes secrets or configmaps, with a customizable key name to source certificate authority data, will allow cluster-operators to plumb certificate management tooling into Pinniped custom resources.
 
 ### API Changes
@@ -178,41 +178,41 @@ Users can use the new `certificateAuthorityDataSource` field to specify:
 2. Using the `name` subfield, the name of the kubernetes secret or configmap.
    It is expected that this secret or configmap, if supplied, will exist in the same namespace where Pinniped is currently running.
    Pinniped controllers do not seek access to secrets or configmap in a different namespace where sensitive information may be stored.
-3. Using the `key` subfield, the key within the secret or the configmap where the certificate authority data can be located. The value associated 
+3. Using the `key` subfield, the key within the secret or the configmap where the certificate authority data can be located. The value associated
    with this key in the configmap is not expected to be base64 encoded. For secrets, they wil be read using kubernetes client-go which assures that
    the value read from the secret are base64 decoded.
 
 
 Implementing this proposal will result in changes to the following Pinniped CRDs and their respective controllers where the `TLSSpec` field is read.
 #### Supervisor
-For Pinniped Supervisor, the `TLSSpec` is generated using the [apis/supervisor/idp/v1alpha1/types_tls.go.tmpl](https://github.com/vmware-tanzu/pinniped/blob/main/apis/supervisor/idp/v1alpha1/types_tls.go.tmpl). This template will be updated to allow Pinniped Supervisor custom resources to source certificate authority data from kubernetes secrets or configmaps.
+For Pinniped Supervisor, the `TLSSpec` is generated using the [apis/supervisor/idp/v1alpha1/types_tls.go.tmpl](https://github.com/vmware/pinniped/blob/main/apis/supervisor/idp/v1alpha1/types_tls.go.tmpl). This template will be updated to allow Pinniped Supervisor custom resources to source certificate authority data from kubernetes secrets or configmaps.
 
 ##### `ActiveDirectoryIdentityProvider`
-The [`ValidateTLSConfig`](https://github.com/vmware-tanzu/pinniped/blob/main/internal/controller/supervisorconfig/upstreamwatchers/upstream_watchers.go#L138) function will be updated to read and validate certificate authority data sourced using the newly added `certificateAuthorityDataSource` field.
+The [`ValidateTLSConfig`](https://github.com/vmware/pinniped/blob/main/internal/controller/supervisorconfig/upstreamwatchers/upstream_watchers.go#L138) function will be updated to read and validate certificate authority data sourced using the newly added `certificateAuthorityDataSource` field.
 This function will continue to set the `TLSConfigurationValid` condition based on the validity.
 This functionality is shared with the `LDAPIdentityProvider` custom resource.
 
 ##### `LDAPIdentityProvider`
-The [`ValidateTLSConfig`](https://github.com/vmware-tanzu/pinniped/blob/main/internal/controller/supervisorconfig/upstreamwatchers/upstream_watchers.go#L138) function will be updated to read and validate certificate authority data sourced using the newly added `certificateAuthorityDataSource` field.
+The [`ValidateTLSConfig`](https://github.com/vmware/pinniped/blob/main/internal/controller/supervisorconfig/upstreamwatchers/upstream_watchers.go#L138) function will be updated to read and validate certificate authority data sourced using the newly added `certificateAuthorityDataSource` field.
 This function will continue to set the `TLSConfigurationValid` condition based on the validity.
 
 ##### `OIDCIdentityProvider`
-The [`getClient`](https://github.com/vmware-tanzu/pinniped/blob/main/internal/controller/supervisorconfig/oidcupstreamwatcher/oidc_upstream_watcher.go#L434) function will be updated to read and validate the certificate authority data sourced using the newly added `certificateAuthorityDataSource` field.
+The [`getClient`](https://github.com/vmware/pinniped/blob/main/internal/controller/supervisorconfig/oidcupstreamwatcher/oidc_upstream_watcher.go#L434) function will be updated to read and validate the certificate authority data sourced using the newly added `certificateAuthorityDataSource` field.
 A new condition with name `TLSConfigurationValid` will be added to this custom resource and will be part of the custom resource's status.
 
 ##### `GitHubIdentityProvider`
-The [`validateTLSConfiguration`](https://github.com/vmware-tanzu/pinniped/blob/main/internal/controller/supervisorconfig/githubupstreamwatcher/github_upstream_watcher.go#L362) function will be updated to read and validate certificate authority data sourced using the newly added `certificateAuthorityDataSource` field.
+The [`validateTLSConfiguration`](https://github.com/vmware/pinniped/blob/main/internal/controller/supervisorconfig/githubupstreamwatcher/github_upstream_watcher.go#L362) function will be updated to read and validate certificate authority data sourced using the newly added `certificateAuthorityDataSource` field.
 This function will continue to set the `TLSConfigurationValid` condition based on the validity.
 
 #### Concierge
-For Pinniped Concierge, the `TLSSpec` is generated using the [apis/concierge/authentication/v1alpha1/types_tls.go.tmpl](https://github.com/vmware-tanzu/pinniped/blob/main/apis/concierge/authentication/v1alpha1/types_tls.go.tmpl). This template will be updated to allow Pinniped Supervisor custom resources to source certificate authority data from kubernetes secrets or configmaps.
+For Pinniped Concierge, the `TLSSpec` is generated using the [apis/concierge/authentication/v1alpha1/types_tls.go.tmpl](https://github.com/vmware/pinniped/blob/main/apis/concierge/authentication/v1alpha1/types_tls.go.tmpl). This template will be updated to allow Pinniped Supervisor custom resources to source certificate authority data from kubernetes secrets or configmaps.
 
 ##### `WebhookAuthenticator`
-The [`validateTLSBundle`](https://github.com/vmware-tanzu/pinniped/blob/main/internal/controller/authenticator/webhookcachefiller/webhookcachefiller.go#L266) function will be updated to read and validate certificate authority data sourced using the newly added `certificateAuthorityDataSource` field.
+The [`validateTLSBundle`](https://github.com/vmware/pinniped/blob/main/internal/controller/authenticator/webhookcachefiller/webhookcachefiller.go#L266) function will be updated to read and validate certificate authority data sourced using the newly added `certificateAuthorityDataSource` field.
 This function will continue to set the `TLSConfigurationValid` condition based on the validity.
 
 ##### `JWTAuthenticator`
-The [`validateTLS`](https://github.com/vmware-tanzu/pinniped/blob/main/internal/controller/authenticator/jwtcachefiller/jwtcachefiller.go#L248) function will be updated to read and validate certificate authority data sourced using the newly added `certificateAuthorityDataSource` field.
+The [`validateTLS`](https://github.com/vmware/pinniped/blob/main/internal/controller/authenticator/jwtcachefiller/jwtcachefiller.go#L248) function will be updated to read and validate certificate authority data sourced using the newly added `certificateAuthorityDataSource` field.
 This function will continue to set the `TLSConfigurationValid` condition based on the validity.
 
 
@@ -256,4 +256,3 @@ This could be accomplished by loading a valid but wrong CA bundle into the secre
 `TLSConfigurationValid` status condition indicates a valid TLS configuration, but that other status conditions indicate
 a failure to connect, and then loading the correct CA bundle into the secret or configmap (without changing the parent CR), and
 observing that the parent custom resource's status conditions indicate a successful connection.
-

--- a/site/config.yaml
+++ b/site/config.yaml
@@ -4,7 +4,7 @@ title: "Pinniped"
 theme: "pinniped"
 params:
   twitter_url: "https://twitter.com/projectpinniped"
-  github_url: "https://github.com/vmware-tanzu/pinniped"
+  github_url: "https://github.com/vmware/pinniped"
   slack_url: "https://go.pinniped.dev/community/slack"
   community_url: "https://go.pinniped.dev/community"
   latest_version: v0.39.0

--- a/site/content/community/_index.html
+++ b/site/content/community/_index.html
@@ -17,7 +17,7 @@ layout: section
             </div>
             <div class="content">
                 <h3><a href="{{< param "github_url" >}}">Check out GitHub</a></h3>
-                <p>Head over to our GitHub repo and check out the <a href="https://github.com/vmware-tanzu/pinniped/discussions">discussions</a> and <a href="https://github.com/vmware-tanzu/pinniped/issues">issues</a>.</p>
+                <p>Head over to our GitHub repo and check out the <a href="https://github.com/vmware/pinniped/discussions">discussions</a> and <a href="https://github.com/vmware/pinniped/issues">issues</a>.</p>
             </div>
         </div>
         <div class="col">

--- a/site/content/docs/_index.md
+++ b/site/content/docs/_index.md
@@ -13,8 +13,8 @@ As a Kubernetes cluster administrator or user, you can learn how Pinniped works,
 dive into internals of Pinniped's APIs and architecture.
 
 Have a question, comment, or idea? Please reach out via
-[GitHub Issues](https://github.com/vmware-tanzu/pinniped/issues),
-[GitHub Discussions](https://github.com/vmware-tanzu/pinniped/discussions),
+[GitHub Issues](https://github.com/vmware/pinniped/issues),
+[GitHub Discussions](https://github.com/vmware/pinniped/discussions),
 or [join the Pinniped community]({{< ref "/community" >}}).
 
 ## New to Pinniped?

--- a/site/content/docs/background/architecture.md
+++ b/site/content/docs/background/architecture.md
@@ -52,7 +52,7 @@ Pinniped currently supports the following external identity provider types.
 1. Identities from GitHub or GitHub Enterprise.
 
 The
-[`idp.supervisor.pinniped.dev`](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#k8s-api-idp-supervisor-pinniped-dev-v1alpha1)
+[`idp.supervisor.pinniped.dev`](https://github.com/vmware/pinniped/blob/main/generated/latest/README.adoc#k8s-api-idp-supervisor-pinniped-dev-v1alpha1)
 API group contains the Kubernetes custom resources that configure the Pinniped
 Supervisor's external IDPs.
 
@@ -72,7 +72,7 @@ Pinniped supports the following authenticator types.
    serve as an extension point for Pinniped by allowing for integration of arbitrary custom authenticators.
    While a custom implementation may be in any language or framework, this project provides a
    sample implementation in Golang. See the `ServeHTTP` method of
-   [internal/localuserauthenticator/localuserauthenticator.go](https://github.com/vmware-tanzu/pinniped/blob/main/internal/localuserauthenticator/localuserauthenticator.go).
+   [internal/localuserauthenticator/localuserauthenticator.go](https://github.com/vmware/pinniped/blob/main/internal/localuserauthenticator/localuserauthenticator.go).
 
 1. A JSON Web Token (JWT) authenticator, which will validate and parse claims
    from JWTs.  This can be used to validate tokens that are issued by the
@@ -85,7 +85,7 @@ Pinniped supports the following authenticator types.
    set on the `kube-apiserver` process.
 
 The
-[`authentication.concierge.pinniped.dev`](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#k8s-api-authentication-concierge-pinniped-dev-v1alpha1)
+[`authentication.concierge.pinniped.dev`](https://github.com/vmware/pinniped/blob/main/generated/latest/README.adoc#k8s-api-authentication-concierge-pinniped-dev-v1alpha1)
 API group contains the Kubernetes custom resources that configure the Pinniped
 Concierge's authenticators.
 
@@ -120,7 +120,7 @@ With any of the above IDPs, authentication methods, and cluster integration stra
 cluster-specific credential via a
 [Kubernetes client-go credential plugin](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins).
 Users may use the Pinniped CLI as the credential plugin, or they may use any proprietary CLI
-built with the [Pinniped Go client library](https://github.com/vmware-tanzu/pinniped/tree/main/generated).
+built with the [Pinniped Go client library](https://github.com/vmware/pinniped/tree/main/generated).
 
 
 ## Pinniped Deployment Strategies

--- a/site/content/docs/howto/cicd.md
+++ b/site/content/docs/howto/cicd.md
@@ -48,7 +48,7 @@ on each cluster.
    and make those kubeconfigs available to CI/CD
    * Be sure to use `pinniped get kubeconfig` with option `--upstream-identity-provider-flow=cli_password` to authenticate non-interactively (without a browser)
    * When using OIDC, the optional CLI-based flow must be enabled by the administrator in the OIDCIdentityProvider configuration before use
-     (see `allowPasswordGrant` in the [API docs](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#oidcauthorizationconfig) for more details).
+     (see `allowPasswordGrant` in the [API docs](https://github.com/vmware/pinniped/blob/main/generated/latest/README.adoc#oidcauthorizationconfig) for more details).
 2. A CI/CD admin should make the non-human user account credentials available to CI/CD tasks
 3. Each CI/CD task should set the environment variables `PINNIPED_USERNAME` and `PINNIPED_PASSWORD` for the `kubectl` (or similar)
    process to avoid the interactive username and password prompts. The values should be provided from the non-human user account credentials.
@@ -85,7 +85,7 @@ Both of these examples can be solved by configuring multiple identity providers:
    to use both providers. Create kubeconfigs using the GitHub provider and distribute them to your human users.
    Create kubeconfigs for your CI/CD use cases using the second provider.
 2. For the second example, configure an OIDCIdentityProvider for your human users. Disable non-interactive
-   authentication (see `allowPasswordGrant` in the [API docs](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#oidcauthorizationconfig)). Create another OIDCIdentityProvider for your
+   authentication (see `allowPasswordGrant` in the [API docs](https://github.com/vmware/pinniped/blob/main/generated/latest/README.adoc#oidcauthorizationconfig)). Create another OIDCIdentityProvider for your
    non-human users, and enable non-interactive authentication for it. For the second OIDCIdentityProvider, use a
    different client ID and client secret from your OIDC provider. Configure your FederationDomain to use both providers.
    In your OIDC provider's admin UI, configure this second client to allow the Resource Owner Password Credentials Grant

--- a/site/content/docs/howto/configure-auth-for-webapps.md
+++ b/site/content/docs/howto/configure-auth-for-webapps.md
@@ -376,7 +376,7 @@ scenes is actually served by the Pinniped Concierge. It can be accessed just lik
 not require any authentication on the request.
 
 The details of the request and response formats are documented in the
-[API docs](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#tokencredentialrequest).
+[API docs](https://github.com/vmware/pinniped/blob/main/generated/latest/README.adoc#tokencredentialrequest).
 
 Here is a sample YAML representation of a request:
 

--- a/site/content/docs/howto/debugging.md
+++ b/site/content/docs/howto/debugging.md
@@ -42,10 +42,10 @@ command-line tools have been installed using the instructions from the [Carvel d
 
 2. Clone the Pinniped GitHub repository and visit the `deploy/supervisor` directory
 
-   - `git clone git@github.com:vmware-tanzu/pinniped.git`
+   - `git clone git@github.com:vmware/pinniped.git`
    - `cd pinniped/deploy/supervisor`
 
-1. Assess which release version is installed on your cluster. All release versions are [listed on GitHub](https://github.com/vmware-tanzu/pinniped/releases).
+1. Assess which release version is installed on your cluster. All release versions are [listed on GitHub](https://github.com/vmware/pinniped/releases).
 
 1. Checkout the version that corresponds to the version tag installed on your cluster, e.g. `{{< latestversion >}}`.
 
@@ -70,10 +70,10 @@ command-line tools have been installed using the instructions from the [Carvel d
 
 2. Clone the Pinniped GitHub repository and visit the `deploy/concierge` directory
 
-   - `git clone git@github.com:vmware-tanzu/pinniped.git`
+   - `git clone git@github.com:vmware/pinniped.git`
    - `cd pinniped/deploy/concierge`
 
-1. Assess which release version is installed on your cluster. All release versions are [listed on GitHub](https://github.com/vmware-tanzu/pinniped/releases).
+1. Assess which release version is installed on your cluster. All release versions are [listed on GitHub](https://github.com/vmware/pinniped/releases).
 
 1. Checkout the version that corresponds to the version tag installed on your cluster, e.g. `{{< latestversion >}}`.
 

--- a/site/content/docs/howto/install-cli.md
+++ b/site/content/docs/howto/install-cli.md
@@ -15,13 +15,13 @@ It must be installed by administrators setting up a Pinniped cluster as well as 
 
 ## Install using Homebrew on macOS or Linux
 
-Use [Homebrew](https://brew.sh/) to install from the Pinniped [tap](https://github.com/vmware-tanzu/homebrew-pinniped):
+Use [Homebrew](https://brew.sh/) to install from the Pinniped [tap](https://github.com/vmware/homebrew-pinniped):
 
-- `brew install vmware-tanzu/pinniped/pinniped-cli`
+- `brew install vmware/pinniped/pinniped-cli`
 
 ## Download binaries
 
-Find the appropriate binary for your platform from the [latest release](https://github.com/vmware-tanzu/pinniped/releases/latest):
+Find the appropriate binary for your platform from the [latest release](https://github.com/vmware/pinniped/releases/latest):
 
 {{< buttonlink filename="pinniped-cli-darwin-amd64" >}}Download {{< latestversion >}} for macOS/amd64{{< buttonicon "download.png" >}}{{< /buttonlink >}}
 {{< buttonlink filename="pinniped-cli-darwin-arm64" >}}Download {{< latestversion >}} for macOS/arm64{{< buttonicon "download.png" >}}{{< /buttonlink >}}
@@ -35,7 +35,7 @@ Find the appropriate binary for your platform from the [latest release](https://
 You should put the command-line tool somewhere on your `$PATH`, such as `/usr/local/bin` on macOS/Linux.
 You'll also need to mark the file as executable, e.g. `chmod +x pinniped` on macOS/Linux.
 
-To find specific versions or view all available platforms and architectures, visit the [releases page](https://github.com/vmware-tanzu/pinniped/releases/).
+To find specific versions or view all available platforms and architectures, visit the [releases page](https://github.com/vmware/pinniped/releases/).
 
 ### Gatekeeper
 
@@ -47,7 +47,7 @@ Click Open to allow the command to proceed.
 
 ## Install a specific version via script
 
-Choose your preferred [release](https://github.com/vmware-tanzu/pinniped/releases) and use it to replace the version number in the URL below.
+Choose your preferred [release](https://github.com/vmware/pinniped/releases) and use it to replace the version number in the URL below.
 
 For example, to install {{< latestversion >}} on Linux/amd64:
 

--- a/site/content/docs/howto/install-concierge.md
+++ b/site/content/docs/howto/install-concierge.md
@@ -13,7 +13,7 @@ This guide shows you how to install the Pinniped Concierge.
 You should have a [supported Kubernetes cluster]({{< ref "../reference/supported-clusters" >}}).
 
 In the examples below, you can replace *{{< latestversion >}}* with your preferred version number.
-You can find a list of Pinniped releases [on GitHub](https://github.com/vmware-tanzu/pinniped/releases).
+You can find a list of Pinniped releases [on GitHub](https://github.com/vmware/pinniped/releases).
 
 ## With default options
 
@@ -46,10 +46,10 @@ Pinniped uses [ytt](https://carvel.dev/ytt/) from [Carvel](https://carvel.dev/) 
 
 1. Clone the Pinniped GitHub repository and visit the `deploy/concierge` directory:
 
-   - `git clone git@github.com:vmware-tanzu/pinniped.git`
+   - `git clone git@github.com:vmware/pinniped.git`
    - `cd pinniped/deploy/concierge`
 
-1. Decide which release version you would like to install. All release versions are [listed on GitHub](https://github.com/vmware-tanzu/pinniped/releases).
+1. Decide which release version you would like to install. All release versions are [listed on GitHub](https://github.com/vmware/pinniped/releases).
 
 1. Checkout your preferred version tag, e.g. `{{< latestversion >}}`.
 
@@ -57,13 +57,13 @@ Pinniped uses [ytt](https://carvel.dev/ytt/) from [Carvel](https://carvel.dev/) 
 
 1. Customize configuration parameters:
 
-    - See the [default values](http://github.com/vmware-tanzu/pinniped/tree/main/deploy/concierge/values.yaml) for documentation about individual configuration parameters.
+    - See the [default values](http://github.com/vmware/pinniped/tree/main/deploy/concierge/values.yaml) for documentation about individual configuration parameters.
       For example, you can change the number of Concierge pods by setting `replicas` or apply custom annotations to the impersonation proxy service using `impersonation_proxy_spec`.
 
     - In a different directory, create a new YAML file to contain your site-specific configuration. For example, you might call this file `site/dev-env.yaml`.
 
       In the file, add the special ytt comment for a values file and the YAML triple-dash which starts a new YAML document.
-      Then add custom overrides for any of the parameters from [`values.yaml`](http://github.com/vmware-tanzu/pinniped/tree/main/deploy/concierge/values.yaml).
+      Then add custom overrides for any of the parameters from [`values.yaml`](http://github.com/vmware/pinniped/tree/main/deploy/concierge/values.yaml).
 
       Override the `image_tag` value to match your preferred version tag, e.g. `{{< latestversion >}}`,
       to ensure that you use the version of the server which matches these templates.

--- a/site/content/docs/howto/install-supervisor.md
+++ b/site/content/docs/howto/install-supervisor.md
@@ -13,7 +13,7 @@ menu:
 This guide shows you how to install the Pinniped Supervisor, which allows seamless login across one or many Kubernetes clusters.
 
 In the examples below, you can replace *{{< latestversion >}}* with your preferred version number.
-You can find a list of Pinniped releases [on GitHub](https://github.com/vmware-tanzu/pinniped/releases).
+You can find a list of Pinniped releases [on GitHub](https://github.com/vmware/pinniped/releases).
 
 ## Prerequisites
 
@@ -47,10 +47,10 @@ Pinniped uses [ytt](https://carvel.dev/ytt/) from [Carvel](https://carvel.dev/) 
 
 1. Clone the Pinniped GitHub repository and visit the `deploy/supervisor` directory:
 
-   - `git clone git@github.com:vmware-tanzu/pinniped.git`
+   - `git clone git@github.com:vmware/pinniped.git`
    - `cd pinniped/deploy/supervisor`
 
-1. Decide which release version you would like to install. All release versions are [listed on GitHub](https://github.com/vmware-tanzu/pinniped/releases).
+1. Decide which release version you would like to install. All release versions are [listed on GitHub](https://github.com/vmware/pinniped/releases).
 
 1. Checkout your preferred version tag, e.g. `{{< latestversion >}}`:
 
@@ -58,13 +58,13 @@ Pinniped uses [ytt](https://carvel.dev/ytt/) from [Carvel](https://carvel.dev/) 
 
 1. Customize configuration parameters:
 
-    - See the [default values](http://github.com/vmware-tanzu/pinniped/tree/main/deploy/supervisor/values.yaml) for documentation about individual configuration parameters.
+    - See the [default values](http://github.com/vmware/pinniped/tree/main/deploy/supervisor/values.yaml) for documentation about individual configuration parameters.
       For example, you can change the number of Supervisor pods by setting `replicas` or install into a non-default namespace using `into_namespace`.
 
     - In a different directory, create a new YAML file to contain your site-specific configuration. For example, you might call this file `site/dev-env.yaml`.
 
       In the file, add the special ytt comment for a values file and the YAML triple-dash which starts a new YAML document.
-      Then add custom overrides for any of the parameters from [`values.yaml`](http://github.com/vmware-tanzu/pinniped/tree/main/deploy/supervisor/values.yaml).
+      Then add custom overrides for any of the parameters from [`values.yaml`](http://github.com/vmware/pinniped/tree/main/deploy/supervisor/values.yaml).
 
       Override the `image_tag` value to match your preferred version tag, e.g. `{{< latestversion >}}`,
       to ensure that you use the version of the server which matches these templates.

--- a/site/content/docs/howto/login.md
+++ b/site/content/docs/howto/login.md
@@ -125,7 +125,7 @@ will depend on which type of identity provider was configured.
   `kubectl` process to avoid the interactive prompts. Note that the optional CLI-based flow must be enabled by the
   administrator in the OIDCIdentityProvider configuration before use
   (see `allowPasswordGrant` in the
-  [API docs](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#oidcauthorizationconfig)
+  [API docs](https://github.com/vmware/pinniped/blob/main/generated/latest/README.adoc#oidcauthorizationconfig)
   for more details).
 
 - For LDAP and Active Directory identity providers, there are also two supported client flows:

--- a/site/content/docs/howto/supervisor/configure-supervisor-federationdomain-idps.md
+++ b/site/content/docs/howto/supervisor/configure-supervisor-federationdomain-idps.md
@@ -20,7 +20,7 @@ This how-to guide assumes that you have already [installed the Pinniped Supervis
 and have already read the guide about how to [configure the Supervisor as an OIDC issuer]({{< ref "configure-supervisor" >}}).
 
 This guide focuses on the use of the `spec.identityProviders` setting on the
-[FederationDomain](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#federationdomain)
+[FederationDomain](https://github.com/vmware/pinniped/blob/main/generated/latest/README.adoc#federationdomain)
 resource.
 
 Note that the `spec.identityProviders` setting on the FederationDomain resource was added in v0.26.0 of Pinniped.
@@ -230,7 +230,7 @@ The following example is contrived to demonstrate every feature of the `transfor
 (constants, expressions, and examples). It is likely more complex than a typical configuration.
 
 Documentation for each of the fields shown below can be found in the API docs for the
-[FederationDomain](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#federationdomain)
+[FederationDomain](https://github.com/vmware/pinniped/blob/main/generated/latest/README.adoc#federationdomain)
 resource.
 
 ```yaml

--- a/site/content/docs/howto/supervisor/configure-supervisor-with-activedirectory.md
+++ b/site/content/docs/howto/supervisor/configure-supervisor-with-activedirectory.md
@@ -24,7 +24,7 @@ and that you have [configured a FederationDomain to issue tokens for your downst
 
 ## Configure the Supervisor cluster
 
-Create an [ActiveDirectoryIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#activedirectoryidentityprovider) in the same namespace as the Supervisor.
+Create an [ActiveDirectoryIdentityProvider](https://github.com/vmware/pinniped/blob/main/generated/latest/README.adoc#activedirectoryidentityprovider) in the same namespace as the Supervisor.
 
 ### ActiveDirectoryIdentityProvider with default options
 

--- a/site/content/docs/howto/supervisor/configure-supervisor-with-auth0.md
+++ b/site/content/docs/howto/supervisor/configure-supervisor-with-auth0.md
@@ -71,7 +71,7 @@ To configure your Kubernetes authorization, please see [how-to login]({{< ref "l
 
 ## Configure the Supervisor
 
-Create an [OIDCIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#oidcidentityprovider) in the same namespace as the Supervisor.
+Create an [OIDCIdentityProvider](https://github.com/vmware/pinniped/blob/main/generated/latest/README.adoc#oidcidentityprovider) in the same namespace as the Supervisor.
 
 For example, this OIDCIdentityProvider uses Auth0's `email` claim as the Kubernetes username:
 

--- a/site/content/docs/howto/supervisor/configure-supervisor-with-azuread.md
+++ b/site/content/docs/howto/supervisor/configure-supervisor-with-azuread.md
@@ -46,7 +46,7 @@ For example, to create a tenant:
 
 ## Configure the Supervisor 
 
-Create an [OIDCIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#oidcidentityprovider) 
+Create an [OIDCIdentityProvider](https://github.com/vmware/pinniped/blob/main/generated/latest/README.adoc#oidcidentityprovider) 
 in the same namespace as the Supervisor.
 
 1. In the [Azure portal](portal.azure.com), navigate to _Home_ > _Azure Active Directory_ > _App Registrations_.

--- a/site/content/docs/howto/supervisor/configure-supervisor-with-dex.md
+++ b/site/content/docs/howto/supervisor/configure-supervisor-with-dex.md
@@ -73,7 +73,7 @@ staticClients:
 
 ## Configure the Supervisor
 
-Create an [OIDCIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#oidcidentityprovider) resource in the same namespace as the Supervisor.
+Create an [OIDCIdentityProvider](https://github.com/vmware/pinniped/blob/main/generated/latest/README.adoc#oidcidentityprovider) resource in the same namespace as the Supervisor.
 
 For example, the following OIDCIdentityProvider and the corresponding Secret use Dex's `email` claim as the Kubernetes username:
 

--- a/site/content/docs/howto/supervisor/configure-supervisor-with-github.md
+++ b/site/content/docs/howto/supervisor/configure-supervisor-with-github.md
@@ -32,7 +32,7 @@ The Pinniped Supervisor supports both.
 
 The instructions below reference the steps needed to configure a GitHub App or GitHub OAuth2 App on https://github.com at the time of writing.
 GitHub UI and documentation changes frequently and may not exactly match the steps below.
-Please submit a PR at the [Pinniped repo](https://github.com/vmware-tanzu/pinniped) to resolve any discrepancies.
+Please submit a PR at the [Pinniped repo](https://github.com/vmware/pinniped) to resolve any discrepancies.
 
 ## Alternative 1: Create a GitHub App
 
@@ -169,7 +169,7 @@ When OAuth app restrictions are enabled, then the organization owner must approv
 
 ## Configure the Supervisor
 
-Create a [GitHubIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/{{< latestcodegenversion >}}/README.adoc#githubidentityprovider) in the same namespace as the Supervisor.
+Create a [GitHubIdentityProvider](https://github.com/vmware/pinniped/blob/main/generated/{{< latestcodegenversion >}}/README.adoc#githubidentityprovider) in the same namespace as the Supervisor.
 
 The simplest example uses https://github.com as the source of identity.
 Note that you do not need to explicitly specify a GitHub host since `github.com` is the default.

--- a/site/content/docs/howto/supervisor/configure-supervisor-with-gitlab.md
+++ b/site/content/docs/howto/supervisor/configure-supervisor-with-gitlab.md
@@ -43,7 +43,7 @@ For example, to create a user-owned application:
 
 ## Configure the Supervisor cluster
 
-Create an [OIDCIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#oidcidentityprovider) in the same namespace as the Supervisor.
+Create an [OIDCIdentityProvider](https://github.com/vmware/pinniped/blob/main/generated/latest/README.adoc#oidcidentityprovider) in the same namespace as the Supervisor.
 
 For example, this OIDCIdentityProvider and corresponding Secret for [gitlab.com](https://gitlab.com) use the `nickname` claim (GitLab username) as the Kubernetes username:
 

--- a/site/content/docs/howto/supervisor/configure-supervisor-with-jumpcloudldap.md
+++ b/site/content/docs/howto/supervisor/configure-supervisor-with-jumpcloudldap.md
@@ -48,7 +48,7 @@ Here are some good resources to review while setting up and using JumpCloud's LD
 
 ## Configure the Supervisor cluster
 
-Create an [LDAPIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#ldapidentityprovider) in the same namespace as the Supervisor.
+Create an [LDAPIdentityProvider](https://github.com/vmware/pinniped/blob/main/generated/latest/README.adoc#ldapidentityprovider) in the same namespace as the Supervisor.
 
 For example, this LDAPIdentityProvider configures the LDAP entry's `uid` as the Kubernetes username,
 and the `cn` (common name) of each group to which the user belongs as the Kubernetes group names.

--- a/site/content/docs/howto/supervisor/configure-supervisor-with-okta.md
+++ b/site/content/docs/howto/supervisor/configure-supervisor-with-okta.md
@@ -51,7 +51,7 @@ For example, to create an app:
 
 ## Configure the Supervisor
 
-Create an [OIDCIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#oidcidentityprovider) in the same namespace as the Supervisor.
+Create an [OIDCIdentityProvider](https://github.com/vmware/pinniped/blob/main/generated/latest/README.adoc#oidcidentityprovider) in the same namespace as the Supervisor.
 
 For example, this OIDCIdentityProvider and corresponding Secret use Okta's `email` claim as the Kubernetes username:
 

--- a/site/content/docs/howto/supervisor/configure-supervisor-with-openldap.md
+++ b/site/content/docs/howto/supervisor/configure-supervisor-with-openldap.md
@@ -188,7 +188,7 @@ kubectl apply -f openldap.yaml
 
 ## Configure the Supervisor cluster
 
-Create an [LDAPIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#ldapidentityprovider) in the same namespace as the Supervisor.
+Create an [LDAPIdentityProvider](https://github.com/vmware/pinniped/blob/main/generated/latest/README.adoc#ldapidentityprovider) in the same namespace as the Supervisor.
 
 For example, this LDAPIdentityProvider configures the LDAP entry's `uid` as the Kubernetes username,
 and the `cn` (common name) of each group to which the user belongs as the Kubernetes group names.

--- a/site/content/docs/howto/supervisor/configure-supervisor-with-workspace_one_access.md
+++ b/site/content/docs/howto/supervisor/configure-supervisor-with-workspace_one_access.md
@@ -54,7 +54,7 @@ For example, to create an app:
 
 ## Configure the Supervisor
 
-Create an [OIDCIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#oidcidentityprovider) in the same namespace as the Supervisor.
+Create an [OIDCIdentityProvider](https://github.com/vmware/pinniped/blob/main/generated/latest/README.adoc#oidcidentityprovider) in the same namespace as the Supervisor.
 
 For example, this OIDCIdentityProvider and corresponding Secret use Workspace ONE Access's `email` claim as the Kubernetes username:
 

--- a/site/content/docs/howto/supervisor/configure-supervisor.md
+++ b/site/content/docs/howto/supervisor/configure-supervisor.md
@@ -25,7 +25,7 @@ This how-to guide assumes that you have already [installed the Pinniped Supervis
 ## Summary
 
 When the Pinniped Supervisor is installed using the YAML files which are attached to the
-[GitHub releases](https://github.com/vmware-tanzu/pinniped/releases), then the following additional configuration
+[GitHub releases](https://github.com/vmware/pinniped/releases), then the following additional configuration
 is required before your end users can use the Supervisor:
 
 1. You must create a new Service to expose port 8443 of the Supervisor pods, and you must configure your preferred
@@ -113,7 +113,7 @@ Some common approaches are:
    HTTP port to listen on a Unix domain socket, such as when the service mesh injects a sidecar container that can
    securely access the socket from within the same Pod. Alternatively, the HTTP port can be configured as a TCP listener
    on loopback interfaces to receive traffic from sidecar containers.
-   See the `endpoints` option in [deploy/supervisor/values.yml](https://github.com/vmware-tanzu/pinniped/blob/main/deploy/supervisor/values.yaml)
+   See the `endpoints` option in [deploy/supervisor/values.yml](https://github.com/vmware/pinniped/blob/main/deploy/supervisor/values.yaml)
    for more information.
    Using either a Unix domain socket or a loopback interface listener would prevent any unencrypted traffic from
    accidentally being transmitted from outside the Pod into the Supervisor app's HTTP port.
@@ -140,7 +140,7 @@ use an Ingress then you'll need to create a Service which the Ingress can use as
 create the Service will depend on how you choose to install the Supervisor:
 
 - If you installed using `ytt` then you can use
-the related `service_*` options from [deploy/supervisor/values.yml](https://github.com/vmware-tanzu/pinniped/blob/main/deploy/supervisor/values.yaml)
+the related `service_*` options from [deploy/supervisor/values.yml](https://github.com/vmware/pinniped/blob/main/deploy/supervisor/values.yaml)
 to create a Service. This will expose the appropriate port.
 - If you installed using the pre-rendered manifests attached to the Pinniped GitHub releases, then you can create
 the Service separately after installing the Supervisor app.

--- a/site/content/docs/reference/active-directory-configuration.md
+++ b/site/content/docs/reference/active-directory-configuration.md
@@ -11,7 +11,7 @@ menu:
 ---
 
 This describes the default values for the `ActiveDirectoryIdentityProvider` user and group search. For more about `ActiveDirectoryIdentityProvider`
-configuration, see [the API reference documentation](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#activedirectoryidentityprovider).
+configuration, see [the API reference documentation](https://github.com/vmware/pinniped/blob/main/generated/latest/README.adoc#activedirectoryidentityprovider).
 
 ### `spec.userSearch.base`
 

--- a/site/content/docs/reference/api.md
+++ b/site/content/docs/reference/api.md
@@ -9,4 +9,4 @@ menu:
     weight: 35
     parent: reference
 ---
-Full API reference documentation for the Pinniped Kubernetes API is available [on GitHub](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc).
+Full API reference documentation for the Pinniped Kubernetes API is available [on GitHub](https://github.com/vmware/pinniped/blob/main/generated/latest/README.adoc).

--- a/site/content/docs/reference/audit-logging.md
+++ b/site/content/docs/reference/audit-logging.md
@@ -69,7 +69,7 @@ Every line in the pod logs contains the following common keys and values, includ
 - `level`, which for an audit event will always have the value `info`
 - `message`, which for audit events is effectively the audit event type, whose
   value will always be one of the messages declared as an enum value in
-  [`audit_event.go`](https://github.com/vmware-tanzu/pinniped/blob/main/internal/auditevent/audit_event.go),
+  [`audit_event.go`](https://github.com/vmware/pinniped/blob/main/internal/auditevent/audit_event.go),
   which is effectively a catalog of all possible audit event types
 - `caller`, which is the line of Go code which caused the log
 - `stacktrace`, which is only included when the global log level is configured to `trace` or `all`,

--- a/site/content/docs/reference/code-walkthrough.md
+++ b/site/content/docs/reference/code-walkthrough.md
@@ -23,7 +23,7 @@ We take an "outside-in" approach, describing how to start finding and understand
 This document avoids getting too detailed in its description because the details of the code will change over time.
 
 New contributors are also encouraged to read the
-[contributor's guide](https://github.com/vmware-tanzu/pinniped/blob/main/CONTRIBUTING.md)
+[contributor's guide](https://github.com/vmware/pinniped/blob/main/CONTRIBUTING.md)
 and [architecture overview]({{< ref "architecture" >}}).
 
 ## Application main functions
@@ -32,15 +32,15 @@ There are three binaries in the Pinniped source:
 
 1. The Pinniped CLI
 
-   The `main()` function is in [cmd/pinniped/main.go](https://github.com/vmware-tanzu/pinniped/blob/main/cmd/pinniped/main.go).
+   The `main()` function is in [cmd/pinniped/main.go](https://github.com/vmware/pinniped/blob/main/cmd/pinniped/main.go).
    Each [subcommand]({{< ref "cli" >}}) is in a file:
-   - `pinniped version` in [cmd/pinniped/cmd/version.go](https://github.com/vmware-tanzu/pinniped/blob/main/cmd/pinniped/cmd/version.go)
-   - `pinniped whoami` in [cmd/pinniped/cmd/whoami.go](https://github.com/vmware-tanzu/pinniped/blob/main/cmd/pinniped/cmd/whoami.go)
-   - `pinniped get kubeconfig` in [cmd/pinniped/cmd/kubeconfig.go](https://github.com/vmware-tanzu/pinniped/blob/main/cmd/pinniped/cmd/kubeconfig.go)
+   - `pinniped version` in [cmd/pinniped/cmd/version.go](https://github.com/vmware/pinniped/blob/main/cmd/pinniped/cmd/version.go)
+   - `pinniped whoami` in [cmd/pinniped/cmd/whoami.go](https://github.com/vmware/pinniped/blob/main/cmd/pinniped/cmd/whoami.go)
+   - `pinniped get kubeconfig` in [cmd/pinniped/cmd/kubeconfig.go](https://github.com/vmware/pinniped/blob/main/cmd/pinniped/cmd/kubeconfig.go)
    - The following subcommands are not typically used directly by and end user. Instead, they are usually embedded as
      a kubectl credential exec plugin in a kubeconfig file:
-     - `pinniped login oidc` in [cmd/pinniped/cmd/login_oidc.go](https://github.com/vmware-tanzu/pinniped/blob/main/cmd/pinniped/cmd/login_oidc.go)
-     - `pinniped login static` in [cmd/pinniped/cmd/login_static.go](https://github.com/vmware-tanzu/pinniped/blob/main/cmd/pinniped/cmd/login_static.go)
+     - `pinniped login oidc` in [cmd/pinniped/cmd/login_oidc.go](https://github.com/vmware/pinniped/blob/main/cmd/pinniped/cmd/login_oidc.go)
+     - `pinniped login static` in [cmd/pinniped/cmd/login_static.go](https://github.com/vmware/pinniped/blob/main/cmd/pinniped/cmd/login_static.go)
 
 2. The Pinniped Kube cert agent component
 
@@ -51,35 +51,35 @@ There are three binaries in the Pinniped source:
    This is to support the Token Credential Request API strategy described in the
    [Supported Cluster Types document]({{< ref "../reference/supported-clusters" >}}).
 
-   The Kube cert agent code is in [cmd/pinniped-concierge-kube-cert-agent/main.go](https://github.com/vmware-tanzu/pinniped/blob/main/cmd/pinniped-concierge-kube-cert-agent/main.go).
+   The Kube cert agent code is in [cmd/pinniped-concierge-kube-cert-agent/main.go](https://github.com/vmware/pinniped/blob/main/cmd/pinniped-concierge-kube-cert-agent/main.go).
 
 3. The Pinniped server components
 
    There are three server components.
-   They are all compiled into a single binary in a single container image by the project's [Dockerfile](https://github.com/vmware-tanzu/pinniped/blob/main/Dockerfile).
+   They are all compiled into a single binary in a single container image by the project's [Dockerfile](https://github.com/vmware/pinniped/blob/main/Dockerfile).
    The `main()` function chooses which component to start based on the path used to invoke the binary, 
-   as seen in [cmd/pinniped-server/main.go](https://github.com/vmware-tanzu/pinniped/blob/main/cmd/pinniped-server/main.go).
+   as seen in [cmd/pinniped-server/main.go](https://github.com/vmware/pinniped/blob/main/cmd/pinniped-server/main.go).
 
    - The Concierge can be installed on a cluster to authenticate users externally via dynamically registered authenticators,
      and then allow those users to access the cluster's API server using that identity. The Concierge's entry point is
-     in [internal/concierge/server/server.go](https://github.com/vmware-tanzu/pinniped/blob/main/internal/concierge/server/server.go).
+     in [internal/concierge/server/server.go](https://github.com/vmware/pinniped/blob/main/internal/concierge/server/server.go).
 
    - The Supervisor can be installed on a central cluster to provide single-sign capabilities on to other clusters,
      using various types of external identity providers as the source of user identity. The Supervisor's entry point is
-     in [internal/supervisor/server/server.go](https://github.com/vmware-tanzu/pinniped/blob/main/internal/supervisor/server/server.go).
+     in [internal/supervisor/server/server.go](https://github.com/vmware/pinniped/blob/main/internal/supervisor/server/server.go).
 
    - The Local User Authenticator is a component used only for integration testing and demos of the Concierge.
      At this time, it is not intended for production use. It can be registered as a WebhookAuthenticator with the Concierge.
-     It is implemented in [internal/localuserauthenticator/localuserauthenticator.go](https://github.com/vmware-tanzu/pinniped/blob/main/internal/localuserauthenticator/localuserauthenticator.go).
+     It is implemented in [internal/localuserauthenticator/localuserauthenticator.go](https://github.com/vmware/pinniped/blob/main/internal/localuserauthenticator/localuserauthenticator.go).
 
 ## Deployment
 
 The YAML manifests required to deploy the server-side components to Kubernetes clusters
-are in the [deploy](https://github.com/vmware-tanzu/pinniped/tree/main/deploy) directory.
+are in the [deploy](https://github.com/vmware/pinniped/tree/main/deploy) directory.
 
 For each release, these ytt templates are rendered by the CI/CD system. The reference to the container image for that
 release is templated in, but otherwise the default values from the respective `values.yaml` files are used.
-The resulting manifests are attached to each [GitHub release of Pinniped](https://github.com/vmware-tanzu/pinniped/releases).
+The resulting manifests are attached to each [GitHub release of Pinniped](https://github.com/vmware/pinniped/releases).
 Users may use these pre-rendered manifests to install the Supervisor or Concierge.
 
 Alternatively, a user may render the templates of any release themselves to customize the values in `values.yaml`
@@ -89,10 +89,10 @@ or [for the Supervisor]({{< ref "install-supervisor" >}}).
 ## Custom Resource Definitions (CRDs)
 
 CRDs are used to configure both the Supervisor and the Concierge. The source code for these can be found in the `.tmpl`
-files under the various subdirectories of the [apis](https://github.com/vmware-tanzu/pinniped/tree/main/apis) directory.
+files under the various subdirectories of the [apis](https://github.com/vmware/pinniped/tree/main/apis) directory.
 Any struct with the special `+kubebuilder:resource:` comment will become a CRD. After adding or changing one of these
-files, the code generator may be executed by running [hack/update.sh](https://github.com/vmware-tanzu/pinniped/blob/main/hack/update.sh)
-and the results will be written to the [generated](https://github.com/vmware-tanzu/pinniped/tree/main/generated) directory, where they may be committed.
+files, the code generator may be executed by running [hack/update.sh](https://github.com/vmware/pinniped/blob/main/hack/update.sh)
+and the results will be written to the [generated](https://github.com/vmware/pinniped/tree/main/generated) directory, where they may be committed.
 
 Other `.tmpl` files that do not use the `+kubebuilder:resource:` comments will also be picked up by the code generator.
 These will not become CRDs, but are also considered part of Pinniped's public API for golang client code to use.
@@ -103,17 +103,17 @@ Both the Supervisor and Concierge components use Kubernetes-style controllers to
 to converge towards a desired state. For example, all the Pinniped CRDs are watched by controllers.
 
 All controllers are written using a custom controller library which is in the
-[internal/controllerlib](https://github.com/vmware-tanzu/pinniped/tree/main/internal/controllerlib) directory.
+[internal/controllerlib](https://github.com/vmware/pinniped/tree/main/internal/controllerlib) directory.
 
 Each individual controller is implemented as a file in one of the subdirectories of
-[internal/controller](https://github.com/vmware-tanzu/pinniped/tree/main/internal/controller).
+[internal/controller](https://github.com/vmware/pinniped/tree/main/internal/controller).
 
 Each server component uses `controllerlib.NewManager()` and then adds all of its controller instances to the manager
 on subsequent lines,
 which can be read as a catalog of all controllers. This happens:
 
-- For the Concierge, in [internal/controllermanager/prepare_controllers.go](https://github.com/vmware-tanzu/pinniped/blob/main/internal/controllermanager/prepare_controllers.go)
-- For the Supervisor, in [internal/supervisor/server/server.go](https://github.com/vmware-tanzu/pinniped/blob/main/internal/supervisor/server/server.go)
+- For the Concierge, in [internal/controllermanager/prepare_controllers.go](https://github.com/vmware/pinniped/blob/main/internal/controllermanager/prepare_controllers.go)
+- For the Supervisor, in [internal/supervisor/server/server.go](https://github.com/vmware/pinniped/blob/main/internal/supervisor/server/server.go)
 
 ### Controller patterns
 
@@ -133,7 +133,7 @@ and annotate it with an expiration timestamp, while another controller watches t
 their expiration time.
 
 A simple example of a controller which employs these patterns is in
-[internal/controller/apicerts/certs_expirer.go](https://github.com/vmware-tanzu/pinniped/blob/main/internal/controller/apicerts/certs_expirer.go).
+[internal/controller/apicerts/certs_expirer.go](https://github.com/vmware/pinniped/blob/main/internal/controller/apicerts/certs_expirer.go).
 
 ### Leader election for controllers
 
@@ -148,7 +148,7 @@ to an existing controller during a rolling upgrade.
 
 Leader election is done transparently in a centralized client middleware
 component, and will not be immediately obvious when looking at the controller source code. The middleware is in
-[internal/leaderelection/leaderelection.go](https://github.com/vmware-tanzu/pinniped/blob/main/internal/leaderelection/leaderelection.go).
+[internal/leaderelection/leaderelection.go](https://github.com/vmware/pinniped/blob/main/internal/leaderelection/leaderelection.go).
 
 One of the Pods is always elected as leader, and only the Kubernetes API client calls made by that pod are allowed
 to perform writes. The non-leader Pods' controllers are always running, but their writes will always fail,
@@ -164,10 +164,10 @@ as aggregated API endpoints, which makes them appear to a client almost as if th
 - `TokenCredentialRequest` can receive a token, pass the token to an external authenticator to authenticate the user,
   and then return a short-lived mTLS client certificate keypair which can be used to gain access to the Kuberetes API
   as that user.
-  It is in [internal/registry/credentialrequest/rest.go](https://github.com/vmware-tanzu/pinniped/blob/main/internal/registry/credentialrequest/rest.go).
+  It is in [internal/registry/credentialrequest/rest.go](https://github.com/vmware/pinniped/blob/main/internal/registry/credentialrequest/rest.go).
 
 - `WhoAmIRequest` will return basic details about the currently authenticated user.
-  It is in [internal/registry/whoamirequest/rest.go](https://github.com/vmware-tanzu/pinniped/blob/main/internal/registry/whoamirequest/rest.go).
+  It is in [internal/registry/whoamirequest/rest.go](https://github.com/vmware/pinniped/blob/main/internal/registry/whoamirequest/rest.go).
 
 The Concierge may also run an impersonation proxy service. This is not an aggregated API endpoint, so it needs to be
 exposed outside the cluster as a Service. When operating this mode, a client's kubeconfig causes the client to
@@ -176,7 +176,7 @@ proxy then authenticates the user and calls the real Kubernetes API on their beh
 Calls made to the real API server are made as a service account using impersonation to impersonate the identity of the end user.
 The code tries to reuse as much code from Kubernetes itself as possible, so it can behave as closely as possible
 to the real API server from the client's point of view. It can be found in
-[internal/concierge/impersonator/impersonator.go](https://github.com/vmware-tanzu/pinniped/blob/main/internal/concierge/impersonator/impersonator.go).
+[internal/concierge/impersonator/impersonator.go](https://github.com/vmware/pinniped/blob/main/internal/concierge/impersonator/impersonator.go).
 Further discussion of this feature can be found in the
 [blog post for release v0.7.0]({{< ref "2021-04-01-concierge-on-managed-clusters" >}}).
 
@@ -192,37 +192,37 @@ The Supervisor's endpoints are:
 Each FederationDomain's endpoints are mounted under the path of the FederationDomain's `spec.issuer`,
 if the `spec.issuer` URL has a path component specified. If the issuer has no path, then they are mounted under `/`.
 These per-FederationDomain endpoint are all mounted by the code in
-[internal/federationdomain/endpointsmanager/manager.go](https://github.com/vmware-tanzu/pinniped/blob/main/internal/federationdomain/endpointsmanager/manager.go).
+[internal/federationdomain/endpointsmanager/manager.go](https://github.com/vmware/pinniped/blob/main/internal/federationdomain/endpointsmanager/manager.go).
 
 The per-FederationDomain endpoints are:
 
 - `<issuer_path>/.well-known/openid-configuration` is the standard OIDC discovery endpoint, which can be used to discover all the other endpoints listed here.
-  See [internal/federationdomain/endpoints/discovery/discovery_handler.go](https://github.com/vmware-tanzu/pinniped/blob/main/internal/federationdomain/endpoints/discovery/discovery_handler.go).
+  See [internal/federationdomain/endpoints/discovery/discovery_handler.go](https://github.com/vmware/pinniped/blob/main/internal/federationdomain/endpoints/discovery/discovery_handler.go).
 - `<issuer_path>/jwks.json` is the standard OIDC JWKS discovery endpoint.
-  See [internal/federationdomain/endpoints/jwks/jwks_handler.go](https://github.com/vmware-tanzu/pinniped/blob/main/internal/federationdomain/endpoints/jwks/jwks_handler.go).
+  See [internal/federationdomain/endpoints/jwks/jwks_handler.go](https://github.com/vmware/pinniped/blob/main/internal/federationdomain/endpoints/jwks/jwks_handler.go).
 - `<issuer_path>/v1alpha1/pinniped_identity_providers` is a custom discovery endpoint for clients to learn about available upstream identity providers.
-  See [internal/federationdomain/endpoints/idpdiscovery/idp_discovery_handler.go](https://github.com/vmware-tanzu/pinniped/blob/main/internal/federationdomain/endpoints/idpdiscovery/idp_discovery_handler.go).
+  See [internal/federationdomain/endpoints/idpdiscovery/idp_discovery_handler.go](https://github.com/vmware/pinniped/blob/main/internal/federationdomain/endpoints/idpdiscovery/idp_discovery_handler.go).
 - `<issuer_path>/oauth2/authorize` is the standard OIDC authorize endpoint.
-  See [internal/federationdomain/endpoints/auth/auth_handler.go](https://github.com/vmware-tanzu/pinniped/blob/main/internal/federationdomain/endpoints/auth/auth_handler.go).
+  See [internal/federationdomain/endpoints/auth/auth_handler.go](https://github.com/vmware/pinniped/blob/main/internal/federationdomain/endpoints/auth/auth_handler.go).
 - `<issuer_path>/oauth2/token` is the standard OIDC token endpoint.
-  See [internal/federationdomain/endpoints/token/token_handler.go](https://github.com/vmware-tanzu/pinniped/blob/main/internal/federationdomain/endpoints/token/token_handler.go).
+  See [internal/federationdomain/endpoints/token/token_handler.go](https://github.com/vmware/pinniped/blob/main/internal/federationdomain/endpoints/token/token_handler.go).
   The token endpoint can handle the standard OIDC `authorization_code` and `refresh_token` grant types, and has also been
-  extended in [internal/federationdomain/endpoints/tokenexchange/token_exchange.go](https://github.com/vmware-tanzu/pinniped/blob/main/internal/federationdomain/endpoints/tokenexchange/token_exchange.go)
+  extended in [internal/federationdomain/endpoints/tokenexchange/token_exchange.go](https://github.com/vmware/pinniped/blob/main/internal/federationdomain/endpoints/tokenexchange/token_exchange.go)
   to handle an additional grant type for [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693) token exchanges to
   reduce the applicable scope (technically, the `aud` claim) of ID tokens.
 - `<issuer_path>/callback` is a special endpoint that is used as the redirect URL when performing an OAuth 2.0 or OIDC authcode flow against an upstream OIDC identity provider as configured by an OIDCIdentityProvider or GitHubIdentityProvider custom resource.
-  See [internal/federationdomain/endpoints/callback/callback_handler.go](https://github.com/vmware-tanzu/pinniped/blob/main/internal/federationdomain/endpoints/callback/callback_handler.go).
+  See [internal/federationdomain/endpoints/callback/callback_handler.go](https://github.com/vmware/pinniped/blob/main/internal/federationdomain/endpoints/callback/callback_handler.go).
 - `<issuer_path>/choose_identity_provider` is a UI page which allows users to choose which identity provider they would like to use during a browser-based login flow.
-  See [internal/federationdomain/endpoints/chooseidp/choose_idp_handler.go](https://github.com/vmware-tanzu/pinniped/blob/main/internal/federationdomain/endpoints/chooseidp/choose_idp_handler.go).
+  See [internal/federationdomain/endpoints/chooseidp/choose_idp_handler.go](https://github.com/vmware/pinniped/blob/main/internal/federationdomain/endpoints/chooseidp/choose_idp_handler.go).
 - `<issuer_path>/login` is a UI page which prompts for username and password to support the optional browser-based login flow for LDAP and Active Directory identity providers.
-  See [internal/federationdomain/endpoints/login/login_handler.go](https://github.com/vmware-tanzu/pinniped/blob/main/internal/federationdomain/endpoints/login/login_handler.go).
+  See [internal/federationdomain/endpoints/login/login_handler.go](https://github.com/vmware/pinniped/blob/main/internal/federationdomain/endpoints/login/login_handler.go).
 
 The OIDC specifications implemented by the Supervisor can be found at [openid.net](https://openid.net/connect).
 
 The aggregated API endpoints are:
 
 - `OIDCClientSecretRequest` may be used to create client secrets for OIDCClients.
-  It is in [internal/registry/clientsecretrequest/rest.go](https://github.com/vmware-tanzu/pinniped/blob/main/internal/registry/clientsecretrequest/rest.go).
+  It is in [internal/registry/clientsecretrequest/rest.go](https://github.com/vmware/pinniped/blob/main/internal/registry/clientsecretrequest/rest.go).
 
 ## Kubernetes API group names
 
@@ -235,4 +235,4 @@ A discussion of this feature, including its implementation details, can be found
 [blog post for release v0.5.0]({{< ref "2021-02-04-multiple-pinnipeds" >}}). Similar to leader election,
 much of this behavior is implemented in client middleware, and will not be obvious when reading the code.
 The middleware will automatically replace the API group names as needed on each request/response to/from the Kubernetes API server.
-The middleware logic can be found in [internal/groupsuffix/groupsuffix.go](https://github.com/vmware-tanzu/pinniped/blob/main/internal/groupsuffix/groupsuffix.go).
+The middleware logic can be found in [internal/groupsuffix/groupsuffix.go](https://github.com/vmware/pinniped/blob/main/internal/groupsuffix/groupsuffix.go).

--- a/site/content/docs/reference/fips.md
+++ b/site/content/docs/reference/fips.md
@@ -15,14 +15,14 @@ environment with FIPS compliance requirements, you will have to build
 the binaries yourself using the `fips_strict` build tag and Golang's
 `GOEXPERIMENT=boringcrypto` compiler option.
 
-The Pinniped team provides an [example Dockerfile](https://github.com/vmware-tanzu/pinniped/blob/main/hack/Dockerfile_fips)
+The Pinniped team provides an [example Dockerfile](https://github.com/vmware/pinniped/blob/main/hack/Dockerfile_fips)
 demonstrating how you can build Pinniped images in a FIPS compatible way.
 However, we do not provide official support for FIPS configuration.
 We provide this for informational purposes only.
 
 To build Pinniped use our example FIPS Dockerfile, you can run:
 ```bash
-$ git clone git@github.com:vmware-tanzu/pinniped.git
+$ git clone git@github.com:vmware/pinniped.git
 $ cd pinniped
 $ git checkout {{< latestversion >}}
 $ docker build -f hack/Dockerfile_fips .

--- a/site/content/docs/reference/supported-clusters.md
+++ b/site/content/docs/reference/supported-clusters.md
@@ -30,7 +30,7 @@ Most managed Kubernetes services do not support this.
 2. Impersonation Proxy: Can be run on any Kubernetes cluster. Default configuration requires that a `LoadBalancer` service can be created. Most cloud-hosted Kubernetes environments have this
 capability. The Impersonation Proxy automatically provisions (when `spec.impersonationProxy.mode` is set to `auto`) a `LoadBalancer` for ingress to the impersonation endpoint. Users who wish to use the impersonation proxy without an automatically
 configured `LoadBalancer` can do so with an automatically provisioned `ClusterIP` or with a Service that they provision themselves. These options
-can be configured in the spec of the [`CredentialIssuer`](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#credentialissuer).
+can be configured in the spec of the [`CredentialIssuer`](https://github.com/vmware/pinniped/blob/main/generated/latest/README.adoc#credentialissuer).
 
 If a cluster is capable of supporting both strategies, the Pinniped CLI will use the
 token credential request API strategy by default.

--- a/site/content/docs/tutorials/concierge-and-supervisor-demo.md
+++ b/site/content/docs/tutorials/concierge-and-supervisor-demo.md
@@ -134,7 +134,7 @@ If you have not already done so, [install the Pinniped command-line tool]({{< re
 On macOS or Linux, you can do this using Homebrew:
 
 ```sh
-brew install vmware-tanzu/pinniped/pinniped-cli
+brew install vmware/pinniped/pinniped-cli
 ```
 
 On other platforms, see the [command-line installation guide]({{< ref "../howto/install-cli" >}}) for more details.
@@ -365,7 +365,7 @@ kubectl get secret supervisor-tls-cert \
 
 ### Configure a FederationDomain in the Pinniped Supervisor
 
-The Supervisor should be configured to have a [FederationDomain](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#federationdomain), which, under the hood:
+The Supervisor should be configured to have a [FederationDomain](https://github.com/vmware/pinniped/blob/main/generated/latest/README.adoc#federationdomain), which, under the hood:
 - Acts as an OIDC provider to the Pinniped CLI, creating a consistent interface for the CLI to use regardless
   of which protocol the Supervisor is using to talk to the external identity provider
 - Also acts as an OIDC provider to the workload cluster's Concierge component, which will receive JWT tokens
@@ -421,7 +421,7 @@ The general steps required to create and configure a client in Okta are:
 
 ### Configure the Supervisor to use Okta as the external identity provider
 
-Create an [OIDCIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#oidcidentityprovider) and a Secret.
+Create an [OIDCIdentityProvider](https://github.com/vmware/pinniped/blob/main/generated/latest/README.adoc#oidcidentityprovider) and a Secret.
 
 ```sh
 # Replace the issuer's domain, the client ID, and client secret below.
@@ -492,7 +492,7 @@ kubectl apply -f \
 
 Configure the Concierge on the first workload cluster to trust the Supervisor's
 FederationDomain for authentication by creating a
-[JWTAuthenticator](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#jwtauthenticator).
+[JWTAuthenticator](https://github.com/vmware/pinniped/blob/main/generated/latest/README.adoc#jwtauthenticator).
 
 ```sh
 # The audience value below is an arbitrary value which must uniquely

--- a/site/content/docs/tutorials/concierge-only-demo.md
+++ b/site/content/docs/tutorials/concierge-only-demo.md
@@ -45,7 +45,7 @@ that protection, but if not then please carefully consider the security implicat
 
    Don't have an authenticator of a type supported by Pinniped handy? No problem, there is a demo authenticator
    available. Start by installing local-user-authenticator on the same cluster where you would like to try Pinniped
-   by following the directions in [deploy/local-user-authenticator/README.md](https://github.com/vmware-tanzu/pinniped/blob/main/deploy/local-user-authenticator/README.md).
+   by following the directions in [deploy/local-user-authenticator/README.md](https://github.com/vmware/pinniped/blob/main/deploy/local-user-authenticator/README.md).
    See below for an example of deploying this on kind.
 
 1. A kubeconfig where the current context points to the cluster and has administrator-like
@@ -85,7 +85,7 @@ as the authenticator.
 
    The `install-local-user-authenticator.yaml` file includes the default deployment options.
    If you would prefer to customize the available options, please
-   see [deploy/local-user-authenticator/README.md](https://github.com/vmware-tanzu/pinniped/blob/main/deploy/local-user-authenticator/README.md)
+   see [deploy/local-user-authenticator/README.md](https://github.com/vmware/pinniped/blob/main/deploy/local-user-authenticator/README.md)
    for instructions on how to deploy using `ytt`.
 
 1. Create a test user named `pinny-the-seal` in the local-user-authenticator namespace.
@@ -138,7 +138,7 @@ as the authenticator.
    On macOS or Linux, you can do this using Homebrew:
 
    ```sh
-   brew install vmware-tanzu/pinniped/pinniped-cli
+   brew install vmware/pinniped/pinniped-cli
    ```
 
    On other platforms, see the [command-line installation guide]({{< ref "../howto/install-cli" >}}) for more details.

--- a/site/content/docs/tutorials/local-concierge-and-supervisor-demo.md
+++ b/site/content/docs/tutorials/local-concierge-and-supervisor-demo.md
@@ -123,7 +123,7 @@ If you have not already done so, [install the Pinniped command-line tool]({{< re
 On macOS or Linux, you can do this using Homebrew:
 
 ```sh
-brew install vmware-tanzu/pinniped/pinniped-cli
+brew install vmware/pinniped/pinniped-cli
 ```
 
 On other platforms, see the [command-line installation guide]({{< ref "../howto/install-cli" >}}) for more details.
@@ -414,7 +414,7 @@ For more information about various configuration options for GitHub, see the
 
 ### Configure a FederationDomain in the Pinniped Supervisor
 
-The Supervisor should be configured to have a [FederationDomain](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#federationdomain), which, under the hood:
+The Supervisor should be configured to have a [FederationDomain](https://github.com/vmware/pinniped/blob/main/generated/latest/README.adoc#federationdomain), which, under the hood:
 - Acts as an OIDC provider to the Pinniped CLI, creating a consistent interface for the CLI to use regardless
   of which protocol the Supervisor is using to talk to the external identity provider
 - Also acts as an OIDC provider to the workload cluster's Concierge component, which will receive JWT tokens
@@ -484,7 +484,7 @@ kubectl apply -f \
 
 Configure the Concierge to trust the Supervisor's
 FederationDomain for authentication by creating a
-[JWTAuthenticator](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#jwtauthenticator).
+[JWTAuthenticator](https://github.com/vmware/pinniped/blob/main/generated/latest/README.adoc#jwtauthenticator).
 
 ```sh
 cat <<EOF | kubectl create -f -

--- a/site/content/posts/2020-11-12-a-seal-of-approval.md
+++ b/site/content/posts/2020-11-12-a-seal-of-approval.md
@@ -50,7 +50,7 @@ Let’s be clear: We’re not there yet, but that’s where we’re headed with 
 - Create a unified login experience across clusters regardless of provider or distribution
 - Advance the state of the art in Kubernetes login security  
 
-From contributing code to uploading documentation to sharing how you’d like to use Pinniped in the wild, there are many ways to get involved. Feel free to ask questions via [#pinniped](https://go.pinniped.dev/community/slack) on Kubernetes Slack, or check out the [Contribute to Pinniped](https://github.com/vmware-tanzu/pinniped/blob/main/CONTRIBUTING.md) page for details on how to contribute to the Pinniped project. There you’ll find out how you can:
+From contributing code to uploading documentation to sharing how you’d like to use Pinniped in the wild, there are many ways to get involved. Feel free to ask questions via [#pinniped](https://go.pinniped.dev/community/slack) on Kubernetes Slack, or check out the [Contribute to Pinniped](https://github.com/vmware/pinniped/blob/main/CONTRIBUTING.md) page for details on how to contribute to the Pinniped project. There you’ll find out how you can:
 
 - Propose or request new features
 - Try writing a plugin

--- a/site/content/posts/2021-02-04-multiple-pinnipeds.md
+++ b/site/content/posts/2021-02-04-multiple-pinnipeds.md
@@ -25,7 +25,7 @@ You may have a similar need for several reasons, such as:
 4. **Backwards Compatibility:** you want to deploy two versions of your controller and provide a window of time for consumers to smoothly upgrade to the new version.
 5. **Controller Development:** you want to run, for example, the *stable* and *alpha* versions of your controller on the same cluster. Most cluster users will only rely on the stable version, but some test workloads will use the alpha version.
 
-With [Pinniped v0.5.0](https://github.com/vmware-tanzu/pinniped/releases/v0.5.0), we wanted to be able to bundle an opinionated configuration of Pinniped into our downstream commercial products while also allowing our customers to install their own Pinniped instance and configure it however they like.
+With [Pinniped v0.5.0](https://github.com/vmware/pinniped/releases/v0.5.0), we wanted to be able to bundle an opinionated configuration of Pinniped into our downstream commercial products while also allowing our customers to install their own Pinniped instance and configure it however they like.
 
 This post describes how we approached the need for multiple Pinnipeds in v0.5.0.
    
@@ -119,18 +119,18 @@ As a team, we have no immediate plans for either of these ideas, but if you are 
 [apiserver-pkg]: https://pkg.go.dev/k8s.io/apiserver/pkg/server
 [apiservice]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#apiservice-v1-apiregistration-k8s-io
 [crd]: https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/
-[custom-scheme]: https://github.com/vmware-tanzu/pinniped/blob/main/internal/concierge/server/server.go#L182
-[discussion]: https://github.com/vmware-tanzu/pinniped/discussions/386
-[groupsuffix]: https://github.com/vmware-tanzu/pinniped/blob/main/internal/groupsuffix/groupsuffix.go
+[custom-scheme]: https://github.com/vmware/pinniped/blob/main/internal/concierge/server/server.go#L182
+[discussion]: https://github.com/vmware/pinniped/discussions/386
+[groupsuffix]: https://github.com/vmware/pinniped/blob/main/internal/groupsuffix/groupsuffix.go
 [ingress-spec]: https://kubernetes.io/docs/reference/kubernetes-api/services-resources/ingress-v1/#IngressSpec
-[kubeclient-client]: https://github.com/vmware-tanzu/pinniped/blob/v0.5.0/internal/kubeclient/kubeclient.go#L22
-[kubeclient-middleware]: https://github.com/vmware-tanzu/pinniped/blob/v0.5.0/internal/kubeclient/middleware.go#L17-L19
+[kubeclient-client]: https://github.com/vmware/pinniped/blob/v0.5.0/internal/kubeclient/kubeclient.go#L22
+[kubeclient-middleware]: https://github.com/vmware/pinniped/blob/v0.5.0/internal/kubeclient/middleware.go#L17-L19
 [ownerreferences]: https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#owners-and-dependents
-[prepare-controllers]: https://github.com/vmware-tanzu/pinniped/blob/v0.5.0/internal/controllermanager/prepare_controllers.go#L116-L120
+[prepare-controllers]: https://github.com/vmware/pinniped/blob/v0.5.0/internal/controllermanager/prepare_controllers.go#L116-L120
 [rest-config-wrap]: https://pkg.go.dev/k8s.io/client-go/rest#Config.Wrap
 [roundtripper]: https://golang.org/pkg/net/http/#RoundTripper
 [runtime-scheme]: https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#Scheme
 [webhook-conversion]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#webhook-conversion
-[ytt-crd-overlay]: https://github.com/vmware-tanzu/pinniped/blob/v0.5.0/deploy/concierge/z0_crd_overlay.yaml
-[ytt-deployment]: https://github.com/vmware-tanzu/pinniped/blob/v0.5.0/deploy/concierge/deployment.yaml#L195
+[ytt-crd-overlay]: https://github.com/vmware/pinniped/blob/v0.5.0/deploy/concierge/z0_crd_overlay.yaml
+[ytt-deployment]: https://github.com/vmware/pinniped/blob/v0.5.0/deploy/concierge/deployment.yaml#L195
 [ytt]: https://carvel.dev/ytt/

--- a/site/content/posts/2021-04-01-concierge-on-managed-clusters.md
+++ b/site/content/posts/2021-04-01-concierge-on-managed-clusters.md
@@ -159,5 +159,5 @@ We invite your suggestions and contributions to make Pinniped work across all fl
 [kube-authn]: https://kubernetes.io/docs/reference/access-authn-authz/authentication/
 [kubeadm]: https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/
 [nodeselector]: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
-[tcr]: https://github.com/vmware-tanzu/pinniped/blob/main/generated/1.20/README.adoc#tokencredentialrequest
+[tcr]: https://github.com/vmware/pinniped/blob/main/generated/1.20/README.adoc#tokencredentialrequest
 [tolerations]: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/

--- a/site/content/posts/2021-06-02-first-ldap-release.md
+++ b/site/content/posts/2021-06-02-first-ldap-release.md
@@ -12,7 +12,7 @@ tags: ['Ryan Richard', 'release']
 *Photo from [matos11 on Pixabay](https://pixabay.com/photos/seal-animal-water-hairy-3585727/)*
 
 Pinniped is a “batteries included” authentication system for Kubernetes clusters.
-With the [release of v0.9.0](https://github.com/vmware-tanzu/pinniped/releases/tag/v0.9.0), Pinniped now supports using LDAP identities to log in to Kubernetes clusters.
+With the [release of v0.9.0](https://github.com/vmware/pinniped/releases/tag/v0.9.0), Pinniped now supports using LDAP identities to log in to Kubernetes clusters.
 
 This post describes how v0.9.0 fits into Pinniped’s quest to bring a smooth, unified login experience to all Kubernetes clusters.
 
@@ -66,7 +66,7 @@ as an LDAP provider, and to include AD in our automated testing suite. Stay tune
 
 In the meantime, please let us know if you run into any issues or concerns using your LDAP system.
 Feel free to ask questions via [#pinniped](https://go.pinniped.dev/community/slack) on Kubernetes Slack,
-or [create an issue](https://github.com/vmware-tanzu/pinniped/issues/new/choose) on our Github repository.
+or [create an issue](https://github.com/vmware/pinniped/issues/new/choose) on our Github repository.
 
 ### Security Considerations
 
@@ -112,7 +112,7 @@ And it is important that your users are using authentic kubeconfig files handed 
 
 Once you have [installed]({{< ref "docs/howto/install-supervisor.md" >}})
 and [configured]({{< ref "docs/howto/supervisor/configure-supervisor.md" >}}) the Supervisor, adding an LDAP provider is as easy as creating
-an [LDAPIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/1.20/README.adoc#ldapidentityprovider) resource.
+an [LDAPIdentityProvider](https://github.com/vmware/pinniped/blob/main/generated/1.20/README.adoc#ldapidentityprovider) resource.
 
 We've provided examples of using [OpenLDAP]({{< ref "docs/howto/install-supervisor.md" >}})
 and [JumpCloud]({{< ref "docs/howto/install-supervisor.md" >}}) as LDAP providers.
@@ -144,8 +144,8 @@ We thrive on community feedback. Did you try our new LDAP features?
 What else do you need from identity systems for your Kubernetes clusters?
 
 Find us in [#pinniped](https://go.pinniped.dev/community/slack) on Kubernetes Slack,
-[create an issue](https://github.com/vmware-tanzu/pinniped/issues/new/choose) on our Github repository,
-or start a [Discussion](https://github.com/vmware-tanzu/pinniped/discussions).
+[create an issue](https://github.com/vmware/pinniped/issues/new/choose) on our Github repository,
+or start a [Discussion](https://github.com/vmware/pinniped/discussions).
 
 Thanks for reading our announcement!
 

--- a/site/content/posts/2021-07-30-supporting-remote-oidc-workflows.md
+++ b/site/content/posts/2021-07-30-supporting-remote-oidc-workflows.md
@@ -17,7 +17,7 @@ Enterprise workloads on Kubernetes clusters often run in a restricted environmen
 
 ## Solution for Browserless clients
 
-In the [v0.10.0 release](https://github.com/vmware-tanzu/pinniped/releases/tag/v0.10.0), we introduce the ability to use a manual workaround to complete the OIDC workflow in such restricted browserless environments by supporting `response_mode=form_post` in the Pinniped Supervisor. As described in the [OAuth 2.0 Form Post spec](https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html), the response parameters are “encoded as HTML form values that are auto-submitted in the User Agent, and thus are transmitted via the HTTP POST method to the Client”. To complete the authentication process, The Pinniped users can copy and paste the response from the HTML page hosted by the Pinniped Supervisor into the waiting CLI process on the Jump Host.
+In the [v0.10.0 release](https://github.com/vmware/pinniped/releases/tag/v0.10.0), we introduce the ability to use a manual workaround to complete the OIDC workflow in such restricted browserless environments by supporting `response_mode=form_post` in the Pinniped Supervisor. As described in the [OAuth 2.0 Form Post spec](https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html), the response parameters are “encoded as HTML form values that are auto-submitted in the User Agent, and thus are transmitted via the HTTP POST method to the Client”. To complete the authentication process, The Pinniped users can copy and paste the response from the HTML page hosted by the Pinniped Supervisor into the waiting CLI process on the Jump Host.
 
 You can find more details in our [design document](https://hackmd.io/Hx17ATt_QpGOdLH_7AH1jA).
 
@@ -43,7 +43,7 @@ You can find more details in our [design document](https://hackmd.io/Hx17ATt_QpG
 4. User competes the web-browser OIDC workflow and gets an authorization response code.
 5. User will copy-paste the authorization code into the Jump Host environment to complete the login.
 
-Additionally, the [v0.10.0 release](https://github.com/vmware-tanzu/pinniped/releases/tag/v0.10.0) includes support for non-interactive password based LDAP logins. This feature provides the ability for Jenkins as well as other CI/CD tools that use LDAP Identity Platforms to access the cluster with centralized service account identities from the LDAP directory
+Additionally, the [v0.10.0 release](https://github.com/vmware/pinniped/releases/tag/v0.10.0) includes support for non-interactive password based LDAP logins. This feature provides the ability for Jenkins as well as other CI/CD tools that use LDAP Identity Platforms to access the cluster with centralized service account identities from the LDAP directory
 
 We invite your suggestions and contributions to make Pinniped work across all flavors of Kubernetes.
 

--- a/site/content/posts/2021-08-27-supporting-ad-oidc-workflows.md
+++ b/site/content/posts/2021-08-27-supporting-ad-oidc-workflows.md
@@ -23,7 +23,7 @@ Our initial LDAP implementation released with v.10.0 can be used to work with an
 
 Pinniped Supervisor authenticates your users with the AD provider via the LDAP protocol, and then issues unique, short-lived, per-cluster tokens. Our previous blog post on [LDAP configuration]({{< ref "2021-06-02-first-ldap-release.md">}}), elaborates on the security considerations to support integration at the Pinniped Supervisor level instead of at the Concierge.
 
-To setup the AD configuration, once you have Supervisor configured with ingress [installed the Pinniped Supervisor]({{< ref "docs/howto/install-supervisor.md" >}}) and you have [configured a FederationDomain]({{< ref "docs/howto/supervisor/configure-supervisor" >}}) to issue tokens for your downstream clusters, you can create an [ActiveDirectoryIdentityProvider](https://github.com/vmware-tanzu/pinniped/blob/main/generated/1.20/README.adoc#activedirectoryidentityprovider) in the same namespace as the Supervisor.
+To setup the AD configuration, once you have Supervisor configured with ingress [installed the Pinniped Supervisor]({{< ref "docs/howto/install-supervisor.md" >}}) and you have [configured a FederationDomain]({{< ref "docs/howto/supervisor/configure-supervisor" >}}) to issue tokens for your downstream clusters, you can create an [ActiveDirectoryIdentityProvider](https://github.com/vmware/pinniped/blob/main/generated/1.20/README.adoc#activedirectoryidentityprovider) in the same namespace as the Supervisor.
 Here’s what an example configuration looks like
 
 ```yaml
@@ -95,7 +95,7 @@ With the new functionality, Users initiate  `pinniped get kubeconfig` with a new
 In this release, we are moving our base container images from Debian to Distroless as it not only increases performance by providing much smaller sized images, but enhances security by removing dependencies on system libraries that may have vulnerabilities.
 
 
-Refer to the [release notes for v0.11.0](https://github.com/vmware-tanzu/pinniped/releases/tag/v0.11.0) for a complete list of fixes and features included in the release.
+Refer to the [release notes for v0.11.0](https://github.com/vmware/pinniped/releases/tag/v0.11.0) for a complete list of fixes and features included in the release.
 
 ## Tell us about your configuration and use cases!
 
@@ -104,12 +104,12 @@ We invite your suggestions and contributions to make Pinniped work for your conf
 The Pinniped community is a vital part of the project's success. This release includes important feedback from community user [Scott Rosenberg](https://github.com/vrabbi) who helped us better understand Active Directory configurations and provided valuable feedback for the OIDC Password Grant feature. Thank you for helping improve Pinniped!
 
 We thrive on community feedback.
-[Are you using Pinniped?](https://github.com/vmware-tanzu/pinniped/discussions/152)  
+[Are you using Pinniped?](https://github.com/vmware/pinniped/discussions/152)  
 Did you try our new LDAP or AD features?
 What other configurations do you need for authenticating users to your Kubernetes clusters?
 
 Find us in [#pinniped](https://go.pinniped.dev/community/slack) on Kubernetes Slack,
-[create an issue](https://github.com/vmware-tanzu/pinniped/issues/new/choose) on our Github repository,
-or start a [Discussion](https://github.com/vmware-tanzu/pinniped/discussions).
+[create an issue](https://github.com/vmware/pinniped/issues/new/choose) on our Github repository,
+or start a [Discussion](https://github.com/vmware/pinniped/discussions).
 
 {{< community >}}

--- a/site/content/posts/2022-01-18-idp-refresh-tls-ciphers-for-compliance.md
+++ b/site/content/posts/2022-01-18-idp-refresh-tls-ciphers-for-compliance.md
@@ -79,7 +79,7 @@ LDAP does not have a concept of sessions or refresh tokens. Hence we run LDAP qu
 
 #### *Update:* LDAP / Active Directory Group Refresh added in v0.15.0
 
-With the release of Pinniped [v0.15.0](https://github.com/vmware-tanzu/pinniped/releases/tag/v0.15.0) in March 2022, we added support for refreshing LDAP and Active Directory groups. A user's group membership is refreshed as they interact with the supervisor to obtain new credentials. This allows group membership changes to be quickly reflected into Kubernetes clusters.
+With the release of Pinniped [v0.15.0](https://github.com/vmware/pinniped/releases/tag/v0.15.0) in March 2022, we added support for refreshing LDAP and Active Directory groups. A user's group membership is refreshed as they interact with the supervisor to obtain new credentials. This allows group membership changes to be quickly reflected into Kubernetes clusters.
 
 In some environments, frequent group membership queries may result in a significant performance impact on the identity provider and/or the supervisor. The best approach to handle performance impacts is to tweak the group query to be more performant, for example by disabling nested group search or by using a more targeted group search base. If the group search query cannot be made performant, and you are willing to have group memberships remain static for approximately a day, then set **skipGroupRefresh** to true.  Please be aware that this is an insecure configuration as authorization policies that are bound to group membership will not notice if a user has been removed from a particular group until their next login. Also, the skipGroupRefresh flag is an experimental feature that may be removed or significantly altered in the future. Consumers of this configuration should carefully read all release notes before upgrading to ensure that the meaning of this field has not changed. See example below for how to configure this in an ActiveDirectoryIdentityProvider custom resource.
 
@@ -128,19 +128,19 @@ The Concierge listen port now **defaults to port 10250** instead of the previous
 
 ## What else is in this release?
 
-Refer to the [release notes for v0.13.0](https://github.com/vmware-tanzu/pinniped/releases/tag/v0.13.0) for a complete list of fixes and features included in the release.
+Refer to the [release notes for v0.13.0](https://github.com/vmware/pinniped/releases/tag/v0.13.0) for a complete list of fixes and features included in the release.
 
 ## Community contributors
 
 The Pinniped community continues to grow, and is a vital part of the project's success. This release includes contributions from users [@mayankbh](https://github.com/mayankbh) and [@rajat404](https://github.com/rajat404). Thank you for helping improve Pinniped!
 
 We thrive on community feedback.
-[Are you using Pinniped?](https://github.com/vmware-tanzu/pinniped/discussions/152)  
+[Are you using Pinniped?](https://github.com/vmware/pinniped/discussions/152)  
 Did you try our new security hardening features?
 What other configurations do you need for secure authentication of users to your Kubernetes clusters?
 
 Find us in [#pinniped](https://go.pinniped.dev/community/slack) on Kubernetes Slack,
-[create an issue](https://github.com/vmware-tanzu/pinniped/issues/new/choose) on our Github repository,
-or start a [Discussion](https://github.com/vmware-tanzu/pinniped/discussions).
+[create an issue](https://github.com/vmware/pinniped/issues/new/choose) on our Github repository,
+or start a [Discussion](https://github.com/vmware/pinniped/discussions).
 
 {{< community >}}

--- a/site/content/posts/2022-04-15-fips-and-more.md
+++ b/site/content/posts/2022-04-15-fips-and-more.md
@@ -23,7 +23,7 @@ Refer to our [FIPS reference documentation]({{< ref "docs/reference/fips.md" >}}
 
 ## Supervisor with default HTTPS listener port
 
-With [v0.13.0](https://github.com/vmware-tanzu/pinniped/releases/tag/v0.13.0) we had announced that we will disable the use of default HTTP listeners.
+With [v0.13.0](https://github.com/vmware/pinniped/releases/tag/v0.13.0) we had announced that we will disable the use of default HTTP listeners.
 
 **Breaking change in this release: With this release, we disable the Supervisor's HTTP listener by default, and will not allow it to be configured to bind to anything other than loopback interfaces.**
 
@@ -35,7 +35,7 @@ This feature does not change any HTTPS listen port configuration nor does it cha
 2. Configure the HTTP listening port to listen on tcp loopback interfaces (ipv4, ipv6, or both) or on a unix domain socket file for listening for connections from inside the pod, for example connections from a service mesh's sidecar container
 3. Choose the port number for the HTTP listening port
 
-For more information on this feature refer to [#981](https://github.com/vmware-tanzu/pinniped/issues/981).
+For more information on this feature refer to [#981](https://github.com/vmware/pinniped/issues/981).
 
 ## Workspace ONE Identity Provider configuration
 
@@ -45,21 +45,21 @@ Refer to our detailed guide  on [how to configure supervisor with Workspace ONE 
 
 ## What else is in this release?
 
-In addition to the above features, this release also adds custom prefixes to Supervisor authcodes, access tokens, and refresh tokens. The prefixes are intended to make the tokens more identifiable to a user when seen out of context. The prefixes are `pin_ac_` for authcodes, `pin_at_` for access tokens, and `pin_rt_` for refresh tokens. See [#688](https://github.com/vmware-tanzu/pinniped/issues/688) for more on this.
-Refer to the [release notes for v0.16.0](https://github.com/vmware-tanzu/pinniped/releases/tag/v0.16.0) for a complete list of fixes and features included in the release.
+In addition to the above features, this release also adds custom prefixes to Supervisor authcodes, access tokens, and refresh tokens. The prefixes are intended to make the tokens more identifiable to a user when seen out of context. The prefixes are `pin_ac_` for authcodes, `pin_at_` for access tokens, and `pin_rt_` for refresh tokens. See [#688](https://github.com/vmware/pinniped/issues/688) for more on this.
+Refer to the [release notes for v0.16.0](https://github.com/vmware/pinniped/releases/tag/v0.16.0) for a complete list of fixes and features included in the release.
 
 ## Community contributors
 
 The Pinniped community continues to grow, and is a vital part of the project's success. This release includes contributions from users [@vicmarbev](https://github.com/vicmarbev) and [@hectorj2f](https://github.com/hectorj2f). Thank you for helping improve Pinniped!
 
-[Are you using Pinniped?](https://github.com/vmware-tanzu/pinniped/discussions/152)  
+[Are you using Pinniped?](https://github.com/vmware/pinniped/discussions/152)  
 Did you try our new security hardening features?
 Are there other Identity Providers for which you want to see documentation similar to what we provided for Workspace ONE Access?  
 
 We thrive on community feedback and would like to hear more!  
 
 Reach out to us in [#pinniped](https://go.pinniped.dev/community/slack) on Kubernetes Slack,
-[create an issue](https://github.com/vmware-tanzu/pinniped/issues/new/choose) on our Github repository,
-or start a [discussion](https://github.com/vmware-tanzu/pinniped/discussions).
+[create an issue](https://github.com/vmware/pinniped/issues/new/choose) on our Github repository,
+or start a [discussion](https://github.com/vmware/pinniped/discussions).
 
 {{< community >}}

--- a/site/content/posts/2022-06-01-json-logging-ldap-ui.md
+++ b/site/content/posts/2022-06-01-json-logging-ldap-ui.md
@@ -42,7 +42,7 @@ Tue, 24 May 2022 11:18:50 EDT  cmd/kubeconfig.go:469  discovered WebhookAuthenti
 
 ## LDAP User Interface
 
-With [v0.18.0](https://github.com/vmware-tanzu/pinniped/releases/tag/v0.18.0) we are also adding support for a User Interface that users can access to input their credentials and login to their LDAP or Active Directory Identity Provider(IDP). This feature is a first step in our effort to provide a UI-driven workflow for our users. We will have more features that support UI workflows coming up in our next release, so stay tuned for that!
+With [v0.18.0](https://github.com/vmware/pinniped/releases/tag/v0.18.0) we are also adding support for a User Interface that users can access to input their credentials and login to their LDAP or Active Directory Identity Provider(IDP). This feature is a first step in our effort to provide a UI-driven workflow for our users. We will have more features that support UI workflows coming up in our next release, so stay tuned for that!
 
 When using the Pinniped CLI, a successful login takes the user to the regular form_post success page, just like the previously supported *browser authcode flow* for an OIDC IDP.
 This feature changes how the `pinniped get kubeconfig` cli deals with ambiguous flows. Previously, if there was more than one flow advertised for an IDP, the cli would require users to use the `--upstream-identity-provider-flow` flag.  Now, it chooses the first flow type in the Supervisor's discovery response by default.
@@ -73,19 +73,19 @@ This can include (but is not limited to) the following features:
 *Note* that Pinniped relies on the user's IDP to address advanced security concerns such as brute force protection, username enumeration, etc.
 
 ## What else is in this release?
-Refer to the [release notes for v0.18.0](https://github.com/vmware-tanzu/pinniped/releases/tag/v0.18.0) for a complete list of fixes and features included in the release.
+Refer to the [release notes for v0.18.0](https://github.com/vmware/pinniped/releases/tag/v0.18.0) for a complete list of fixes and features included in the release.
 
 ## Community contributors
 
 The Pinniped community continues to grow, and is a vital part of the project's success.
 
-[Are you using Pinniped?](https://github.com/vmware-tanzu/pinniped/discussions/152)  
+[Are you using Pinniped?](https://github.com/vmware/pinniped/discussions/152)  
 Have you tried any of our new features? Let us know what you think of our logging and UI features and if you are looking for any of the enhancements mentioned above.   
 
 We thrive on community feedback and would like to hear more!  
 
 Reach out to us in [#pinniped](https://go.pinniped.dev/community/slack) on Kubernetes Slack,
-[create an issue](https://github.com/vmware-tanzu/pinniped/issues/new/choose) on our Github repository,
-or start a [discussion](https://github.com/vmware-tanzu/pinniped/discussions).
+[create an issue](https://github.com/vmware/pinniped/issues/new/choose) on our Github repository,
+or start a [discussion](https://github.com/vmware/pinniped/discussions).
 
 {{< community >}}

--- a/site/content/posts/2023-08-09-v0.25.0-impersonation-proxy-with-external-certs.md
+++ b/site/content/posts/2023-08-09-v0.25.0-impersonation-proxy-with-external-certs.md
@@ -19,7 +19,7 @@ impersonation proxy is a component within Pinniped that allows the project to su
 [Amazon Elastic Kubernetes Service (EKS)](https://aws.amazon.com/eks/), [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine),
 and [Azure Kubernetes Service (AKS)](https://azure.microsoft.com/en-us/overview/kubernetes-on-azure).
 
-To read more on this feature, and the design decisions behind it, see the [proposal](https://github.com/vmware-tanzu/pinniped/tree/main/proposals/1547_impersonation-proxy-external-certs).
+To read more on this feature, and the design decisions behind it, see the [proposal](https://github.com/vmware/pinniped/tree/main/proposals/1547_impersonation-proxy-external-certs).
 To read more about the impersonation proxy, see the [docs](https://pinniped.dev/docs/reference/supported-clusters/#background).
 
 To see the feature in practice on a local kind cluster, follow these instructions.

--- a/site/content/posts/2023-09-19-multiple-idps-and-identity-transformations.md
+++ b/site/content/posts/2023-09-19-multiple-idps-and-identity-transformations.md
@@ -22,7 +22,7 @@ identity providers and more. If you want to learn about using multiple different
 providers with a fleet of clusters federated to a single identity broker, read on!
 
 Additionally, the release includes several dependency updates and fixes.
-See the [release notes](https://github.com/vmware-tanzu/pinniped/releases/tag/v0.26.0) for more details.
+See the [release notes](https://github.com/vmware/pinniped/releases/tag/v0.26.0) for more details.
 
 ## Background: Identity provider resources
 
@@ -132,7 +132,7 @@ with these new features, see:
 - The documentation for [creating FederationDomains]({{< ref "docs/howto/supervisor/configure-supervisor.md" >}}).
 - The documentation for [configuring identity providers on FederationDomains]({{< ref "docs/howto/supervisor/configure-supervisor-federationdomain-idps.md" >}}).
 - The API documentation for the `spec.identityProviders` setting on the
-[FederationDomain](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#federationdomain)
+[FederationDomain](https://github.com/vmware/pinniped/blob/main/generated/latest/README.adoc#federationdomain)
 resource.
 
 {{< community >}}

--- a/site/content/posts/2024-06-06-githubidentityprovider.md
+++ b/site/content/posts/2024-06-06-githubidentityprovider.md
@@ -22,7 +22,7 @@ Now you can easily control their authentication and authorization to your fleets
 using that same GitHub identity, with the same great security and user experience that Pinniped already offers.
 
 Additionally, the release includes several dependency updates and other changes.
-See the [release notes](https://github.com/vmware-tanzu/pinniped/releases/tag/v0.31.0) for more details.
+See the [release notes](https://github.com/vmware/pinniped/releases/tag/v0.31.0) for more details.
 
 ## Configuring GitHub authentication
 
@@ -187,7 +187,7 @@ This blog post is just a quick overview of this new feature. To learn about how 
 with this new feature, see:
 
 - The [GitHub configuration guide]({{< ref "docs/howto/supervisor/configure-supervisor-with-github.md" >}}).
-- The [GitHubIdentityProvider resource](https://github.com/vmware-tanzu/pinniped/blob/main/generated/latest/README.adoc#githubidentityprovider) documentation.
+- The [GitHubIdentityProvider resource](https://github.com/vmware/pinniped/blob/main/generated/latest/README.adoc#githubidentityprovider) documentation.
 - The documentation for [configuring identity providers on FederationDomains]({{< ref "docs/howto/supervisor/configure-supervisor-federationdomain-idps.md" >}}).
 
 {{< community >}}

--- a/site/content/posts/2024-08-0-externally-managed-ca-bundles.md
+++ b/site/content/posts/2024-08-0-externally-managed-ca-bundles.md
@@ -232,6 +232,6 @@ $ kubectl get pods -A --kubeconfig pinniped-kubeconfig.yaml
 
 ## Where to read more
 
-- See the original proposal for this body of work [here](https://github.com/vmware-tanzu/pinniped/tree/main/proposals/1984_ca-bundle-from-secret-ref)
+- See the original proposal for this body of work [here](https://github.com/vmware/pinniped/tree/main/proposals/1984_ca-bundle-from-secret-ref)
 
 {{< community >}}

--- a/site/content/resources/_index.html
+++ b/site/content/resources/_index.html
@@ -28,13 +28,13 @@ layout: section
         </div>
 
         <div class="col">
-            <a href="https://github.com/vmware-tanzu/pinniped">
+            <a href="https://github.com/vmware/pinniped">
                 <div class="icon">
                     <img src="/img/logo.svg"/>
                 </div>
                 <div class="content">
                     <p class="strong">Pinniped Source Code:</p>
-                    <p>https://github.com/vmware-tanzu/pinniped</p>
+                    <p>https://github.com/vmware/pinniped</p>
                 </div>
             </a>
         </div>

--- a/site/redirects/get.pinniped.dev/netlify.toml
+++ b/site/redirects/get.pinniped.dev/netlify.toml
@@ -12,12 +12,12 @@
 
 [[redirects]]
   from = "/latest/*"
-  to = "https://github.com/vmware-tanzu/pinniped/releases/latest/download/:splat"
+  to = "https://github.com/vmware/pinniped/releases/latest/download/:splat"
   status = 302
   force = true
 
 [[redirects]]
   from = "/*"
-  to = "https://github.com/vmware-tanzu/pinniped/releases/download/:splat"
+  to = "https://github.com/vmware/pinniped/releases/download/:splat"
   status = 302
   force = true

--- a/site/redirects/go.pinniped.dev/index.html
+++ b/site/redirects/go.pinniped.dev/index.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="utf-8">
 <title>go.pinniped.dev/</title>
-<meta name="go-import" content="go.pinniped.dev git https://github.com/vmware-tanzu/pinniped">
-<meta name="go-source" content="go.pinniped.dev https://github.com/vmware-tanzu/pinniped https://github.com/vmware-tanzu/pinniped/tree/main{/dir} https://github.com/vmware-tanzu/pinniped/blob/main{/dir}/{file}#L{line}">
+<meta name="go-import" content="go.pinniped.dev git https://github.com/vmware/pinniped">
+<meta name="go-source" content="go.pinniped.dev https://github.com/vmware/pinniped https://github.com/vmware/pinniped/tree/main{/dir} https://github.com/vmware/pinniped/blob/main{/dir}/{file}#L{line}">
 <style>
 * { font-family: sans-serif; }
 body { margin-top: 0; }
@@ -19,7 +19,7 @@ ul { margin-top: 16px; margin-bottom: 16px; }
 <code>go get go.pinniped.dev/</code>
 <code>import "go.pinniped.dev/"</code>
 Home: <a href="https://godoc.org/go.pinniped.dev/">https://godoc.org/go.pinniped.dev/</a><br/>
-Source: <a href="https://github.com/vmware-tanzu/pinniped">https://github.com/vmware-tanzu/pinniped</a><br/>
+Source: <a href="https://github.com/vmware/pinniped">https://github.com/vmware/pinniped</a><br/>
 </div>
 </body>
 </html>

--- a/site/themes/pinniped/layouts/index.html
+++ b/site/themes/pinniped/layouts/index.html
@@ -10,7 +10,7 @@
 				</div>
 				<div class="col">
 					<p class="strong">How do you use Pinniped?</p>
-					<p>Tell us about your experience using Pinniped <a href="https://github.com/vmware-tanzu/pinniped/discussions/152">Share with us here!</a></p>
+					<p>Tell us about your experience using Pinniped <a href="https://github.com/vmware/pinniped/discussions/152">Share with us here!</a></p>
 				</div>
 			</div>
 		</div>

--- a/site/themes/pinniped/layouts/partials/header.html
+++ b/site/themes/pinniped/layouts/partials/header.html
@@ -22,7 +22,7 @@
 			</ul>
 			<div class="social">
 				<a href="https://twitter.com/projectpinniped"><img src="/img/twitter.png" />Twitter</a>
-				<a href="https://github.com/vmware-tanzu/pinniped"><img src="/img/github.svg" />GitHub</a>
+				<a href="https://github.com/vmware/pinniped"><img src="/img/github.svg" />GitHub</a>
 				<a href="https://kubernetes.slack.com/messages/pinniped"><img src="/img/slack.png" />Slack</a>
 			</div>
 		</div>

--- a/site/themes/pinniped/layouts/partials/hero.html
+++ b/site/themes/pinniped/layouts/partials/hero.html
@@ -5,7 +5,7 @@
 			<p>Pinniped is the easy, secure way to log in to your Kubernetes clusters.</p>
 			<div class="buttons">
                 <a class="button" href="/docs/">Get Started with Pinniped</a>
-                <a class="button secondary" href="https://github.com/vmware-tanzu/pinniped/releases">Download Latest Release</a>
+                <a class="button secondary" href="https://github.com/vmware/pinniped/releases">Download Latest Release</a>
             </div>
 		</div>
 	</div>

--- a/site/themes/pinniped/layouts/partials/team.html
+++ b/site/themes/pinniped/layouts/partials/team.html
@@ -18,6 +18,6 @@
             </div>
         </div>
         <h3>Contributing:</h3>
-        <p>The Pinniped project team welcomes contributions from the community, please see the <a href="https://github.com/vmware-tanzu/pinniped/blob/main/CONTRIBUTING.md">contributor’s guide</a> for more information.</p>
+        <p>The Pinniped project team welcomes contributions from the community, please see the <a href="https://github.com/vmware/pinniped/blob/main/CONTRIBUTING.md">contributor’s guide</a> for more information.</p>
     </div>
 </div>

--- a/site/themes/pinniped/layouts/shortcodes/community.html
+++ b/site/themes/pinniped/layouts/shortcodes/community.html
@@ -5,7 +5,7 @@
         It's because of you that we can bring great software to the community.
     </p>
     <p>
-        Connect with the community on <a href="https://github.com/vmware-tanzu/pinniped">GitHub</a>
+        Connect with the community on <a href="https://github.com/vmware/pinniped">GitHub</a>
         and <a href="https://go.pinniped.dev/community/slack">Slack</a>.
     </p>
 <!--    <p>-->


### PR DESCRIPTION
Change all `vmware-tanzu` to `vmware` as it relates to GitHub in the source and docs.

This changes a lot of documentation and web site links.

Most importantly, it changes the default value for the location of the container image in the ytt templates for the Concierge and Supervisor (in the `values.yaml` files). In the upcoming v0.40.0 release, we cannot push to our old container repository at `ghcr.io/vmware-tanzu/pinniped/pinniped-server` anymore because the git repository was moved to a new GitHub org (trying to push returns an error saying that it was moved permanently). Therefore, we will need to push the container image to `ghcr.io/vmware/pinniped/pinniped-server` instead. This PR updates the ytt templates to make this the new default location for Concierge and Supervisor deployments.

This also accounts for the move of `vmware-tanzu/carvel` to `carvel-dev/carvel` in our docs and scripts, although that technically happened a long time ago.

**Release note**:

```release-note
Released container images for v0.40.0 and going forward will need to be pulled from a new location.
```
