### PR TITLE
support partial anonymous authentication in the impersonation proxy

### DIFF
--- a/test/cluster_capabilities/aks.yaml
+++ b/test/cluster_capabilities/aks.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 the Pinniped contributors. All Rights Reserved.
+# Copyright 2021-2026 the Pinniped contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # The name of the cluster type.
@@ -13,9 +13,13 @@ capabilities:
   # Will the cluster successfully provision a load balancer if requested?
   hasExternalLoadBalancerProvider: true
 
-  # Does the cluster allow requests without authentication?
-  # https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-requests
-  anonymousAuthenticationSupported: false
-
   # Are LDAP ports on the Internet reachable without interference from network firewalls or proxies?
   canReachInternetLDAPPorts: true
+
+  # Does the cluster allow requests without authentication?
+  # https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-requests
+  anonymousAuthentication:
+    healthEndpoints:
+      allowed: false
+    otherEndpoints:
+      allowed: false

--- a/test/cluster_capabilities/eks.yaml
+++ b/test/cluster_capabilities/eks.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 the Pinniped contributors. All Rights Reserved.
+# Copyright 2021-2026 the Pinniped contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # The name of the cluster type.
@@ -13,9 +13,14 @@ capabilities:
   # Will the cluster successfully provision a load balancer if requested?
   hasExternalLoadBalancerProvider: true
 
-  # Does the cluster allow requests without authentication?
-  # https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-requests
-  anonymousAuthenticationSupported: true
-
   # Are LDAP ports on the Internet reachable without interference from network firewalls or proxies?
   canReachInternetLDAPPorts: true
+
+  # Does the cluster allow requests without authentication?
+  # https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-requests
+  # Amazon disabled anonymous authentication in EKS clusters starting with k8s 1.32.
+  anonymousAuthentication:
+    healthEndpoints:
+      allowed: true
+    otherEndpoints:
+      allowedIfK8sMinorVersionLessThan: 32

--- a/test/cluster_capabilities/gke.yaml
+++ b/test/cluster_capabilities/gke.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+# Copyright 2020-2026 the Pinniped contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # The name of the cluster type.
@@ -13,9 +13,14 @@ capabilities:
   # Will the cluster successfully provision a load balancer if requested?
   hasExternalLoadBalancerProvider: true
 
-  # Does the cluster allow requests without authentication?
-  # https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-requests
-  anonymousAuthenticationSupported: true
-
   # Are LDAP ports on the Internet reachable without interference from network firewalls or proxies?
   canReachInternetLDAPPorts: true
+
+  # Does the cluster allow requests without authentication?
+  # https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-requests
+  # Google disabled anonymous authentication in GKE clusters by default starting with k8s 1.35.
+  anonymousAuthentication:
+    healthEndpoints:
+      allowed: true
+    otherEndpoints:
+      allowedIfK8sMinorVersionLessThan: 35

--- a/test/cluster_capabilities/kind.yaml
+++ b/test/cluster_capabilities/kind.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+# Copyright 2020-2026 the Pinniped contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # The name of the cluster type.
@@ -13,9 +13,13 @@ capabilities:
   # Will the cluster successfully provision a load balancer if requested?
   hasExternalLoadBalancerProvider: false
 
-  # Does the cluster allow requests without authentication?
-  # https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-requests
-  anonymousAuthenticationSupported: true
-
   # Are LDAP ports on the Internet reachable without interference from network firewalls or proxies?
   canReachInternetLDAPPorts: true
+
+  # Does the cluster allow requests without authentication?
+  # https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-requests
+  anonymousAuthentication:
+    healthEndpoints:
+      allowed: true
+    otherEndpoints:
+      allowed: true

--- a/test/cluster_capabilities/tkgs.yaml
+++ b/test/cluster_capabilities/tkgs.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the Pinniped contributors. All Rights Reserved.
+# Copyright 2020-2026 the Pinniped contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # The name of the cluster type.
@@ -13,9 +13,13 @@ capabilities:
   # Will the cluster successfully provision a load balancer if requested?
   hasExternalLoadBalancerProvider: true
 
-  # Does the cluster allow requests without authentication?
-  # https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-requests
-  anonymousAuthenticationSupported: true
-
   # Are LDAP ports on the Internet reachable without interference from network firewalls or proxies?
   canReachInternetLDAPPorts: true
+
+  # Does the cluster allow requests without authentication?
+  # https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-requests
+  anonymousAuthentication:
+    healthEndpoints:
+      allowed: true
+    otherEndpoints:
+      allowed: true

--- a/test/integration/concierge_credentialrequest_test.go
+++ b/test/integration/concierge_credentialrequest_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2025 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2026 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package integration
@@ -218,7 +218,7 @@ func TestCredentialRequest_Browser(t *testing.T) {
 // for its localhost listener via --listen-port=env.CLIUpstreamOIDC.CallbackURL.Port() per oidcLoginCommand.
 // Since ports are global to the process, tests using oidcLoginCommand must be run serially.
 func TestCredentialRequest_JWTAuthenticatorRulesToDisallowLogin_Browser(t *testing.T) {
-	env := testlib.IntegrationEnv(t).WithCapability(testlib.AnonymousAuthenticationSupported)
+	env := testlib.IntegrationEnv(t).WithCapability(testlib.AnonymousAuthenticationSupportedForOtherEndpoints)
 
 	basicSpec := &authenticationv1alpha1.JWTAuthenticatorSpec{
 		Issuer:   env.CLIUpstreamOIDC.Issuer,
@@ -321,7 +321,7 @@ func TestCredentialRequest_JWTAuthenticatorRulesToDisallowLogin_Browser(t *testi
 
 // TCRs are non-mutating and safe to run in parallel with serial tests, see main_test.go.
 func TestCredentialRequest_ShouldFailWhenTheAuthenticatorDoesNotExist_Parallel(t *testing.T) {
-	env := testlib.IntegrationEnv(t).WithCapability(testlib.AnonymousAuthenticationSupported)
+	env := testlib.IntegrationEnv(t).WithCapability(testlib.AnonymousAuthenticationSupportedForOtherEndpoints)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	t.Cleanup(cancel)
@@ -344,7 +344,7 @@ func TestCredentialRequest_ShouldFailWhenTheAuthenticatorDoesNotExist_Parallel(t
 
 // TCRs are non-mutating and safe to run in parallel with serial tests, see main_test.go.
 func TestCredentialRequest_ShouldFailWhenTheRequestIsValidButTheTokenDoesNotAuthenticateTheUser_Parallel(t *testing.T) {
-	env := testlib.IntegrationEnv(t).WithCapability(testlib.AnonymousAuthenticationSupported)
+	env := testlib.IntegrationEnv(t).WithCapability(testlib.AnonymousAuthenticationSupportedForOtherEndpoints)
 
 	// Create a testWebhook so we have a legitimate authenticator to pass to the TokenCredentialRequest API.
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
@@ -365,7 +365,7 @@ func TestCredentialRequest_ShouldFailWhenTheRequestIsValidButTheTokenDoesNotAuth
 
 // TCRs are non-mutating and safe to run in parallel with serial tests, see main_test.go.
 func TestCredentialRequest_ShouldFailWhenRequestDoesNotIncludeToken_Parallel(t *testing.T) {
-	env := testlib.IntegrationEnv(t).WithCapability(testlib.AnonymousAuthenticationSupported)
+	env := testlib.IntegrationEnv(t).WithCapability(testlib.AnonymousAuthenticationSupportedForOtherEndpoints)
 
 	// Create a testWebhook so we have a legitimate authenticator to pass to the TokenCredentialRequest API.
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)

--- a/test/integration/concierge_whoami_test.go
+++ b/test/integration/concierge_whoami_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2025 the Pinniped contributors. All Rights Reserved.
+// Copyright 2020-2026 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 package integration
 
@@ -394,7 +394,7 @@ func maybeNeedsExtraWithSHA256(
 
 // whoami requests are non-mutating and safe to run in parallel with serial tests, see main_test.go.
 func TestWhoAmI_Anonymous_Parallel(t *testing.T) {
-	_ = testlib.IntegrationEnv(t).WithCapability(testlib.AnonymousAuthenticationSupported)
+	_ = testlib.IntegrationEnv(t).WithCapability(testlib.AnonymousAuthenticationSupportedForOtherEndpoints)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()

--- a/test/integration/supervisor_oidcclientsecret_test.go
+++ b/test/integration/supervisor_oidcclientsecret_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 the Pinniped contributors. All Rights Reserved.
+// Copyright 2022-2026 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package integration
@@ -1040,11 +1040,11 @@ func TestOIDCClientSecretRequestUnauthenticated_Parallel(t *testing.T) {
 		}, metav1.CreateOptions{})
 	require.Error(t, err)
 
-	if env.KubernetesDistribution == testlib.AKSDistro {
-		// On AKS the error just says "Unauthorized".
-		require.Contains(t, err.Error(), "Unauthorized")
-	} else {
+	if env.HasCapability(testlib.AnonymousAuthenticationSupportedForOtherEndpoints) {
 		// Clusters which allow anonymous auth will give a more detailed error.
 		require.Contains(t, err.Error(), `User "system:anonymous" cannot create resource "oidcclientsecretrequests"`)
+	} else {
+		// On AKS and any other cluster which disallows anonymous auth, the error just says "Unauthorized".
+		require.Contains(t, err.Error(), "Unauthorized")
 	}
 }


### PR DESCRIPTION
The impersonation proxy is how the Pinniped Concierge provides authentication on clusters which the Kubernetes signing keys are not available. These are usually could provider distributions such as GKE, EKS, and AKS. The impersonation proxy is not used at all on clusters where the signing key is available, such as a Kind cluster, TKG cluster, or VKS cluster. You can check if the impersonation proxy is being used on your cluster by looking at the `status` of the `CredentialIssuer` resource.

One feature of the impersonation proxy is that it tries to mimic the cluster's Kubernetes API server's anonymous authentication behavior. If the cluster allows anonymous authentication, then the impersonation proxy also allowed anonymous authentication. (Of course, it still enforces authorization (RBAC) checks for every API.) If the cluster did not, then the impersonation proxy also did not.

Previously, anonymous authentication in Kubernetes was either on or off for the entire API surface. The impersonation proxy would auto-detect this by making an anonymous request to the k8s API server's `/healthz` endpoint. If the response was Unauthorized, then this indicated that anonymous authentication was disabled. If the response was Forbidden, then this indicated that anonymous authentication was allowed and that the request was rejected due to RBAC configuration. If the response was success, then this also indicated that anonymous authentication was allowed. Based on this heuristic, the impersonation proxy would either allow or disallow anonymous authentication for the whole API surface.

However, more recent versions of Kubernetes have configuration options to allow anonymous authentication to be partially enabled for only selected endpoints. The heuristic described above cannot determine these configurations. The most common configurations now seem to be:
- Anonymous authentication is disabled for all endpoints, such as in AKS clusters.
- Anonymous authentication is enabled for all endpoints, such as in EKS clusters before version 1.32 and GKE clusters before 1.35.
- Anonymous authentication is enabled for the health endpoints `/healthz`, `/readyz`, and `/livez`, but is disabled for all other endpoints, such as on EKS clusters 1.32 and newer and by default on GKE clusters 1.35 and newer. However, note that on newer GKE clusters there is an option that allows the user to enable anonymous authentication for all APIs at cluster creation time.

This implies that the impersonation proxy is no longer accurately mimicking the cluster's anonymous authentication configuration in all cases. When the `/healthz` endpoint allows anonymous authentication, the impersonation proxy incorrectly assumes that the whole API surface should allow anonymous authentication. Of course, authorization checks are still performed for every API call, including anonymous calls. But since the goal is to accurately mimic the behavior of the API server, the impersonation proxy needs a behavior change.

This PR updates that heuristic to instead make two probe requests. The `/healthz` probe is still made as described above, but its response is only interpreted to be representative of the three health endpoints. The `/api/v1/nodes` API is also called, and its response is interpreted to be representative of all other API endpoints. Then the impersonation proxy allows anonymous requests to the three health check endpoints only if the cluster allowed the anonymous request to the `/healthz` endpoint. And the impersonation proxy allows anonymous requests to the rest of the API's endpoints only if the cluster allowed the anonymous request to the `/api/v1/nodes` endpoint.

This new heuristic cannot detect all possible configurations of anonymous authentication, but can capture the three most common configurations as described above. There is no practical way for Pinniped to auto-detect the exact configuration of which endpoints allow anonymous authentication, so the only alternative would be to allow more configuration of Pinniped's impersonation proxy. Adding more configuration is possible, but puts more burden on the user to configure it correctly. For now, automatically supporting the three most common configurations seems like a sufficient improvement, but the maintainers are always open to feedback from the community.

Note that this heuristic only runs at pod startup time. If somehow the configuration of anon auth in the API server changed at runtime, then the user should manually restart the Pinniped Concierge pods. This is not expected to happen for AKS, EKS, or GKE.

**Release note**:

```release-note
The heuristic used by the impersonation proxy to decide if the cluster supports anonymous
authentication, and therefore decides whether the impersonation proxy should allow
anonymous authentication on k8s API requests, was updated to better support recent
AKS and GKE clusters which allow anonymous authentication only at the health endpoints.
```
