### PR TITLE
Allow users to specify the RunAsUser and RunAsGroup for the kube-cert-agent container

### DIFF
--- a/internal/config/concierge/config.go
+++ b/internal/config/concierge/config.go
@@ -192,6 +192,14 @@ func validateNames(names *NamesConfigSpec) error {
 }
 
 func validateKubeCertAgent(agentConfig *KubeCertAgentSpec) error {
+	if agentConfig.RunAsUser != nil && *agentConfig.RunAsUser < 0 {
+		return constable.Error(fmt.Sprintf("runAsUser must be 0 or greater (instead of %d)", *agentConfig.RunAsUser))
+	}
+
+	if agentConfig.RunAsGroup != nil && *agentConfig.RunAsGroup < 0 {
+		return constable.Error(fmt.Sprintf("runAsGroup must be 0 or greater (instead of %d)", *agentConfig.RunAsGroup))
+	}
+
 	if len(agentConfig.PriorityClassName) == 0 {
 		// Optional, so empty is valid.
 		return nil

--- a/internal/config/concierge/config_test.go
+++ b/internal/config/concierge/config_test.go
@@ -69,6 +69,8 @@ func TestFromPath(t *testing.T) {
 				  image: kube-cert-agent-image
 				  imagePullSecrets: [kube-cert-agent-image-pull-secret]
 				  priorityClassName: %s
+				  runAsUser: 1
+				  runAsGroup: 2
 				log:
 				  level: debug
 				tls:
@@ -121,6 +123,8 @@ func TestFromPath(t *testing.T) {
 					Image:             ptr.To("kube-cert-agent-image"),
 					ImagePullSecrets:  []string{"kube-cert-agent-image-pull-secret"},
 					PriorityClassName: stringOfLength253,
+					RunAsUser:         ptr.To(int64(1)),
+					RunAsGroup:        ptr.To(int64(2)),
 				},
 				Log: plog.LogSpec{
 					Level: plog.LevelDebug,
@@ -754,6 +758,48 @@ func TestFromPath(t *testing.T) {
 				  priorityClassName: thisIsNotAValidPriorityClassName
 			`),
 			wantError: `validate kubeCertAgent: invalid priorityClassName: a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`,
+		},
+		{
+			name: "negative runAsUser",
+			yaml: here.Doc(`
+				---
+				names:
+				  servingCertificateSecret: pinniped-concierge-api-tls-serving-certificate
+				  credentialIssuer: pinniped-config
+				  apiService: pinniped-api
+				  impersonationLoadBalancerService: impersonationLoadBalancerService-value
+				  impersonationClusterIPService: impersonationClusterIPService-value
+				  impersonationTLSCertificateSecret: impersonationTLSCertificateSecret-value
+				  impersonationCACertificateSecret: impersonationCACertificateSecret-value
+				  impersonationSignerSecret: impersonationSignerSecret-value
+				  agentServiceAccount: agentServiceAccount-value
+				  impersonationProxyServiceAccount: impersonationProxyServiceAccount-value
+				  impersonationProxyLegacySecret: impersonationProxyLegacySecret-value
+				kubeCertAgent:
+				  runAsUser: -1
+			`),
+			wantError: `validate kubeCertAgent: runAsUser must be 0 or greater (instead of -1)`,
+		},
+		{
+			name: "negative runAsGroup",
+			yaml: here.Doc(`
+				---
+				names:
+				  servingCertificateSecret: pinniped-concierge-api-tls-serving-certificate
+				  credentialIssuer: pinniped-config
+				  apiService: pinniped-api
+				  impersonationLoadBalancerService: impersonationLoadBalancerService-value
+				  impersonationClusterIPService: impersonationClusterIPService-value
+				  impersonationTLSCertificateSecret: impersonationTLSCertificateSecret-value
+				  impersonationCACertificateSecret: impersonationCACertificateSecret-value
+				  impersonationSignerSecret: impersonationSignerSecret-value
+				  agentServiceAccount: agentServiceAccount-value
+				  impersonationProxyServiceAccount: impersonationProxyServiceAccount-value
+				  impersonationProxyLegacySecret: impersonationProxyLegacySecret-value
+				kubeCertAgent:
+				  runAsGroup: -1
+			`),
+			wantError: `validate kubeCertAgent: runAsGroup must be 0 or greater (instead of -1)`,
 		},
 	}
 	for _, test := range tests {

--- a/internal/config/concierge/types.go
+++ b/internal/config/concierge/types.go
@@ -111,4 +111,13 @@ type KubeCertAgentSpec struct {
 
 	// PriorityClassName optionally sets the PriorityClassName for the agent's pod.
 	PriorityClassName string `json:"priorityClassName"`
+
+	// The UID to run the entrypoint of the kube-cert-agent container.
+	// Defaults to 0 (root). No validation is performed on this value.
+	// If set to any value other than 0, RunAsNonRoot will be set to true.
+	RunAsUser *int64 `json:"runAsUser"`
+
+	// The GID to run the entrypoint of the kube-cert-agent container.
+	// Defaults to 0 (root). No validation is performed on this value.
+	RunAsGroup *int64 `json:"runAsGroup"`
 }

--- a/internal/controllermanager/prepare_controllers.go
+++ b/internal/controllermanager/prepare_controllers.go
@@ -141,6 +141,8 @@ func PrepareControllers(c *Config) (controllerinit.RunnerBuilder, error) { //nol
 		CredentialIssuerName:      c.NamesConfig.CredentialIssuer,
 		DiscoveryURLOverride:      c.DiscoveryURLOverride,
 		PriorityClassName:         c.KubeCertAgentConfig.PriorityClassName,
+		RunAsUser:                 c.KubeCertAgentConfig.RunAsUser,
+		RunAsGroup:                c.KubeCertAgentConfig.RunAsGroup,
 	}
 
 	// Create controller manager.


### PR DESCRIPTION
Allow users to specify the RunAsUser and RunAsGroup for the kube-cert-agent container